### PR TITLE
Flutter Engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+Mar 18, 2024
+1. flutter-engine: default desktop-embedding off
+2. flutter-engine: remove gtk dep if unit-tests disabled
+
 Mar 12, 2024
 1. Rive 0.8.4
 2. packagegroup-flutter-sdk-deps

--- a/recipes-graphics/flutter-engine/files/0001-Skip-configuration-dependency-if-unit-tests-are-disa.patch
+++ b/recipes-graphics/flutter-engine/files/0001-Skip-configuration-dependency-if-unit-tests-are-disa.patch
@@ -1,0 +1,26 @@
+From 4e7bd1d0a02ff2f3b17f30d20e40a9cb4f83f409 Mon Sep 17 00:00:00 2001
+From: Joel Winarske <joel.winarske@gmail.com>
+Date: Mon, 18 Mar 2024 13:56:37 -0700
+Subject: [PATCH] Skip configuration dependency if unit tests are disabled
+
+Signed-off-by: Joel Winarske <joel.winarske@gmail.com>
+---
+ flutter/testing/BUILD.gn | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/flutter/testing/BUILD.gn b/flutter/testing/BUILD.gn
+index 9eac294525..a7d094695c 100644
+--- a/flutter/testing/BUILD.gn
++++ b/flutter/testing/BUILD.gn
+@@ -51,7 +51,7 @@ source_set("testing") {
+ 
+   sources = [ "run_all_unittests.cc" ]
+ 
+-  if (is_linux) {
++  if (enable_unittests && is_linux) {
+     # So that we can call gtk_init in main().
+     configs += [ "//flutter/shell/platform/linux/config:gtk" ]
+   }
+-- 
+2.44.0
+

--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -27,6 +27,7 @@ FLUTTER_ENGINE_PATCHES ?= "\
     file://0001-remove-x11-dependency.patch \
     file://0001-disable-x11.patch \
     file://0001-impeller-workaround.patch \
+    file://0001-Skip-configuration-dependency-if-unit-tests-are-disa.patch \
     "
 
 SRC_URI = "\
@@ -62,7 +63,6 @@ COMPATIBLE_MACHINE:x86-64 = "(.*)"
 
 PACKAGECONFIG ??= "\
     debug profile release \
-    desktop-embeddings \
     embedder-for-target \
     fontconfig \
     mallinfo2 \


### PR DESCRIPTION
-default desktop-embedding off
-remove gtk dep if unit-tests disabled
-pulls in patch: https://github.com/flutter/engine/pull/51179