### PR TITLE
Remove Rust workaround for proc-macro2

### DIFF
--- a/recipes-devtools/rust/libstd-rs_%.bbappend
+++ b/recipes-devtools/rust/libstd-rs_%.bbappend
@@ -1,1 +1,0 @@
-S = "${RUSTSRC}/library/test"


### PR DESCRIPTION
-removes workaround for `can't find crate for proc_macro` when compiling proc-macro2` -https://github.com/meta-rust/meta-rust/issues/266 -https://github.com/meta-flutter/meta-flutter/issues/370