### PR TITLE
rive-text LTO build option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+Apr 2, 2024
+1. rive-text LTO build option.  Resolves 32-bit build issue.
+
 March 29, 2024
 1. improve flutter app build error handling
 

--- a/dynamic-layers/clang-layer/recipes-devtools/rive/rive-text_0.3.2.bb
+++ b/dynamic-layers/clang-layer/recipes-devtools/rive/rive-text_0.3.2.bb
@@ -29,7 +29,7 @@ TOOLCHAIN = "clang"
 PREFERRED_PROVIDER_libgcc = "compiler-rt"
 LIBCPLUSPLUS = "-stdlib=libc++"
 
-SRCREV = "fcad7687d196e2ba64810e08374ec780c6e2bfb8"
+SRCREV = "dd22e78e99ed708fdb39f01f7c067ae5cbe34e9a"
 SRC_URI = "gitsm://github.com/meta-flutter/rive-common.git;protocol=https;lfs=0;nobranch=1"
 
 S = "${WORKDIR}/git"

--- a/meta-flutter-apps/conf/layer.conf
+++ b/meta-flutter-apps/conf/layer.conf
@@ -34,4 +34,4 @@ BBFILES_DYNAMIC += " \
 
 BBFILE_COLLECTIONS += "meta-flutter-apps"
 BBFILE_PATTERN_meta-flutter-apps = "${BBFILE_PATTERN_flutter-apps-layer}"
-LAYERSERIES_COMPAT_meta-flutter-apps = "nanbield scarthgap"
+LAYERSERIES_COMPAT_meta-flutter-apps = "zeus dunfell honister hardknott gatesgarth kirkstone"


### PR DESCRIPTION
-enables 32-bit builds
-addresses: https://github.com/meta-flutter/meta-flutter/issues/465
-For 32-bit configure in your conf/local.conf using:
 `EXTRA_OECMAKE:pn-rive-text = "-DENABLE_LTO=FALSE"`