### PR TITLE
Catchup to some of the dunfell branch changes.

### DIFF
--- a/lib/gn.py
+++ b/lib/gn.py
@@ -90,10 +90,10 @@ class GN(FetchMethod):
         bb.utils.mkdirhier(ud.syncpath)
         os.chdir(ud.syncpath)
 
-        logger.debug2("Fetching %s using command '%s'" % (ud.url, ud.basecmd))
+        logger.debug(2, "Fetching %s using command '%s'" % (ud.url, ud.basecmd))
         bb.fetch2.check_network_access(d, ud.basecmd, ud.url)
         runfetchcmd(ud.basecmd, d, quiet, workdir=None)
-        logger.debug2("Packing %s using command '%s'" % (ud.url, ud.packcmd))
+        logger.debug(2, "Packing %s using command '%s'" % (ud.url, ud.packcmd))
         runfetchcmd(ud.packcmd, d, quiet, workdir=None)
 
     def localpath(self, ud, d):

--- a/recipes-graphics/flutter-apps/flutter-gallery_git.bb
+++ b/recipes-graphics/flutter-apps/flutter-gallery_git.bb
@@ -13,7 +13,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3ac21e3d8ebe7dd79f273ca11b9e7b4e"
 
 SRCREV = "6a8d738c94d0710e229d726729c09fdb5ccaf7ed"
-SRC_URI = "git://github.com/flutter/gallery.git;lfs=0;branch=master;protocol=https;destsuffix=git"
+SRC_URI = "git://github.com/flutter/gallery.git;lfs=0;branch=main;protocol=https;destsuffix=git"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
With these modifications (and some config tweaks I found in other issue history) I was able to use the wayland-client to launch flutter apps on a Digi ConnectCore i.MX6 SBC development platform with gatesgarth as my base system.

---

fix: Make gn.py work again with older versions of python (used in the gatesgarth branch)
fix: Update the branch name for flutter-gallery to 'main', as it's now what is used.