### PR TITLE
flutter-sdk: add http(s)_proxy environment setting

### DIFF
--- a/recipes-graphics/flutter-apps/flutter-sdk_git.bb
+++ b/recipes-graphics/flutter-apps/flutter-sdk_git.bb
@@ -35,6 +35,9 @@ common_compile() {
     export PATH=${S}/bin:$PATH
     export PUB_CACHE=${S}/.pub-cache
 
+    export http_proxy=${http_proxy}
+    export https_proxy=${https_proxy}
+
     bbnote "Flutter SDK: ${FLUTTER_SDK_TAG}"
 
     flutter config --no-enable-android


### PR DESCRIPTION
In the environemts requiring http_proxy and/or https_proxy to access the
flutter websites, this recipe will be failed.
To avoid such failure, I added the environments "http_proxy" and
"https_proxy" in common_compile().

Signed-off-by: Kazuyoshi Akiyama <kazuyoshi.akiyama@woven-planet.global>