### PR TITLE
Updated M1 Mac instructions in  tools/README.md

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -109,7 +109,7 @@ entry, then it will add entry to `.vscode/launch.json`.
 
 ### M1 Mac PyCurl install
 ```
-arch -arm64 brew reinstall openssl
+arch -arm64 brew reinstall openssl@1.1
 pip3 uninstall pycurl
-arch -arm64 pip3 install --install-option="--with-openssl" --install-option="--openssl-dir=/usr/local/opt/openssl@1.1" pycurl
+arch -arm64 pip3 install --install-option="--with-openssl" --install-option="--openssl-dir=/opt/homebrew/opt/openssl@1.1" pycurl
 ```


### PR DESCRIPTION
Changes to the m1 mac pycurl instructions, the openssl_dir in the readme corresponded to linux-based filesystem