### PR TITLE
ivi-homescreen_git.bb: remove duplicated rdepends

### DIFF
--- a/recipes-graphics/toyota/ivi-homescreen_git.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_git.bb
@@ -103,5 +103,3 @@ cmake_do_install:append() {
 }
 
 BBCLASSEXTEND = "verbose-logs"
-
-RDEPENDS:${PN} = "flutter-engine"


### PR DESCRIPTION
Rdepends to flutter-engine has been added twice to the recipe over time. See line 24.