### PR TITLE
flutter-engine: Enable deprecated mallinfo to support clang-12

### DIFF
--- a/recipes-graphics/flutter-engine/files/0005-dart-enable-mallinfo2.patch
+++ b/recipes-graphics/flutter-engine/files/0005-dart-enable-mallinfo2.patch
@@ -1,0 +1,13 @@
+diff --git a/runtime/runtime_args.gni b/runtime/runtime_args.gni
+index dd25e813dff..8b3999abcc0 100644
+--- a/runtime/runtime_args.gni
++++ b/runtime/runtime_args.gni
+@@ -48,7 +48,7 @@
+ 
+   # Whether to use mallinfo2 instead of mallinfo which is deprecated starting
+   # with libc 2.33
+-  dart_use_mallinfo2 = false
++  dart_use_mallinfo2 = true
+ 
+   # Whether to link Crashpad library for crash handling. Only supported on
+   # Windows for now.

--- a/recipes-graphics/flutter-engine/flutter-engine.inc
+++ b/recipes-graphics/flutter-engine/flutter-engine.inc
@@ -19,7 +19,9 @@ DEPENDS += "\
 
 SRC_URI = "gn://github.com/flutter/engine.git;name=src/flutter \
            file://0001-clang-toolchain.patch \
-           file://0002-x64-sysroot-assert.patch"
+           file://0002-x64-sysroot-assert.patch \
+           file://0005-dart-enable-mallinfo2.patch;patchdir=third_party/dart \
+"
 
 S = "${WORKDIR}/src"
 


### PR DESCRIPTION
Prevent this observed failure:

  FAILED: obj/third_party/dart/runtime/vm/libdart_vm_jit.malloc_hooks_unsupported.o
  .../flutter-engine-debug/git-r0/src/buildtools/linux-x64/clang/bin/clang++ \
  (...)
  ../../third_party/dart/runtime/vm/malloc_hooks_unsupported.cc:76:26: \
  error: 'mallinfo' is deprecated [-Werror,-Wdeprecated-declarations]
  truct mallinfo info = mallinfo();
                         ^
Relate-to: https://gitlab.eclipse.org/eclipse/oniro-core/oniro/-/merge_requests/4
Thanks-to: Natalia Kovalenko <waykovalenko@gmail.com>
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>