### PR TITLE
homescreen: Add libunwind dep

### DIFF
--- a/recipes-graphics/toyota/ivi-homescreen.inc
+++ b/recipes-graphics/toyota/ivi-homescreen.inc
@@ -12,6 +12,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=39ae29158ce710399736340c60147314"
 DEPENDS += "\
     compiler-rt \
     libcxx \
+    libunwind \
     libxkbcommon \
     virtual/egl \
     wayland \


### PR DESCRIPTION
Observed issue on Oniro is:

    x86_64-oniro-linux-ld.lld: error: unable to find library -lunwind

Forwarded: https://github.com/meta-flutter/meta-flutter/pulls?q=author%3Arzr
Relate-to: https://booting.oniroproject.org/distro/oniro/-/merge_requests/541
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>