### PR TITLE
Add wayland to DEPENDS even without vulkan

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -18,6 +18,7 @@ DEPENDS += "\
     compiler-rt \
     libcxx \
     zip-native \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'wayland', 'wayland', '', d)} \
     "
 
 FLUTTER_ENGINE_PATCHES ?= "\


### PR DESCRIPTION
When not using vulkan wayland is still needed to build `flutter-engine`.

This should fix #278 