### PR TITLE
Bump depot_tools revision

### DIFF
--- a/recipes-devtools/depot-tools/depot-tools-native_git.bb
+++ b/recipes-devtools/depot-tools/depot-tools-native_git.bb
@@ -8,7 +8,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=c2c05f9bdd5fc0b458037c2d1fb8d95e"
 SRC_URI = "git://chromium.googlesource.com/chromium/tools/depot_tools;protocol=https;branch=main \
            file://0001-disable-ninjalog_upload.patch"
 
-SRCREV = "3a56ba9d9c9d22bc78e24f96a9096247d53649f8"
+SRCREV = "64b61755572b1d03b3a43f1a29b617dcae3a3fe0"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
This fixes the following issue while bootstrapping depot_tools as a dependency of CEF on AGL:

Could not find a version that satisfies the requirement setuptools>=40.3.0 (from google_api_core==1.31.5->-r /tmp/vpython_bootstrap882189871/requirements.txt (line 22)) (from versions:) No matching distribution found for setuptools>=40.3.0 (from google_api_core==1.31.5->-r /tmp/vpython_bootstrap882189871/requirements.txt (line 22))