### PR TITLE
Fix compiling against 3.13.x

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -48,12 +48,6 @@ GN_CUSTOM_VARS ?= '\
     "download_windows_deps": False, \
     "download_linux_deps": False,   \
 }'
-# https://github.com/flutter/flutter/issues/127606
-GN_CUSTOM_DEPS ?= '\
-{\
-    "src/third_party/dart/third_party/pkg/tools": \
-    "https://dart.googlesource.com/tools.git@545d7e1c73ce21b8c91f638021f9d487d324a501" \
-}'
 EXTRA_GN_SYNC ?= "--shallow --no-history -R -D"
 
 COMPATIBLE_MACHINE = "(-)"


### PR DESCRIPTION
https://github.com/flutter/flutter/issues/127606 has been fixed for quite some time and is no longer needed. In addition, the inclusion of https://dart.googlesource.com/tools.git@545d7e1c73ce21b8c91f638021f9d487d324a501 causes 3.13.x to fail with the following error:

output: Error: Couldn't resolve the package 'linter' in 'package:linter/src/rules.dart'.
analytics_manager.dart:223:23: Error: The method 'send' isn't defined for the class 'Analytics'.

Remove the inclusion of unified_analytics.