### PR TITLE
URI: change "name" format (#252)

### DIFF
--- a/lib/gn.py
+++ b/lib/gn.py
@@ -33,6 +33,14 @@ class GN(FetchMethod):
     def urldata_init(self, ud, d):
         # syntax: gn://<URL>;name=<NAME>;destdir=<D>;proto=<PROTO>
         name = ud.parm.get("name", "src")
+        # URI "name=" is special, can't have path slashes, otherwise we
+        # risk parse errors with things like
+        # SRC_URI[src/flutter.sha256sum].
+        # So always prepend the checkout path with "src/" when not using
+        # the default.
+        if not name.startswith("src"):
+            name = os.path.join("src/", name)
+
         ud.destdir = "" if "destdir" not in ud.parm else ud.parm["destdir"]
         proto = "https" if "proto" not in ud.parm else ud.parm["proto"]
 

--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -16,7 +16,7 @@ DEPENDS += "\
     zip-native \
     "
 
-SRC_URI = "gn://github.com/flutter/engine.git;name=src/flutter \
+SRC_URI = "gn://github.com/flutter/engine.git;name=flutter \
            file://0001-clang-toolchain.patch \
            file://0002-x64-sysroot-assert.patch \
            file://0001-remove-x11-dependency.patch \


### PR DESCRIPTION
Using name=src/flutter wound up causing some amount of trouble when Running a Yocto build with a PREMIRROR.  The original failure:

ERROR: flutter-engine-runtimerelease-git-r0 do_fetch: No checksum specified for '/hd/utils_test/release-tmp/re po_base/downloads/https__github.com_flutter_engine.git-8f2221fbef28b478debb78dd233f5250b220ca99.tar.bz2', plea se add at least one to the recipe:
SRC_URI[src/flutter.sha256sum] = "d16173dd94e967f44aed198d283d8212640d892cf86631a9318b72e61f793c4d" ERROR: flutter-engine-runtimerelease-git-r0 do_fetch: Bitbake Fetcher Error: NoChecksumError('Missing SRC_URI checksum', 'https://artifactory.foo.com/Yocto/dunfell/https__github.com_flutter_engine.git-8f2221fbef28b478debb78dd233f5250b220ca99.tar.bz2;name=src/flutter')

But using the above suggestion of setting
"SRC_URI[src/flutter.sha256sum]" in a .bbappend results with this error:

ERROR: ParseError at /hd/dunfell/sources/meta-foo/recipes-graphics/flutter-engine/flutter-engine_git.bbappend:10: unparsed line: 'SRC_URI[src/flutter.sha256sum] = "d16173dd94e967f44aed198d283d8212640d892cf86631a9318b72e61f793c4d"'

So we change gn.py to prepend "src/" to the name for writing the gclient solution, and change the gn URI in flutter-engine to not include "src/".

Cherry-pick: b22e5be8eab8d940d52eb7b5d25d91e8c56afe40