### PR TITLE
rename gallery branch

### DIFF
--- a/recipes-graphics/flutter-apps/flutter-gallery_git.bb
+++ b/recipes-graphics/flutter-apps/flutter-gallery_git.bb
@@ -13,7 +13,7 @@ LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=3ac21e3d8ebe7dd79f273ca11b9e7b4e"
 
 SRCREV = "6a8d738c94d0710e229d726729c09fdb5ccaf7ed"
-SRC_URI = "git://github.com/flutter/gallery.git;lfs=0;branch=master;protocol=https;destsuffix=git"
+SRC_URI = "git://github.com/flutter/gallery.git;lfs=0;branch=main;protocol=https;destsuffix=git"
 
 S = "${WORKDIR}/git"
 


### PR DESCRIPTION
Rename master to main.  There is an alias from master to main now, but may be removed in the future