### PR TITLE
App Bundle Folder Structure

### DIFF
--- a/classes/flutter-app.bbclass
+++ b/classes/flutter-app.bbclass
@@ -227,12 +227,12 @@ FILES:SOLIBSDEV = ""
 
 do_install() {
 
-    install -d ${D}${FLUTTER_INSTALL_DIR}/flutter_assets
-    cp -r ${S}/${FLUTTER_APPLICATION_PATH}/build/flutter_assets/* ${D}${FLUTTER_INSTALL_DIR}/flutter_assets/
+    install -d ${D}${FLUTTER_INSTALL_DIR}/data/flutter_assets
+    cp -r ${S}/${FLUTTER_APPLICATION_PATH}/build/flutter_assets/* ${D}${FLUTTER_INSTALL_DIR}/data/flutter_assets/
 
     if ${@bb.utils.contains('FLUTTER_RUNTIME', 'release', 'true', 'false', d)} || \
-       ${@bb.utils.contains('FLUTTER_RUNTIME', 'profile', 'true', 'false', d)}; then
-       install -d ${D}${FLUTTER_INSTALL_DIR}/lib
+        ${@bb.utils.contains('FLUTTER_RUNTIME', 'profile', 'true', 'false', d)}; then
+        install -d ${D}${FLUTTER_INSTALL_DIR}/lib
         cp ${S}/${FLUTTER_APPLICATION_PATH}/libapp.so ${D}${FLUTTER_INSTALL_DIR}/lib/
     fi
 

--- a/recipes-graphics/flutter-pi/files/0001-path-updates.patch
+++ b/recipes-graphics/flutter-pi/files/0001-path-updates.patch
@@ -1,32 +1,36 @@
-From a34e06e871322a427741a88e67995d67847761ef Mon Sep 17 00:00:00 2001
+From 30c7b363ce7555d36921c3167f84cbcdba524183 Mon Sep 17 00:00:00 2001
 From: Joel Winarske <joel.winarske@gmail.com>
-Date: Wed, 23 Feb 2022 13:42:13 -0800
+Date: Sat, 9 Jul 2022 09:16:10 -0700
 Subject: [PATCH] path updates
 
 Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
 ---
- src/flutter-pi.c | 8 ++++----
- 1 file changed, 4 insertions(+), 4 deletions(-)
+ src/flutter-pi.c | 12 ++++++------
+ 1 file changed, 6 insertions(+), 6 deletions(-)
 
 diff --git a/src/flutter-pi.c b/src/flutter-pi.c
-index 46ab470..4149626 100644
+index 128fe2d..6131e8d 100644
 --- a/src/flutter-pi.c
 +++ b/src/flutter-pi.c
-@@ -2260,7 +2260,7 @@ static bool setup_paths(void) {
+@@ -2267,24 +2267,24 @@ static bool setup_paths(void) {
+         return false;
      }
-     
-     asprintf(&kernel_blob_path, "%s/kernel_blob.bin", flutterpi.flutter.asset_bundle_path);
+ 
+-    asprintf(&kernel_blob_path, "%s/kernel_blob.bin", flutterpi.flutter.asset_bundle_path);
 -    asprintf(&app_elf_path, "%s/app.so", flutterpi.flutter.asset_bundle_path);
-+    asprintf(&app_elf_path, "%s/libapp.so", flutterpi.flutter.asset_bundle_path);
++    asprintf(&kernel_blob_path, "%s/data/flutter_assets/kernel_blob.bin", flutterpi.flutter.asset_bundle_path);
++    asprintf(&app_elf_path, "%s/lib/libapp.so", flutterpi.flutter.asset_bundle_path);
  
      if (flutterpi.flutter.runtime_mode == kDebug) {
          if (!PATH_EXISTS(kernel_blob_path)) {
-@@ -2269,14 +2269,14 @@ static bool setup_paths(void) {
+-            LOG_ERROR("Could not find \"kernel.blob\" file inside \"%s\", which is required for debug mode.\n", flutterpi.flutter.asset_bundle_path);
++            LOG_ERROR("Could not find \"kernel.blob\" file inside \"%s/data/flutter_assets/\", which is required for debug mode.\n", flutterpi.flutter.asset_bundle_path);
+             return false;
          }
      } else if (flutterpi.flutter.runtime_mode == kRelease) {
          if (!PATH_EXISTS(app_elf_path)) {
 -            LOG_ERROR("Could not find \"app.so\" file inside \"%s\", which is required for release and profile mode.\n", flutterpi.flutter.asset_bundle_path);
-+            LOG_ERROR("Could not find \"libapp.so\" file inside \"%s\", which is required for release and profile mode.\n", flutterpi.flutter.asset_bundle_path);
++            LOG_ERROR("Could not find \"libapp.so\" file inside \"%s/lib/\", which is required for release and profile mode.\n", flutterpi.flutter.asset_bundle_path);
              return false;
          }
      }
@@ -40,4 +44,5 @@ index 46ab470..4149626 100644
      }
  
 -- 
-2.31.1
+2.32.1 (Apple Git-133)
+

--- a/recipes-graphics/sony/files/0001-path-updates.patch
+++ b/recipes-graphics/sony/files/0001-path-updates.patch
@@ -1,30 +1,26 @@
-From f0b42bea91887ba23b3fb32f88bd0b1097b66cb3 Mon Sep 17 00:00:00 2001
+From f34991cb65d04779c495d6dac5e0d997f9f72fce Mon Sep 17 00:00:00 2001
 From: Joel Winarske <joel.winarske@gmail.com>
-Date: Tue, 16 Nov 2021 19:41:16 -0800
-Subject: [PATCH] Update path locations
+Date: Sat, 9 Jul 2022 09:05:08 -0700
+Subject: [PATCH] path updates
 
 Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
 ---
- src/client_wrapper/include/flutter/dart_project.h | 6 +++---
- 1 file changed, 3 insertions(+), 3 deletions(-)
+ src/client_wrapper/include/flutter/dart_project.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
 
 diff --git a/src/client_wrapper/include/flutter/dart_project.h b/src/client_wrapper/include/flutter/dart_project.h
-index 6c67c87..6d4a0d3 100644
+index 6c67c87..c567117 100644
 --- a/src/client_wrapper/include/flutter/dart_project.h
 +++ b/src/client_wrapper/include/flutter/dart_project.h
-@@ -22,9 +22,9 @@ class DartProject {
-   // The path can either be absolute, or relative to the directory containing
+@@ -23,7 +23,7 @@ class DartProject {
    // the running executable.
    explicit DartProject(const std::wstring& path) {
--    assets_path_ = path + L"/data/flutter_assets";
+     assets_path_ = path + L"/data/flutter_assets";
 -    icu_data_path_ = path + L"/data/icudtl.dat";
--    aot_library_path_ = path + L"/lib/libapp.so";
-+    assets_path_ = path;
 +    icu_data_path_ = L"/usr/share/flutter/icudtl.dat";
-+    aot_library_path_ = path + L"/libapp.so";
+     aot_library_path_ = path + L"/lib/libapp.so";
    }
  
-   ~DartProject() = default;
 -- 
-2.25.1
+2.32.1 (Apple Git-133)
 


### PR DESCRIPTION
-Flutter Application Installation now follows this pattern
```
FLUTTER_INSTALL_DIR (aka app bundle)
 ├── data
 │   └── flutter_assets
 └── lib
     └── libapp.so
```
-flutter-pi and Sony embedders paths have been updated to match this


Signed-off-by: Joel Winarske <joel.winarske@gmail.com>