### PR TITLE
flutter-engine: allow local version pinning

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -20,12 +20,16 @@ DEPENDS += "\
     zip-native \
     "
 
-SRC_URI = "\
-    gn://github.com/flutter/engine.git;name=flutter \
+FLUTTER_ENGINE_PATCHES ?= "\
     file://0001-clang-toolchain.patch \
     file://0001-disable-pre-canned-sysroot.patch \
     file://0001-remove-x11-dependency.patch \
     file://0001-Disable-x11.patch \
+    "
+
+SRC_URI = "\
+    gn://github.com/flutter/engine.git;name=flutter \
+    ${FLUTTER_ENGINE_PATCHES} \
     "
 
 S = "${WORKDIR}/src"


### PR DESCRIPTION
currently the local patches in flutter-engine do only fit for the proposed default version of FLUTTER_SDK_TAG.
If one would want to locally pin the version to something different one or more patches wouldn’t apply.
Fix this by weak defining a new variable called FLUTTER_ENGINE_PATCHES which can be easily overridden in a local setup or a layer on top of meta-flutter to have the right set of patches stored there