### PR TITLE
c/flutter-app.bbclass: Add symlink to libapp.so

### DIFF
--- a/classes/flutter-app.bbclass
+++ b/classes/flutter-app.bbclass
@@ -221,7 +221,7 @@ do_compile() {
     fi
 }
 
-INSANE_SKIP:${PN} += " ldflags libdir"
+INSANE_SKIP:${PN} += " dev-so ldflags libdir"
 SOLIBS = ".so"
 FILES:SOLIBSDEV = ""
 
@@ -234,6 +234,7 @@ do_install() {
        ${@bb.utils.contains('FLUTTER_RUNTIME', 'profile', 'true', 'false', d)}; then
        install -d ${D}${FLUTTER_INSTALL_DIR}/lib
         cp ${S}/${FLUTTER_APPLICATION_PATH}/libapp.so ${D}${FLUTTER_INSTALL_DIR}/lib/
+        ln -s ../lib/libapp.so ${D}${FLUTTER_INSTALL_DIR}/flutter_assets/
     fi
 
        


### PR DESCRIPTION
This fix application launching in release mode,
ivi-homescreen is looking for lib (along kernel_blob.bin) in assets dir
(ie: --a=/usr/share/flutter/gallery/flutter_assets/ )

Observed issue was:

    [ERROR:flutter/runtime/dart_vm_data.cc(18)] \
    VM snapshot invalid and could not be inferred from settings.
    [ERROR:flutter/runtime/dart_vm.cc(269)] \
    Could not set up VM data to bootstrap the VM from.
    [ERROR:flutter/runtime/dart_vm_lifecycle.cc(84)] \
    Could not create Dart VM instance.
    [FATAL:flutter/shell/common/shell.cc(143)] \
    Check failed: vm. Must be able to initialize the VM.
    Aborted

Relate-to: https://booting.oniroproject.org/rzr/meta-oniro-blueprint-flutter/-/issues/3#note_24362
Relate-to: https://github.com/meta-flutter/meta-flutter/issues/115#issuecomment-1160263129
Signed-off-by: Philippe Coval <philippe.coval.ext@huawei.com>