### PR TITLE
build: Support modern bitbake syntax for override

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,8 @@ Then run:
 local.conf changes
 
     FLUTTER_CHANNEL = "master"
-    IMAGE_INSTALL_append = " flutter-drm-eglstream-backend"
-    IMAGE_INSTALL_append = " flutter-gallery"
+    IMAGE_INSTALL:append = " flutter-drm-eglstream-backend"
+    IMAGE_INSTALL:append = " flutter-gallery"
 
 OR
 
@@ -118,8 +118,8 @@ git clone -b dunfell https://github.com/jwinarske/meta-flutter.git
 popd
 bitbake-layers add-layer ../sources/meta-clang ../sources/meta-flutter
 echo -e 'FLUTTER_CHANNEL = "dev"' >> conf/local.conf
-echo -e 'IMAGE_INSTALL_append = " flutter-wayland"' >> conf/local.conf
-echo -e 'IMAGE_INSTALL_append = " flutter-gallery"' >> conf/local.conf
+echo -e 'IMAGE_INSTALL:append = " flutter-wayland"' >> conf/local.conf
+echo -e 'IMAGE_INSTALL:append = " flutter-gallery"' >> conf/local.conf
 bitbake fsl-image-multimedia
 ```
 
@@ -135,4 +135,4 @@ See Dunfell branch for CI job example.
 
 When building on systems with GCC version > than uninative in Yocto distro add the following to conf/local.conf
 
-    INHERIT_remove = "uninative"
+    INHERIT:remove = "uninative"


### PR DESCRIPTION
This will enable support for kirstone branch
and still remain compatible with honister.

Recipes were converted using
poky/src/poky/scripts/contrib/convert-overrides.py

Relate-to: https://github.com/meta-flutter/meta-flutter/pull/67
Relate-to: https://docs.yoctoproject.org/migration-guides/migration-3.4.html#override-syntax-changes
Thanks-to:  Simon Kuhnle <@snke>
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>