### PR TITLE
flutter-gallery: Allow networking for compile task

### DIFF
--- a/recipes-graphics/flutter-apps/flutter-gallery.inc
+++ b/recipes-graphics/flutter-apps/flutter-gallery.inc
@@ -19,3 +19,5 @@ PUBSPEC_APPNAME = "gallery"
 inherit flutter-app
 
 FILES:${PN} += "${datadir}/homescreen"
+
+do_compile[network] = "1"


### PR DESCRIPTION
Observed issue (on Oniro) is:

    flutter build bundle
    (...)
    Downloading Material fonts...                                        1ms
    (...)
    Failed to download https://storage.googleapis.com/flutter_infra_release/flutter/fonts/3ebf18904a0b2d50fe311ff41e9e1e4894bc270d/fonts.zip. \
    Ensure you have network connectivity and then try again.
    SocketException: Failed host lookup: 'storage.googleapis.com' (OS Error: Temporary failure in name resolution, errno = -3)

Forwarded: https://github.com/sony/meta-flutter/pulls?q=author%3Arzr
Relate-to: https://booting.oniroproject.org/distro/oniro/-/merge_requests/541
Signed-off-by: Philippe Coval <philippe.coval@huawei.com>