### PR TITLE
all: address do_compile proxy issues

### DIFF
--- a/classes/gn-for-flutter.bbclass
+++ b/classes/gn-for-flutter.bbclass
@@ -1,8 +1,10 @@
 # Copyright (c) 2020-2022 Woven Alpha, Inc
 
 python () {
+    from bb.utils import export_proxies
     import gn
     bb.fetch2.methods.append(gn.GN())
+    export_proxies(d)
 }
 
 DEPENDS += " \
@@ -31,10 +33,6 @@ do_fetch[depends] += " \
 
 do_configure[network] = "1"
 do_configure:prepend() {
-    export http_proxy=${http_proxy}
-    export https_proxy=${https_proxy}
-    export HTTP_PROXY=${HTTP_PROXY}
-    export HTTPS_PROXY=${HTTPS_PROXY}
     export PATH=${DEPOT_TOOLS}:${DEPOT_TOOLS}/${PYTHON2_PATH}:${PATH}
     export DEPOT_TOOLS_UPDATE=0
     export GCLIENT_PY3=0
@@ -42,10 +40,6 @@ do_configure:prepend() {
 
 do_compile[network] = "1"
 do_compile:prepend() {
-    export http_proxy=${http_proxy}
-    export https_proxy=${https_proxy}
-    export HTTP_PROXY=${HTTP_PROXY}
-    export HTTPS_PROXY=${HTTPS_PROXY}
     export PATH=${DEPOT_TOOLS}:${DEPOT_TOOLS}/${PYTHON2_PATH}:${PATH}
     export DEPOT_TOOLS_UPDATE=0
     export GCLIENT_PY3=0

--- a/recipes-devtools/depot-tools/depot-tools-native_git.bb
+++ b/recipes-devtools/depot-tools/depot-tools-native_git.bb
@@ -14,6 +14,11 @@ S = "${WORKDIR}/git"
 
 inherit native
 
+python () {
+    from bb.utils import export_proxies
+    export_proxies(d)
+}
+
 do_compile[network] = "1"
 do_compile() {
 

--- a/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
+++ b/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
@@ -36,13 +36,15 @@ do_unpack[network] = "1"
 do_patch[network] = "1"
 do_compile[network] = "1"
 
+python () {
+    from bb.utils import export_proxies
+    export_proxies(d)
+}
+
 do_compile() {
     export CURL_CA_BUNDLE=${STAGING_DIR_NATIVE}/etc/ssl/certs/ca-certificates.crt
     export PATH=${S}/bin:$PATH
     export PUB_CACHE=${S}/.pub-cache
-
-    export http_proxy=${http_proxy}
-    export https_proxy=${https_proxy}
 
     bbnote "Flutter SDK: ${FLUTTER_SDK_TAG}"
 


### PR DESCRIPTION
The compile phase of certain packages depends on a loopback websocket connection. If a proxy is exported for this without a corresponding no_proxy config containing localhost, ::1, and 127.0.0.1, it will result in a connection issue and error out.

If we're exporting most of the proxy variables manually now then lets just use the export_proxy command from bitbake directly were proxies are needed.