### PR TITLE
Fix attempting AOT compile for debug builds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+Jan 22, 2024
+1. Fix debug builds for apps
+
 Jan 19, 2024
 1. Add `FLUTTER_SDK_TAG` to pub-cache archive filename.  When updating SDK version this will update pub-cache correctly now network is disabled for compile.
 2. Move flutter-packages-example-file-selector_git.bb to dynamic-layers/gnome-layer/recipes-graphics/flutter-apps/ since it has a runtime dependency on meta-gnome.

--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -306,7 +306,7 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
 
         bb.note(f'[{runtime_mode}] flutter build {flutter_build_args}: Completed')
 
-        if runtime_mode == 'release' or 'profile':
+        if runtime_mode == 'release' or runtime_mode == 'profile':
 
             bb.note(f'kernel_snapshot_{runtime_mode}: Starting')
 


### PR DESCRIPTION
Invalid if statement meant that the recipe attempted to build AOT snapshot for debug builds.

Potentially fixes https://github.com/meta-flutter/meta-flutter/issues/387