### PR TITLE
Use argparse.ArgumentParser.parse_known_args

### DIFF
--- a/conf/include/gn-utils.inc
+++ b/conf/include/gn-utils.inc
@@ -211,7 +211,8 @@ def parse_args(d):
     parser.add_argument('--tsan', default=False, action='store_true')
     parser.add_argument('--ubsan', default=False, action='store_true')
 
-    return parser.parse_args(args)
+    args, unknown = parser.parse_known_args()
+	return args
 
 def get_out_dir(d):
     """Gets output directory based on the Package Configuration args."""


### PR DESCRIPTION
bitbake crash if you supply arguments gn-utils.inc doesn't support (but https://github.com/flutter/engine/blob/main/tools/gn does). This PR simply ignore unknown arguments.