### PR TITLE
gn: Rename gn.bbclass to avoid collision

### DIFF
--- a/classes/gn_flutter.bbclass
+++ b/classes/gn_flutter.bbclass
@@ -1,0 +1,49 @@
+# Copyright (c) 2021-2022 Woven Alpha, Inc
+
+python () {
+    import gn
+    bb.fetch2.methods.append(gn.GN())
+}
+
+DEPENDS += " \
+    ca-certificates-native \
+    curl-native \
+    depot-tools-native \
+    pbzip2-native \
+    tar-native \
+"
+
+inherit python3native
+
+CURL_CA_BUNDLE ??= "${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt"
+DEPOT_TOOLS ??= "${STAGING_DIR_NATIVE}/usr/share/depot_tools"
+PYTHON2_PATH ??= "bootstrap-2@3.8.9.chromium.14_bin/python/bin"
+EXTRA_GN_SYNC ??= ""
+GN_CUSTOM_VARS ??= "{}"
+do_fetch[depends] += " \
+    ca-certificates-native:do_populate_sysroot \
+    curl-native:do_populate_sysroot \
+    depot-tools-native:do_populate_sysroot \
+    tar-native:do_populate_sysroot \
+    pbzip2-native:do_populate_sysroot \
+"
+
+do_configure:prepend() {
+    export http_proxy=${http_proxy}
+    export https_proxy=${https_proxy}
+    export HTTP_PROXY=${HTTP_PROXY}
+    export HTTPS_PROXY=${HTTPS_PROXY}
+    export PATH=${DEPOT_TOOLS}:${DEPOT_TOOLS}/${PYTHON2_PATH}:${PATH}
+    export DEPOT_TOOLS_UPDATE=0
+    export GCLIENT_PY3=0
+}
+
+do_compile:prepend() {
+    export http_proxy=${http_proxy}
+    export https_proxy=${https_proxy}
+    export HTTP_PROXY=${HTTP_PROXY}
+    export HTTPS_PROXY=${HTTPS_PROXY}
+    export PATH=${DEPOT_TOOLS}:${DEPOT_TOOLS}/${PYTHON2_PATH}:${PATH}
+    export DEPOT_TOOLS_UPDATE=0
+    export GCLIENT_PY3=0
+}

--- a/recipes-graphics/flutter-engine/flutter-engine.inc
+++ b/recipes-graphics/flutter-engine/flutter-engine.inc
@@ -23,7 +23,7 @@ SRC_URI = "gn://github.com/flutter/engine.git;name=src/flutter \
 
 S = "${WORKDIR}/src"
 
-inherit gn python3native features_check pkgconfig
+inherit gn_flutter python3native features_check pkgconfig
 
 require conf/include/gn-utils.inc
 require conf/include/flutter-version.inc


### PR DESCRIPTION
GN tool is not only specific to flutter,
Until it's upstreamed into a shared layer
let's rename it to avoid collision
with other projects using gn (ie: oniro)

BTW, may I suggest to later rename it to gclient too,
to prevent ambiguity with gn buid system.

Relate-to: https://gitlab.eclipse.org/eclipse/oniro-core/oniro/-/merge_requests/4
Forwarded: https://github.com/meta-flutter/meta-flutter/pulls?q=author%3Arzr
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>