### PR TITLE
flutter-engine do_install failure

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -173,6 +173,7 @@ do_install() {
     zip -r engine_sdk.zip sdk
     rm -rf sdk
 }
+do_install[network] = "1"
 do_install[depends] += "zip-native:do_populate_sysroot"
 
 PACKAGES =+ "${PN}-sdk-dev"


### PR DESCRIPTION
-This is added to address some reports of do_install failing for flutter-engine.
 There is no empirical data to support this being required, as I am unable to
 repro in CI builds using Ubuntu 20 docker container.

Signed-off-by: Joel Winarske <joel.winarske@gmail.com>