### PR TITLE
flutter_gallery: Native dart shall be used for frontend_server

### DIFF
--- a/recipes-graphics/flutter-apps/flutter-gallery_git.bb
+++ b/recipes-graphics/flutter-apps/flutter-gallery_git.bb
@@ -49,7 +49,7 @@ do_compile() {
     flutter create .
     flutter build bundle
     
-    ${ENGINE_SDK}/clang_x64/dart ${FLUTTER_SDK}/bin/cache/dart-sdk/bin/snapshots/frontend_server.dart.snapshot \
+    dart ${FLUTTER_SDK}/bin/cache/dart-sdk/bin/snapshots/frontend_server.dart.snapshot \
       --aot --tfa --target=flutter \
       --sdk-root ${FLUTTER_SDK}/bin/cache/artifacts/engine/common/flutter_patched_sdk \
       --output-dill app.dill \


### PR DESCRIPTION
Currently, when building for raspberrypi3-64, there is an error in flutter_gallery:do_compile:
```
...
All done!
In order to run your application, type:

  $ cd .
  $ flutter run

Your application code is in ./lib/main.dart.


💪 Building with sound null safety 💪

Snapshot not compatible with the current VM configuration: the snapshot requires 
'release no-code_comments no-dwarf_stack_traces_mode lazy_async_stacks lazy_dispatchers use_bare_instructions no-dedup_instructions no-"asserts" "use_field_guards" "use_osr" x64-sysv no-null-safety' but the VM has 
'product no-code_comments no-dwarf_stack_traces_mode lazy_async_stacks lazy_dispatchers use_bare_instructions dedup_instructions no-"asserts" "use_field_guards" "use_osr" arm64-sysv no-null-safety'
WARNING: exit code 255 from a shell command.
...
```