### PR TITLE
Allow wayland client runtime mode to be overridden

### DIFF
--- a/recipes-graphics/sony/flutter-wayland-client_git.bb
+++ b/recipes-graphics/sony/flutter-wayland-client_git.bb
@@ -5,7 +5,7 @@ REQUIRED_DISTRO_FEATURES = "wayland opengl"
 
 require sony-flutter.inc
 
-FLUTTER_RUNTIME = "release"
+FLUTTER_RUNTIME ??= "release"
 
 DEPENDS += "\
     flutter-engine-${FLUTTER_RUNTIME} \


### PR DESCRIPTION
Allow wayland client runtime mode to be overridden through distro or local.conf. This is needed, as the app and the wayland client must be built against the same runtime mode, or the application won't be able to start.