### PR TITLE
AGL Refactor

### DIFF
--- a/.github/workflows/kirkstone-agl-renesas-m3.yml
+++ b/.github/workflows/kirkstone-agl-renesas-m3.yml
@@ -59,12 +59,11 @@ jobs:
           rm -rf meta-flutter || true
           ln -sf ../../meta-flutter meta-flutter
           cd ..
-          sed -i '/weston-ini-conf-landscape/d' meta-agl-devel/meta-agl-flutter/recipes-platform/images/agl-image-flutter-debug.bb
-          sed -i '/weston-ini-conf-landscape/d' meta-agl-devel/meta-agl-flutter/recipes-platform/images/agl-image-flutter-profile.bb
-          sed -i '/weston-ini-conf-landscape/d' meta-agl-devel/meta-agl-flutter/recipes-platform/images/agl-image-flutter.bb
-          rm ./bsp/meta-rcar/meta-rcar-gen3-adas/recipes-bsp/u-boot/u-boot_2020.01.bbappend || true
-          rm ./meta-agl/meta-agl-bsp/meta-rcar-gen3/recipes-bsp/u-boot/u-boot_2020.01.bbappend || true
-          rm ./bsp/meta-renesas/meta-rcar-gen3/recipes-graphics/cogl/cogl-1.0_1.%.bbappend || true
+          rm -rf meta-agl-devel
+          git clone https://github.com/meta-flutter/meta-agl-devel.git
+          # rm ./bsp/meta-rcar/meta-rcar-gen3-adas/recipes-bsp/u-boot/u-boot_2020.01.bbappend || true
+          # rm ./meta-agl/meta-agl-bsp/meta-rcar-gen3/recipes-bsp/u-boot/u-boot_2020.01.bbappend || true
+          # rm ./bsp/meta-renesas/meta-rcar-gen3/recipes-graphics/cogl/cogl-1.0_1.%.bbappend || true
           
       - name: Configure AGL build
         shell: bash
@@ -110,17 +109,17 @@ jobs:
           bitbake ivi-homescreen-runtimerelease -c do_cleansstate
           bitbake ivi-homescreen-runtimeprofile -c do_cleansstate
 
