### PR TITLE
Only build flutter-engine for enabled configurations

### DIFF
--- a/classes/flutter-app.bbclass
+++ b/classes/flutter-app.bbclass
@@ -185,7 +185,7 @@ do_compile() {
     ${FLUTTER_PREBUILD_CMD}
 
     # determine build type based on what flutter-engine installed
-    FLUTTER_RUNTIME_MODES="$(ls ${STAGING_DIR_TARGET}${datadir}/flutter/${FLUTTER_SDK_VERSION})"
+    FLUTTER_RUNTIME_MODES="$(basename -a $(dirname $(ls ${STAGING_DIR_TARGET}${datadir}/flutter/${FLUTTER_SDK_VERSION}/*/engine_sdk.zip)))"
 
     for FLUTTER_RUNTIME_MODE in $FLUTTER_RUNTIME_MODES; do
 
@@ -283,7 +283,7 @@ do_compile() {
 do_install() {
 
     # determine build type based on what flutter-engine installed
-    FLUTTER_RUNTIME_MODES="$(ls ${STAGING_DIR_TARGET}${datadir}/flutter/${FLUTTER_SDK_VERSION})"
+    FLUTTER_RUNTIME_MODES="$(basename -a $(dirname $(ls ${STAGING_DIR_TARGET}${datadir}/flutter/${FLUTTER_SDK_VERSION}/*/engine_sdk.zip)))"
 
     for FLUTTER_RUNTIME_MODE in $FLUTTER_RUNTIME_MODES; do
 

--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -133,17 +133,9 @@ do_configure[depends] += "depot-tools-native:do_populate_sysroot"
 
 do_compile() {
 
-    FLUTTER_RUNTIME_MODES="\
-        ${@d.getVarFlags("PACKAGECONFIG").get('debug')} \
-        ${@d.getVarFlags("PACKAGECONFIG").get('profile')} \
-        ${@d.getVarFlags("PACKAGECONFIG").get('release')} \
-        ${@d.getVarFlags("PACKAGECONFIG").get('jit_release')}"
+    FLUTTER_RUNTIME_MODES="$(echo "${PACKAGECONFIG_CONFARGS}" | grep -o -P -e '(?<=--runtime-mode )(\w+)')"
 
     for FLUTTER_RUNTIME_MODE in $FLUTTER_RUNTIME_MODES; do
-        if [ "${FLUTTER_RUNTIME_MODE}" = "--runtime-mode" ]; then
-            continue
-        fi
-
         BUILD_DIR="$(echo ${TMP_OUT_DIR} | sed "s/_RUNTIME_/${FLUTTER_RUNTIME_MODE}/g")"
 
         ./flutter/tools/gn ${GN_ARGS_LESS_RUNTIME_MODES} --runtime-mode $FLUTTER_RUNTIME_MODE
@@ -158,17 +150,9 @@ do_compile[progress] = "outof:^\[(\d+)/(\d+)\]\s+"
 
 do_install() {
 
-    FLUTTER_RUNTIME_MODES="\
-        ${@d.getVarFlags("PACKAGECONFIG").get('debug')} \
-        ${@d.getVarFlags("PACKAGECONFIG").get('profile')} \
-        ${@d.getVarFlags("PACKAGECONFIG").get('release')} \
-        ${@d.getVarFlags("PACKAGECONFIG").get('jit_release')}"
+    FLUTTER_RUNTIME_MODES="$(echo "${PACKAGECONFIG_CONFARGS}" | grep -o -P -e '(?<=--runtime-mode )(\w+)')"
 
     for FLUTTER_RUNTIME_MODE in $FLUTTER_RUNTIME_MODES; do
-        if [ "${FLUTTER_RUNTIME_MODE}" = "--runtime-mode" ]; then
-            continue
-        fi
-
         BUILD_DIR="$(echo ${TMP_OUT_DIR} | sed "s/_RUNTIME_/${FLUTTER_RUNTIME_MODE}/g")"
 
         install -D -m 0644 ${S}/${BUILD_DIR}/so.unstripped/libflutter_engine.so \


### PR DESCRIPTION
Two changes in this PR.

* Only build and install the flutter-engine for the enabled modes by querying the processed PACKAGECONFIG.
* Only build apps (inherit flutter-app) for the enabled (installed) engine modes (by looking for installed engine_sdk.zip).

The second commit ("Only build flutter-apps for actually installed modes") is required to fix leftover empty directories in the sysroot.

You could also have determined the enabled modes like this (for flutter-engine)

```bash
     FLUTTER_RUNTIME_MODES="\
        ${@bb.utils.contains('PACKAGECONFIG', 'debug', 'debug', '', d)} \
        ${@bb.utils.contains('PACKAGECONFIG', 'profile', 'profile', '', d)} \
        ${@bb.utils.contains('PACKAGECONFIG', 'release', 'release', '', d)} \
        ${@bb.utils.contains('PACKAGECONFIG', 'jit_release', 'jit_release', '', d)}"
```

but since the old code preferred to fetch the mode names from what's enabled via --runtime-mode I opted to look at the parsed config instead.