### PR TITLE
homescreen: Rename variables with namespace prefix

### DIFF
--- a/recipes-graphics/toyota/ivi-homescreen.inc
+++ b/recipes-graphics/toyota/ivi-homescreen.inc
@@ -28,7 +28,7 @@ SRC_URI = "git://github.com/toyota-connected/ivi-homescreen.git;protocol=https;b
 
 S = "${WORKDIR}/git"
 
-inherit cmake features_check systemd
+inherit cmake features_check pkgconfig systemd
 
 RUNTIME = "llvm"
 TOOLCHAIN = "clang"
@@ -50,22 +50,22 @@ FLUTTER_RUNTIME ??= "release"
 # Use pattern "--a={absolute path to flutter_assets}"
 IVI_HOMESCREEN_APP_OVERRIDE ??= ""
 # parameters to pass to homescreen app and Dart VM
-SERVICE_EXEC_START_PARAMS ??= ""
+FLUTTER_HOMESCREEN_SERVICE_EXEC_START_PARAMS ??= ""
 
-SERVICE_UNIT        ??= "Requires=weston@root.service\nAfter=weston@root.service\n"
-SERVICE_USER_GROUP  ??= "User=root\nGroup=root"
-SERVICE_RESTART     ??= "Restart=on-failure\nRestartSec=1"
-SERVICE_ENVIRONMENT ??= "Environment=HOME=/home/root\nEnvironment=XDG_RUNTIME_DIR=/run/user/0"
-SERVICE_EXEC_START  ??= "ExecStart=/usr/bin/homescreen --f ${IVI_HOMESCREEN_APP_OVERRIDE} ${SERVICE_EXEC_START_PARAMS}"
-SERVICE_SERVICE     ??= "${SERVICE_USER_GROUP}\n${SERVICE_RESTART}\n${SERVICE_ENVIRONMENT}\n${SERVICE_EXEC_START}\n"
-SERVICE_INSTALL     ??= "WantedBy=graphical.target\n"
+FLUTTER_HOMESCREEN_SERVICE_UNIT        ??= "Requires=weston@root.service\nAfter=weston@root.service\n"
+FLUTTER_HOMESCREEN_SERVICE_USER_GROUP  ??= "User=root\nGroup=root"
+FLUTTER_HOMESCREEN_SERVICE_RESTART     ??= "Restart=on-failure\nRestartSec=1"
+FLUTTER_HOMESCREEN_SERVICE_ENVIRONMENT ??= "Environment=HOME=/home/root\nEnvironment=XDG_RUNTIME_DIR=/run/user/0"
+FLUTTER_HOMESCREEN_SERVICE_EXEC_START  ??= "ExecStart=/usr/bin/homescreen --f ${IVI_HOMESCREEN_APP_OVERRIDE} ${FLUTTER_HOMESCREEN_SERVICE_EXEC_START_PARAMS}"
+FLUTTER_HOMESCREEN_SERVICE_SERVICE     ??= "${FLUTTER_HOMESCREEN_SERVICE_USER_GROUP}\n${FLUTTER_HOMESCREEN_SERVICE_RESTART}\n${FLUTTER_HOMESCREEN_SERVICE_ENVIRONMENT}\n${FLUTTER_HOMESCREEN_SERVICE_EXEC_START}\n"
+FLUTTER_HOMESCREEN_SERVICE_INSTALL     ??= "WantedBy=graphical.target\n"
 
 do_install_append() {
     if ${@bb.utils.contains('PACKAGECONFIG', 'systemd', 'true', 'false', d)}; then
         install -m 644 ${WORKDIR}/homescreen.service.in ${WORKDIR}/homescreen.service
-        sed -i "s|@ServiceUnit@|${SERVICE_UNIT}|g" ${WORKDIR}/homescreen.service
-        sed -i "s|@ServiceService@|${SERVICE_SERVICE}|g" ${WORKDIR}/homescreen.service
-        sed -i "s|@ServiceInstall@|${SERVICE_INSTALL}|g" ${WORKDIR}/homescreen.service
+        sed -i "s|@ServiceUnit@|${FLUTTER_HOMESCREEN_SERVICE_UNIT}|g" ${WORKDIR}/homescreen.service
+        sed -i "s|@ServiceService@|${FLUTTER_HOMESCREEN_SERVICE_SERVICE}|g" ${WORKDIR}/homescreen.service
+        sed -i "s|@ServiceInstall@|${FLUTTER_HOMESCREEN_SERVICE_INSTALL}|g" ${WORKDIR}/homescreen.service
         install -d ${D}${systemd_system_unitdir}
         install -m 644 ${WORKDIR}/homescreen.service ${D}${systemd_system_unitdir}/homescreen.service
     fi


### PR DESCRIPTION
This change is helpful for overiding (in local.conf or distro conf)

For the record Oniro overrides env as follow:

```
FLUTTER_HOMESCREEN_SERVICE_EXEC_START_PARAMS ?= "--a=/usr/share/gallery"
FLUTTER_HOMESCREEN_SERVICE_UNIT ?= "Requires=weston.service\nAfter=weston.service\n"
FLUTTER_HOMESCREEN_SERVICE_USER_GROUP ?= "User=weston\nGroup=weston"
FLUTTER_HOMESCREEN_SERVICE_ENVIRONMENT ?= "Environment=HOME=/home/weston\nEnvironment=XDG_RUNTIME_DIR=/run/user/1000"
```

Also add pkg-config dep since it's also used here

Relate-to: https://booting.oniroproject.org/distro/oniro/-/merge_requests/541
Forwarded: https://github.com/meta-flutter/meta-flutter/pulls?q=author%3Arzr
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>