### PR TITLE
Remove pyyaml dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+Nov 9, 2023
+1. Replace pyyaml use with re to avoid mixing host and Yocto -native
+   Python bits.
+2. Changed a couple of pubspec.yaml name errors to bb.fatal to stop
+   build immediately, as do_compile will fail.
+
 Nov 8, 2023
 1. Update engine_sdk.zip contents to enable impeller 3d aot generation from host
 2. Support unpotimized builds with IsCreationCurrentThreadCurrent patch

--- a/conf/include/app-utils.inc
+++ b/conf/include/app-utils.inc
@@ -14,44 +14,30 @@ def get_pubspec_yaml_filepath(d):
     bb.debug(1, f'pubspec_yaml filepath [{filepath}]')
 
     if not os.path.exists(filepath):
-        bb.error("pubspec.yaml not found, check FLUTTER_APPLICATION_PATH value")
+        bb.fatal("pubspec.yaml not found, check FLUTTER_APPLICATION_PATH value")
 
     return filepath
 
 
-def write_pubspec_obj_to_file(d, obj):
-    """ Writes YAML object to file """
-    os.sys.path.append(d.getVar('PYTHON3_SITEPACKAGES_DIR'))
-    import yaml
-
-    filepath = get_pubspec_yaml_filepath(d)
-    with open(filepath, 'w') as outfile:
-        yaml.dump(obj, outfile)
-
-
-def get_pubspec_yaml(d):
-    """ Returns python object of pubspec.yaml """
-    os.sys.path.append(d.getVar('PYTHON3_SITEPACKAGES_DIR'))
-    import yaml
-
-    filepath = get_pubspec_yaml_filepath(d)
-
-    data_loaded = None
-    with open(filepath, "r") as stream:
-        try:
-            data_loaded = yaml.safe_load(stream)
-
-        except yaml.YAMLError as exc:
-            bb.error(f'Failed loading {exc} - {filepath}')
-
-        return data_loaded
-
-
-def get_pubspec_appname(d):
+def get_pubspec_yaml_appname(d):
     """ Returns the application name from the pubspec.yaml """
-    yaml = get_pubspec_yaml(d)
-    return yaml["name"]
 
+    filepath = get_pubspec_yaml_filepath(d)
+    with open(filepath, "r") as f:
+        lines = f.readlines()
+
+    import re
+    pattern = re.compile(r'^name:\s+(\w+)$')
+    name = ''
+    for line in lines:
+        m = pattern.match(line)
+        if m:
+           name = m.group(1)
+           break
+    if not m:
+        bb.fatal("'name' not found in pubspec.yaml")
+
+    return name
 
 def filter_plugin_registrant(dart_file):
     """ Removes unused items from the dart plugin registrant file """

--- a/conf/include/flutter-app.inc
+++ b/conf/include/flutter-app.inc
@@ -13,13 +13,10 @@ require conf/include/flutter-version.inc
 require conf/include/app-utils.inc
 require conf/include/common.inc
 
-inherit python3-dir
-
 DEPENDS += " \
     ca-certificates-native \
     flutter-engine \
     flutter-sdk-native \
-    python3-pyyaml-native \
     unzip-native \
     "
 
@@ -179,11 +176,11 @@ do_compile[network] = "1"
 python do_compile() {
     import shutil
 
-    pubspec_yaml = get_pubspec_yaml(d)
+    pubspec_yaml_appname = get_pubspec_yaml_appname(d)
     pubspec_appname = d.getVar("PUBSPEC_APPNAME")
-    if pubspec_appname != pubspec_yaml["name"]:
-        bb.error("Set PUBSPEC_APPNAME to match name value in pubspec.yaml")
-    
+    if pubspec_appname != pubspec_yaml_appname:
+        bb.fatal("Set PUBSPEC_APPNAME to match name value in pubspec.yaml")
+
     flutter_sdk = d.getVar('FLUTTER_SDK')
 
     env = os.environ


### PR DESCRIPTION
Replace pyyaml module usage in app bbclass code with re based parsing of the app name from pubspec.yaml.  This avoids needing either pyyaml on the build host or mixing the host and -native Pythons as was being done. Also, a couple of the app name errors have been bumped to bb.fatal from bb.error to end building immediately, as do_compile is going to fail in those situations, anyways.