-      - name: Build agl-image-flutter-debug
+      - name: Build agl-image-flutter-runtimedebug
         shell: bash
         working-directory: ${{ env.WORKSPACE }}
         run: |
           . ./build/agl-init-build-env
           rm -rf /home/dev/artifacts/*
-          bitbake agl-image-flutter-debug
+          bitbake agl-image-flutter-runtimedebug
           cp bb.environment /home/dev/artifacts
           cd tmp/deploy/images/${{ env.MACHINE }}
-          cp agl-image-flutter-debug-m3ulcb-*.rootfs.wic.bmap /home/dev/artifacts
-          cp agl-image-flutter-debug-m3ulcb-*.rootfs.wic.xz /home/dev/artifacts
+          cp agl-image-flutter-runtimedebug-m3ulcb-*.rootfs.wic.bmap /home/dev/artifacts
+          cp agl-image-flutter-runtimedebug-m3ulcb-*.rootfs.wic.xz /home/dev/artifacts
           mkdir -p /home/dev/artifacts/boot
           cp bootparam_sa0.srec /home/dev/artifacts
           cp bl2-m3ulcb.srec /home/dev/artifacts
@@ -136,15 +135,15 @@ jobs:
           path: |
              /home/dev/artifacts/*
 
-      - name: Build agl-image-flutter-debug SDK
+      - name: Build agl-image-flutter-runtimedebug SDK
         shell: bash
         working-directory: ${{ env.WORKSPACE }}
         run: |
           . ./build/agl-init-build-env
           rm -rf /home/dev/artifacts/*
-          bitbake agl-image-flutter-debug -c do_populate_sdk
+          bitbake agl-image-flutter-runtimedebug -c do_populate_sdk
           cp bb.environment /home/dev/artifacts
-          cp tmp/deploy/sdk/poky-agl-glibc-*-agl-image-flutter-debug-*.sh /home/dev/artifacts
+          cp tmp/deploy/sdk/poky-agl-glibc-*-agl-image-flutter-runtimedebug-*.sh /home/dev/artifacts
 
       - name: Publish agl-image-flutter-runtimedebug SDK artifact
         uses: actions/upload-artifact@v2

--- a/.github/workflows/kirkstone-agl-x86_64.yml
+++ b/.github/workflows/kirkstone-agl-x86_64.yml
@@ -58,9 +58,8 @@ jobs:
           rm -rf meta-flutter || true
           ln -sf ../../meta-flutter meta-flutter
           cd ..
-          sed -i '/weston-ini-conf-landscape/d' meta-agl-devel/meta-agl-flutter/recipes-platform/images/agl-image-flutter-debug.bb || true
-          sed -i '/weston-ini-conf-landscape/d' meta-agl-devel/meta-agl-flutter/recipes-platform/images/agl-image-flutter-profile.bb || true
-          sed -i '/weston-ini-conf-landscape/d' meta-agl-devel/meta-agl-flutter/recipes-platform/images/agl-image-flutter.bb || true
+          rm -rf meta-agl-devel
+          git clone https://github.com/meta-flutter/meta-agl-devel.git
 
       - name: Configure AGL build
         shell: bash
@@ -101,76 +100,70 @@ jobs:
           bitbake ivi-homescreen-runtimeprofile -c do_cleansstate
           bitbake ivi-homescreen-runtimedebug -c do_cleansstate
 
-      - name: Build agl-image-flutter
+      - name: Build agl-image-flutter-runtimerelease
         shell: bash
         working-directory: ../agl-master-qemux86_64
         run: |
           . ./build/agl-init-build-env
           rm -rf /home/dev/artifacts/*
-          bitbake agl-image-flutter
+          bitbake agl-image-flutter-runtimerelease
           cp bb.environment /home/dev/artifacts
-          cp tmp/deploy/images/${{ env.MACHINE }}/agl-image-flutter-${{ env.MACHINE }}.wic.vmdk /home/dev/artifacts
-          cp tmp/deploy/images/${{ env.MACHINE }}/agl-image-flutter-${{ env.MACHINE }}.ext4 /home/dev/artifacts
-          cp tmp/deploy/images/${{ env.MACHINE }}/bzImage /home/dev/artifacts
+          cp tmp/deploy/images/${{ env.MACHINE }}/agl-image-flutter-runtimerelease-${{ env.MACHINE }}.wic.vmdk /home/dev/artifacts
 
-      - name: Publish agl-image-flutter artifacts
+      - name: Publish agl-image-flutter-runtimerelease artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: agl-image-flutter-qemux86-64-linux
+          name: agl-image-flutter-runtimerelease-qemux86-64-linux
           path: |
              /home/dev/artifacts/*
 
-      - name: Build agl-image-flutter-profile
+      - name: Build agl-image-flutter-runtimeprofile
         shell: bash
         working-directory: ../agl-master-qemux86_64
         run: |
           . ./build/agl-init-build-env
           rm -rf /home/dev/artifacts/*
-          bitbake agl-image-flutter-profile
+          bitbake agl-image-flutter-runtimeprofile
           cp bb.environment /home/dev/artifacts
-          cp tmp/deploy/images/${{ env.MACHINE }}/agl-image-flutter-profile-${{ env.MACHINE }}.wic.vmdk /home/dev/artifacts
-          cp tmp/deploy/images/${{ env.MACHINE }}/agl-image-flutter-profile-${{ env.MACHINE }}.ext4 /home/dev/artifacts
-          cp tmp/deploy/images/${{ env.MACHINE }}/bzImage /home/dev/artifacts
+          cp tmp/deploy/images/${{ env.MACHINE }}/agl-image-flutter-runtimeprofile-${{ env.MACHINE }}.wic.vmdk /home/dev/artifacts
 
-      - name: Publish agl-image-flutter-profile artifacts
+      - name: Publish agl-image-flutter-runtimeprofile artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: agl-image-flutter-profile-qemux86-64-linux
+          name: agl-image-flutter-runtimeprofile-qemux86-64-linux
           path: |
              /home/dev/artifacts/*
 
-      - name: Build agl-image-flutter-debug
+      - name: Build agl-image-flutter-runtimedebug
         shell: bash
         working-directory: ../agl-master-qemux86_64
         run: |
           . ./build/agl-init-build-env
           rm -rf /home/dev/artifacts/*
-          bitbake agl-image-flutter-debug
+          bitbake agl-image-flutter-runtimedebug
           cp bb.environment /home/dev/artifacts
-          cp tmp/deploy/images/${{ env.MACHINE }}/agl-image-flutter-debug-${{ env.MACHINE }}.wic.vmdk /home/dev/artifacts
-          cp tmp/deploy/images/${{ env.MACHINE }}/agl-image-flutter-debug-${{ env.MACHINE }}.ext4 /home/dev/artifacts
-          cp tmp/deploy/images/${{ env.MACHINE }}/bzImage /home/dev/artifacts
+          cp tmp/deploy/images/${{ env.MACHINE }}/agl-image-flutter-runtimedebug-${{ env.MACHINE }}.wic.vmdk /home/dev/artifacts
 
-      - name: Publish agl-image-flutter-debug artifacts
+      - name: Publish agl-image-flutter-runtimedebug artifacts
         uses: actions/upload-artifact@v2
         with:
-          name: agl-image-flutter-debug-qemux86-64-linux
+          name: agl-image-flutter-runtimedebug-qemux86-64-linux
           path: |
              /home/dev/artifacts/*
 
-      - name: Build agl-image-flutter-debug SDK
+      - name: Build agl-image-flutter-runtimedebug SDK
         shell: bash
         working-directory: ../agl-master-qemux86_64
         run: |
           . ./build/agl-init-build-env
           rm -rf /home/dev/artifacts/*
-          bitbake agl-image-flutter-debug -c do_populate_sdk
+          bitbake agl-image-flutter-runtimedebug -c do_populate_sdk
           cp bb.environment /home/dev/artifacts
-          cp tmp/deploy/sdk/poky-agl-glibc-*-agl-image-flutter-debug-*.sh /home/dev/artifacts
+          cp tmp/deploy/sdk/poky-agl-glibc-*-agl-image-flutter-runtimedebug-*.sh /home/dev/artifacts
 
-      - name: Publish agl-image-flutter-debug SDK artifact
+      - name: Publish agl-image-flutter-runtimedebug SDK artifact
         uses: actions/upload-artifact@v2
         with:
-          name: agl-image-flutter-debug-sdk-qemux86-64-linux
+          name: agl-image-flutter-runtimedebug-sdk-qemux86-64-linux
           path: |
              /home/dev/artifacts/*

--- a/.github/workflows/kirkstone-linux-dummy.yml
+++ b/.github/workflows/kirkstone-linux-dummy.yml
@@ -312,3 +312,15 @@ jobs:
           bitbake flutter-test-video-player-runtimerelease
           bitbake flutter-test-video-player-runtimeprofile
           bitbake flutter-test-video-player-runtimedebug
+
+      - name: Build flutter-test-localization
+        shell: bash
+        working-directory: ../yocto-kirkstone
+        run: |
+          . ./poky/oe-init-build-env
+          bitbake flutter-test-localization-runtimerelease -c do_cleansstate
+          bitbake flutter-test-localization-runtimeprofile -c do_cleansstate
+          bitbake flutter-test-localization-runtimedebug -c do_cleansstate
+          bitbake flutter-test-localization-runtimerelease
+          bitbake flutter-test-localization-runtimeprofile
+          bitbake flutter-test-localization-runtimedebug

--- a/.github/workflows/kirkstone-qc-dragonboard.yml
+++ b/.github/workflows/kirkstone-qc-dragonboard.yml
@@ -90,6 +90,7 @@ jobs:
               flutter-test-secure-storage-runtimerelease \
               flutter-test-texture-egl-runtimerelease \
               flutter-test-video-player-runtimerelease \
+              flutter-test-localization-runtimerelease \
               "' >> conf/local.conf
           echo 'LICENSE_FLAGS_ACCEPTED += " commercial"' >> conf/local.conf
           echo '********** conf/local.conf **********'
@@ -113,6 +114,7 @@ jobs:
           bitbake -c do_cleansstate flutter-test-secure-storage-runtimerelease
           bitbake -c do_cleansstate flutter-test-texture-egl-runtimerelease
           bitbake -c do_cleansstate flutter-test-video-player-runtimerelease
+          bitbake -c do_cleansstate flutter-test-localization-runtimerelease
 
       - name: Build rpb-weston-image
         shell: bash
@@ -217,6 +219,7 @@ jobs:
               flutter-test-video-player-runtimerelease \
               flutter-test-plugins-runtimerelease \
               flutter-test-texture-egl-runtimerelease \
+              flutter-test-localization \
               "' >> conf/local.conf
           echo 'LICENSE_FLAGS_ACCEPTED += " commercial"' >> conf/local.conf
           echo '********** conf/local.conf **********'
@@ -240,6 +243,7 @@ jobs:
           bitbake -c do_cleansstate flutter-test-secure-storage-runtimerelease
           bitbake -c do_cleansstate flutter-test-texture-egl-runtimerelease
           bitbake -c do_cleansstate flutter-test-video-player-runtimerelease
+          bitbake -c do_cleansstate flutter-test-localization-runtimerelease
 
       - name: Build rpb-weston-image
         shell: bash

--- a/.github/workflows/kirkstone-rpi-zero2w-64.yml
+++ b/.github/workflows/kirkstone-rpi-zero2w-64.yml
@@ -89,6 +89,7 @@ jobs:
               flutter-test-video-player-runtimerelease \
               flutter-test-plugins-runtimerelease \
               flutter-test-texture-egl-runtimerelease \
+              flutter-test-localization-runtimerelease \
               "' >> ./conf/local.conf
           echo 'LICENSE_FLAGS_ACCEPTED += " commercial"' >> ./conf/local.conf
           echo '********** ./conf/local.conf **********'
@@ -112,6 +113,7 @@ jobs:
           bitbake -c do_cleansstate flutter-test-secure-storage-runtimerelease
           bitbake -c do_cleansstate flutter-test-texture-egl-runtimerelease
           bitbake -c do_cleansstate flutter-test-video-player-runtimerelease
+          bitbake -c do_cleansstate flutter-test-localization-runtimerelease
 
       - name: Build rpi-image-flutter-wayland
         shell: bash

--- a/recipes-graphics/flutter-apps/flutter-test-localization_git.bb
+++ b/recipes-graphics/flutter-apps/flutter-test-localization_git.bb
@@ -1,0 +1,20 @@
+SUMMARY = "Localization Test Application"
+DESCRIPTION = "Localization Test Application"
+AUTHOR = "Lakshydeep Vikram"
+HOMEPAGE = "https://github.com/meta-flutter/tests"
+BUGTRACKER = "https://github.com/meta-flutter/tests/issues"
+SECTION = "graphics"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=df6bd2163489eedcdea6b9406bcbe1dd"
+
+SRCREV = "ce7bb3916197f1ccb2b64064fa3fcdf1307223f7"
+SRC_URI = "git://github.com/meta-flutter/tests.git;lfs=0;branch=main;protocol=https;destsuffix=git"
+
+S = "${WORKDIR}/git"
+
+PUBSPEC_APPNAME = "localization"
+FLUTTER_APPLICATION_PATH = "localization"
+FLUTTER_APPLICATION_INSTALL_PREFIX = "/flutter"
+
+inherit flutter-app

--- a/recipes-graphics/flutter-apps/flutter-test-plugins_git.bb
+++ b/recipes-graphics/flutter-apps/flutter-test-plugins_git.bb
@@ -46,8 +46,8 @@ require conf/include/flutter-version.inc
 
 # Plugin Plus "Device Info" requires "/etc/lsb-release" which is not present with Poky
 do_install:append() {
-    install -d ${D}${sysconfdir}
-    install -m 644 ${WORKDIR}/lsb-release ${D}${sysconfdir}
+    install -D -m0644 ${WORKDIR}/lsb-release \
+        ${D}${sysconfdir}/lsb-release
     sed -i "s|@FLUTTER_SDK_TAG@|${@get_flutter_sdk_version(d)}|g" ${D}${sysconfdir}/lsb-release
 }
 

--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -34,6 +34,8 @@ require conf/include/flutter-runtime.inc
 
 BBCLASSEXTEND = "runtimerelease runtimeprofile runtimedebug"
 
+PREFERRED_PROVIDER:${PN} = "${PN}"
+
 # For gn.bbclass
 GN_CUSTOM_VARS ?= '\
 {\
@@ -145,23 +147,23 @@ do_compile[progress] = "outof:^\[(\d+)/(\d+)\]\s+"
 
 do_install() {
 
-    install -d ${D}${libdir}
-    install -m 644 ${S}/${OUT_DIR_REL}/so.unstripped/libflutter_engine.so ${D}${libdir}
+    install -D -m0644 ${S}/${OUT_DIR_REL}/so.unstripped/libflutter_engine.so \
+        ${D}${libdir}/libflutter_engine.so
+    
     if ${@bb.utils.contains('PACKAGECONFIG', 'desktop-embeddings', 'true', 'false', d)}; then
-        install -m 644 ${S}/${OUT_DIR_REL}/so.unstripped/libflutter_linux_gtk.so ${D}${libdir}
+        install -m0644 ${S}/${OUT_DIR_REL}/so.unstripped/libflutter_linux_gtk.so ${D}${libdir}
     fi
 
-    install -d ${D}${includedir}
-    install -m 644 ${S}/${OUT_DIR_REL}/flutter_embedder.h ${D}${includedir}
+    install -D -m0644 ${S}/${OUT_DIR_REL}/flutter_embedder.h \
+        ${D}${includedir}/flutter_embedder.h
 
-    install -d ${D}${datadir}
-    install -d ${D}${datadir}/flutter/
-    install -m 644 ${S}/${OUT_DIR_REL}/icudtl.dat ${D}${datadir}/flutter/
+    install -D -m0644 ${S}/${OUT_DIR_REL}/icudtl.dat \
+        ${D}${datadir}/flutter/icudtl.dat
 
     # create SDK
-    install -d ${D}${datadir}/flutter/sdk
-    install -d ${D}${datadir}/flutter/sdk/clang_x64
-    install -m 755 ${S}/${OUT_DIR_REL}/clang_x64/gen_snapshot ${D}${datadir}/flutter/sdk/clang_x64/
+    install -D -m0755 ${S}/${OUT_DIR_REL}/clang_x64/gen_snapshot \
+        ${D}${datadir}/flutter/sdk/clang_x64/gen_snapshot
+    
     cd ${S}/flutter
     echo `git rev-parse HEAD` > ${D}${datadir}/flutter/sdk/engine.version
     echo ${FLUTTER_ENGINE_REPO_URL} >> ${D}${datadir}/flutter/sdk/engine.version

--- a/recipes-graphics/sony/flutter-drm-eglstream-backend_git.bb
+++ b/recipes-graphics/sony/flutter-drm-eglstream-backend_git.bb
@@ -5,15 +5,11 @@ REQUIRED_DISTRO_FEATURES = "wayland opengl"
 
 require sony-flutter.inc
 
-DEPENDS += "\
-    libdrm \
-    "
+DEPENDS += "libdrm"
 
 do_install() {
-   install -d ${D}${bindir}
-   install -m 755 ${WORKDIR}/build/flutter-drm-eglstream-backend ${D}${bindir}
+    install -D -m0755 ${WORKDIR}/build/flutter-drm-eglstream-backend \
+        ${D}${bindir}/flutter-drm-eglstream-backend
 }
 
-FILES:${PN} = "\
-   ${bindir} \
-   "
+FILES:${PN} = "${bindir}"

--- a/recipes-graphics/sony/flutter-drm-gbm-backend_git.bb
+++ b/recipes-graphics/sony/flutter-drm-gbm-backend_git.bb
@@ -5,15 +5,11 @@ REQUIRED_DISTRO_FEATURES = "opengl"
 
 require sony-flutter.inc
 
-DEPENDS += "\
-    libdrm \
-    "
+DEPENDS += "libdrm"
 
 do_install() {
-   install -d ${D}${bindir}
-   install -m 755 ${WORKDIR}/build/flutter-drm-gbm-backend ${D}${bindir}
+    install -D -m0755 ${WORKDIR}/build/flutter-drm-gbm-backend \
+        ${D}${bindir}/flutter-drm-gbm-backend
 }
 
-FILES:${PN} = "\
-   ${bindir} \
-   "
+FILES:${PN} = "${bindir}"

--- a/recipes-graphics/sony/flutter-external-texture-plugin_git.bb
+++ b/recipes-graphics/sony/flutter-external-texture-plugin_git.bb
@@ -15,10 +15,10 @@ SOLIBS = ".so"
 FILES_SOLIBSDEV = ""
 
 do_install() {
-   install -d ${D}${bindir}
-   install -d ${D}${libdir}
-   install -m 755 ${WORKDIR}/build/flutter-client ${D}${bindir}
-   install -m 644 ${WORKDIR}/build/plugins/external_texture_test/libexternal_texture_test_plugin.so ${D}${libdir}
+    install -D -m0755 ${WORKDIR}/build/flutter-client \
+        ${D}${bindir}/flutter-client
+    install -D -m0644 ${WORKDIR}/build/plugins/external_texture_test/libexternal_texture_test_plugin.so \
+        ${D}${libdir}/libexternal_texture_test_plugin.so
 }
 
 FILES:${PN} = "\

--- a/recipes-graphics/sony/flutter-video-player-plugin_git.bb
+++ b/recipes-graphics/sony/flutter-video-player-plugin_git.bb
@@ -22,10 +22,10 @@ SOLIBS = ".so"
 FILES_SOLIBSDEV = ""
 
 do_install() {
-   install -d ${D}${bindir}
-   install -d ${D}${libdir}
-   install -m 755 ${WORKDIR}/build/flutter-client ${D}${bindir}
-   install -m 644 ${WORKDIR}/build/plugins/video_player/libvideo_player_plugin.so ${D}${libdir}
+    install -D -m0755 ${WORKDIR}/build/flutter-client \
+        ${D}${bindir}/flutter-client
+    install -D -m0644 ${WORKDIR}/build/plugins/video_player/libvideo_player_plugin.so \
+        ${D}${libdir}/libvideo_player_plugin.so
 }
 
 FILES:${PN} = "\

--- a/recipes-graphics/sony/flutter-wayland-client_git.bb
+++ b/recipes-graphics/sony/flutter-wayland-client_git.bb
@@ -11,10 +11,8 @@ DEPENDS += "\
     "
 
 do_install() {
-   install -d ${D}${bindir}
-   install -m 755 ${WORKDIR}/build/flutter-client ${D}${bindir}
+    install -D -m0755 ${WORKDIR}/build/flutter-client \
+        ${D}${bindir}/flutter-client
 }
 
-FILES:${PN} = "\
-   ${bindir} \
-   "
+FILES:${PN} = "${bindir}"

--- a/recipes-graphics/sony/flutter-x11-client_git.bb
+++ b/recipes-graphics/sony/flutter-x11-client_git.bb
@@ -6,10 +6,8 @@ REQUIRED_DISTRO_FEATURES = "x11 opengl"
 require sony-flutter.inc
 
 do_install() {
-   install -d ${D}${bindir}
-   install -m 755 ${WORKDIR}/build/flutter-x11-client ${D}${bindir}
+    install -D -m0755 ${WORKDIR}/build/flutter-x11-client \
+        ${D}${bindir}/flutter-x11-client
 }
 
-FILES:${PN} = "\
-   ${bindir} \
-   "
+FILES:${PN} = "${bindir}"

--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -36,7 +36,7 @@ EXTRA_OECMAKE += "\
     "
 
 do_configure:prepend() {
-   install -d ${S}/build
+   mkdir -p ${S}/build | true
    ln -sf ${STAGING_LIBDIR}/libflutter_engine.so ${S}/build/libflutter_engine.so
 }
 

--- a/recipes-graphics/toyota/files/homescreen.service.in
+++ b/recipes-graphics/toyota/files/homescreen.service.in
@@ -1,8 +1,0 @@
-[Unit]
-@ServiceUnit@
-
-[Service]
-@ServiceService@
-
-[Install]
-@ServiceInstall@

--- a/recipes-graphics/toyota/ivi-homescreen.inc
+++ b/recipes-graphics/toyota/ivi-homescreen.inc
@@ -21,14 +21,12 @@ DEPENDS += "\
 
 REQUIRED_DISTRO_FEATURES = "wayland opengl"
 
-SRCREV ??= "7f3f913ec5bea1d94c04f8a029db659c33e56dbf"
-SRC_URI = "git://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=main \
-           file://homescreen.service.in \
-          "
+SRCREV ??= "e45815f118532794196dc939e5edfab1fdc6ed65"
+SRC_URI = "git://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=main"
 
 S = "${WORKDIR}/git"
 
-inherit cmake features_check pkgconfig systemd
+inherit cmake features_check pkgconfig 
 
 require conf/include/flutter-runtime.inc
 
@@ -36,54 +34,41 @@ RUNTIME = "llvm"
 TOOLCHAIN = "clang"
 PREFERRED_PROVIDER:libgcc = "compiler-rt"
 
-PACKAGECONFIG ??= "gstreamer mouse-cursor package-info secure-storage text-input transparency url-launcher texture-test-egl"
+PACKAGECONFIG ??= "\
+    ${@bb.utils.contains('DISTRO_FEATURES', 'vulkan', 'backend-vulkan', 'backend-egl', d)} \
+    gstreamer \
+    mouse-cursor \
+    package-info \
+    secure-storage \
+    text-input \
+    texture-test-egl \
+    transparency \
+    url-launcher \
+    "
 
 PACKAGECONFIG[accessibility] = "-DBUILD_PLUGIN_ACCESSIBILITY=ON, -DBUILD_PLUGIN_ACCESSIBILITY=OFF"
+PACKAGECONFIG[backend-egl] = "-DBUILD_BACKEND_WAYLAND_EGL=ON -DBUILD_BACKEND_WAYLAND_VULKAN=OFF"
+PACKAGECONFIG[backend-vulkan] = "-DBUILD_BACKEND_WAYLAND_VULKAN=ON -DBUILD_BACKEND_WAYLAND_EGL=OFF"
 PACKAGECONFIG[gstreamer] = "-DBUILD_PLUGIN_GSTREAMER_EGL=ON, -DBUILD_PLUGIN_GSTREAMER_EGL=OFF, gstreamer1.0 gstreamer1.0-plugins-base ffmpeg"
 PACKAGECONFIG[isolate] = "-DBUILD_PLUGIN_ISOLATE=ON, -DBUILD_PLUGIN_ISOLATE=OFF"
 PACKAGECONFIG[mouse-cursor] = "-DBUILD_PLUGIN_MOUSE_CURSOR=ON, -DBUILD_PLUGIN_MOUSE_CURSOR=OFF"
 PACKAGECONFIG[navigation] = "-DBUILD_PLUGIN_NAVIGATION=ON, -DBUILD_PLUGIN_NAVIGATION=OFF"
-PACKAGECONFIG[texture-test-egl] = "-DBUILD_TEXTURE_TEST_EGL=ON, -DBUILD_TEXTURE_TEST_EGL=OFF"
 PACKAGECONFIG[package-info] = "-DBUILD_PLUGIN_PACKAGE_INFO=ON, -DBUILD_PLUGIN_PACKAGE_INFO=OFF"
 PACKAGECONFIG[platform] = "-DBUILD_PLUGIN_PLATFORM=ON, -DBUILD_PLUGIN_PLATFORM=OFF"
 PACKAGECONFIG[platform-view] = "-DBUILD_PLUGIN_PLATFORM_VIEW=ON, -DBUILD_PLUGIN_PLATFORM_VIEW=OFF"
 PACKAGECONFIG[restoration] = "-DBUILD_PLUGIN_RESTORATION=ON, -DBUILD_PLUGIN_RESTORATION=OFF"
 PACKAGECONFIG[secure-storage] = "-DBUILD_PLUGIN_SECURE_STORAGE=ON, -DBUILD_PLUGIN_SECURE_STORAGE=OFF, libsecret"
 PACKAGECONFIG[text-input] = "-DBUILD_PLUGIN_TEXT_INPUT=ON, -DBUILD_PLUGIN_TEXT_INPUT=OFF"
+PACKAGECONFIG[texture-test-egl] = "-DBUILD_TEXTURE_TEST_EGL=ON, -DBUILD_TEXTURE_TEST_EGL=OFF"
 PACKAGECONFIG[transparency] = "-DBUILD_EGL_TRANSPARENCY=ON, -DBUILD_EGL_TRANSPARENCY=OFF"
 PACKAGECONFIG[url-launcher] = "-DBUILD_PLUGIN_URL_LAUNCHER=ON, -DBUILD_PLUGIN_URL_LAUNCHER=OFF"
 
 
-EXTRA_OECMAKE += "\
-    -D CMAKE_SYSROOT=${STAGING_DIR_TARGET}/usr \
-    "
+EXTRA_OECMAKE += " -D CMAKE_SYSROOT=${STAGING_DIR_TARGET}/usr"
 
-# Use pattern "--b={absolute path to flutter_assets}"
-IVI_HOMESCREEN_APP_OVERRIDE ??= ""
-# parameters to pass to homescreen app and Dart VM
-SERVICE_EXEC_START_PARAMS ??= ""
-
-SERVICE_UNIT        ??= "Requires=weston@root.service\nAfter=weston@root.service\n"
-SERVICE_USER_GROUP  ??= "User=weston\nGroup=weston"
-SERVICE_RESTART     ??= "Restart=on-failure\nRestartSec=1"
-SERVICE_ENVIRONMENT ??= "Environment=HOME=/home/weston\nEnvironment=XDG_RUNTIME_DIR=/run/user/1000"
-SERVICE_EXEC_START  ??= "ExecStart=/usr/bin/homescreen --f ${IVI_HOMESCREEN_APP_OVERRIDE} ${SERVICE_EXEC_START_PARAMS}"
-SERVICE_SERVICE     ??= "${SERVICE_USER_GROUP}\n${SERVICE_RESTART}\n${SERVICE_ENVIRONMENT}\n${SERVICE_EXEC_START}\n"
-SERVICE_INSTALL     ??= "WantedBy=graphical.target\n"
-
-do_install:append() {
-    if ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'true', 'false', d)}; then
-        install -m 644 ${WORKDIR}/homescreen.service.in ${WORKDIR}/homescreen.service
-        sed -i "s|@ServiceUnit@|${SERVICE_UNIT}|g" ${WORKDIR}/homescreen.service
-        sed -i "s|@ServiceService@|${SERVICE_SERVICE}|g" ${WORKDIR}/homescreen.service
-        sed -i "s|@ServiceInstall@|${SERVICE_INSTALL}|g" ${WORKDIR}/homescreen.service
-        install -d ${D}${systemd_system_unitdir}
-        install -m 644 ${WORKDIR}/homescreen.service ${D}${systemd_system_unitdir}/homescreen.service
-    fi
+cmake_do_install:append() {
+    rm -rf ${D}${libdir}
 }
 
-SYSTEMD_SERVICE:${PN} += "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'homescreen.service', '', d)}"
-SYSTEMD_PACKAGES = "${@bb.utils.contains('DISTRO_FEATURES', 'systemd', '${PN}', '', d)}"
-
 BBCLASSEXTEND = "runtimerelease runtimeprofile runtimedebug"
-RDEPENDS:${PN} += "flutter-engine-${@gn_get_flutter_runtime_name(d)}"
+RDEPENDS:${PN} += " flutter-engine-${@gn_get_flutter_runtime_name(d)}"


### PR DESCRIPTION
-Backend selection for ivi-homescreen
  defaults to backend-egl unless DISTRO_FEATURES includes vulkan
-Roll ivi-homescreen
 Makes default window type Background.  No-op in case of desktop.
-Remove ivi-homescreen system service logic in favor of
   using bbappend for a given platform
-Localization test app

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>