### PR TITLE
ivi-homescreen.inc: Inhertit pkg-config

### DIFF
--- a/recipes-graphics/toyota/ivi-homescreen.inc
+++ b/recipes-graphics/toyota/ivi-homescreen.inc
@@ -28,7 +28,7 @@ SRC_URI = "git://github.com/toyota-connected/ivi-homescreen.git;protocol=https;b
 
 S = "${WORKDIR}/git"
 
-inherit cmake features_check systemd
+inherit cmake features_check pkgconfig systemd
 
 RUNTIME = "llvm"
 TOOLCHAIN = "clang"


### PR DESCRIPTION
Because its used in recipe, it may be added by default on some branches,
Oniro is kirkstone based.

Forwarded: https://github.com/sony/meta-flutter/pulls?q=author%3Arzr
Origin: https://github.com/meta-flutter/meta-flutter/pull/61
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>