### PR TITLE
HOME contamination fix

### DIFF
--- a/classes/flutter-app.bbclass
+++ b/classes/flutter-app.bbclass
@@ -80,9 +80,10 @@ python do_archive_pub_cache() {
 
     pub_cache_cmd = \
         'export PUB_CACHE=%s; ' \
+        'export XDG_CONFIG_HOME=%s;' \
         '%s/bin/flutter pub get;' \
         '%s/bin/flutter pub get --offline' % \
-        (pub_cache, flutter_sdk, flutter_sdk)
+        (pub_cache, workdir, flutter_sdk, flutter_sdk)
 
     bb.note("Running %s in %s" % (pub_cache_cmd, app_root))
     runfetchcmd('%s' % (pub_cache_cmd), d, quiet=False, workdir=app_root)


### PR DESCRIPTION
-When Flutter SDK tools are used, then get stored in $HOME
 The Flutter SDK tooling checks if XDG_CONFIG_HOME is set before using $HOME.
 This change sets the base path for flutter tools to use XDG_CONFIG_HOME.
 Which points to an individual recipes workdir

- https://github.com/meta-flutter/meta-flutter/issues/124