### PR TITLE
homescreen: Fix systemd service template for sed

### DIFF
--- a/recipes-graphics/toyota/files/homescreen.service.in
+++ b/recipes-graphics/toyota/files/homescreen.service.in
@@ -1,13 +1,8 @@
 [Unit]
-Requires=weston.service
-After=weston.service
+@ServiceUnit@
 
 [Service]
-# Placeholder configuration to run as weston user for now.
-User=weston
-Group=weston
-Environment=XDG_RUNTIME_DIR=/run/user/200
-ExecStart=@ExecStart@
+@ServiceService@
 
 [Install]
-WantedBy=graphical.target
+@ServiceInstall@


### PR DESCRIPTION
For the record if was tested with oniro using:

```
SERVICE_EXEC_START_PARAMS:pn-ivi-homescreen-debug = "--f --a=/usr/share/gallery --t=DMZ-White"
SERVICE_UNIT:pn-ivi-homescreen-debug = "Requires=weston.service\nAfter=weston.service\n"
SERVICE_USER_GROUP:pn-ivi-homescreen-debug = "User=weston\nGroup=weston"
SERVICE_ENVIRONMENT:pn-ivi-homescreen-debug = "Environment=HOME=/home/weston\nEnvironment=XDG_RUNTIME_DIR=/run/user/1000"
```

Forwarded: https://github.com/meta-flutter/meta-flutter/pulls?q=author%3Arzr
Relate-to: https://github.com/meta-flutter/meta-flutter/pull/71
Relate-to: https://booting.oniroproject.org/distro/oniro/-/merge_requests/541
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>