### PR TITLE
Add failed commands' output to bitbake logs

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -59,6 +59,8 @@ def run_command(d, cmd, cwd, env):
     bb.note('Running [%s] in %s' % (cmd, cwd))
     (retval, output) = getstatusoutput(cmd, cwd, env)
     if retval:
+        formatted_output = '\n  ' + output.replace('\n','\n  ')
+        bb.note(f'Output:{formatted_output}')
         bb.fatal(f'{cmd} failed: {retval}')
 
 #


### PR DESCRIPTION
This amends [1e7f0c6](https://github.com/meta-flutter/meta-flutter/commit/1e7f0c6e55922d409ca5e407f58480fd658e337f). Here the failed command's output was removed from the error message, so the output was not visible anymore, neither in the bitbake output nor in the logs.
After this change:
* We have a short error message that describes what failed in bitbake's output and in the logs (unchanged)
* We have the failed commands' output in the logs only. This makes sense because they can be very long.