### PR TITLE
depot-tools-native: fix INSANE_SKIP

### DIFF
--- a/recipes-devtools/depot-tools/depot-tools-native_git.bb
+++ b/recipes-devtools/depot-tools/depot-tools-native_git.bb
@@ -33,10 +33,6 @@ do_install() {
     cp -rTv ${S}/. ${D}${datadir}/depot_tools
 }
 
-FILES:${PN}-dev = "${datadir}/depot_tools/*"
-
-INSANE_SKIP:${PN}-dev = "already-stripped"
-
-BBCLASSEXTEND += "native"
+INSANE_SKIP:${PN} = "already-stripped"
 
 # vim:set ts=4 sw=4 sts=4 expandtab:


### PR DESCRIPTION
as depot-tools already is a native only package, there isn't any use in defining BBCLASSEXTEND.
Futhermore native recipes do not have any kind of packaging, rendering the assignments of FILES:${PN}-dev and INSANE_SKIP:${PN}-dev not applicable.
Remove any packaging related setting and just use INSANE_SKIP:${PN}. Fixes: ninja-linux64 from depot-tools-native was already stripped, this will prevent future debugging!