### PR TITLE
build failure with curl command missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+Feb 5, 2024
+1. Unable to find `curl` fix.
+   `occasional` flutter-sdk-native build failures on clean source tree.
+   Initial issue may be related to host machine HW thread count.  Not reproducible
+   on 32+ HW threads.
+
 Feb 4, 2024
 1. Improved recipe names
 2. Add AWS amplify-flutter apps

--- a/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
+++ b/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
@@ -69,6 +69,12 @@ def run_command(d, cmd, cwd, env):
 
 
 do_unpack[network] = "1"
+do_unpack[depends] += " \
+    ca-certificates-native:do_prepare_recipe_sysroot \
+    curl-native:do_prepare_recipe_sysroot \
+    ninja-native:do_prepare_recipe_sysroot \
+    unzip-native:do_prepare_recipe_sysroot \
+"
 python do_unpack:append() {
     import shutil
 


### PR DESCRIPTION
-adds do_prepare_recipe_sysroot dependencies to do_unpack -tested scenarios:
 ```
 bitbake ca-certificates-native -cdo_cleanall
 bitbake curl-native -cdo_cleanall
 bitbake ninja-native -cdo_cleanall
 bitbake unzip-native -cdo_cleanall
 bitbake flutter-sdk-native -cdo_cleanall
 bitbake flutter-sdk-native
 ```
 and same sequence using uni-proc in conf/local.conf:
 ```
 PARALLEL_MAKE = "-j 1"
 BB_NUMBER_THREADS = "1"
 ```