### PR TITLE
Address proxy and host contamination issues

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -106,6 +106,24 @@ python do_archive_pub_cache() {
     # required for flutter: https://github.com/flutter/flutter/issues/59430
     env['XDG_CONFIG_HOME'] = f'{workdir}'
 
+    http_proxy = d.getVar('http_proxy')
+    if http_proxy != None:
+        env['http_proxy']     = f'{http_proxy}'
+
+    https_proxy = d.getVar('https_proxy')
+    if https_proxy != None:
+        env['https_proxy']    = f'{https_proxy}'
+
+    http_proxy_ = d.getVar('HTTP_PROXY')
+    if http_proxy_ != None:
+        env['HTTP_PROXY']     = f'{http_proxy_}'
+
+    https_proxy_ = d.getVar('HTTPS_PROXY')
+    if https_proxy_ != None:
+        env['HTTPS_PROXY']    = f'{https_proxy_}'
+
+    env['NO_PROXY']       = 'localhost,127.0.0.1,::1'
+
     flutter_sdk = os.path.join(d.getVar("STAGING_DATADIR_NATIVE"), 'flutter/sdk')
     env['PATH'] = f'{env["PATH"]}:{flutter_sdk}/bin'
 

--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -101,7 +101,10 @@ python do_archive_pub_cache() {
     shutil.copytree(flutter_sdk_pub_cache, pub_cache)
 
     workdir = d.getVar("WORKDIR")
-    env['XDG_CONFIG_HOME'] = workdir
+    # required for dart: https://github.com/dart-lang/sdk/issues/41560
+    env['HOME'] = f'{workdir}'
+    # required for flutter: https://github.com/flutter/flutter/issues/59430
+    env['XDG_CONFIG_HOME'] = f'{workdir}'
 
     flutter_sdk = os.path.join(d.getVar("STAGING_DATADIR_NATIVE"), 'flutter/sdk')
     env['PATH'] = f'{env["PATH"]}:{flutter_sdk}/bin'
@@ -250,6 +253,10 @@ python do_compile() {
 
     staging_dir_target = d.getVar('STAGING_DIR_TARGET')
     env['PKG_CONFIG_PATH'] = f'{staging_dir_target}/usr/lib/pkgconfig:{staging_dir_target}/usr/share/pkgconfig:{d.getVar("PKG_CONFIG_PATH")}'
+
+    workdir = d.getVar("WORKDIR")
+    # required for flutter: https://github.com/flutter/flutter/issues/59430
+    env['XDG_CONFIG_HOME'] = f'{workdir}'
 
     bb.note(f'{env}')
 

--- a/lib/gn.py
+++ b/lib/gn.py
@@ -71,10 +71,12 @@ class GN(FetchMethod):
 
         depot_tools_path = d.getVar("DEPOT_TOOLS")
         python3_folder = os.path.join(depot_tools_path, d.getVar("PYTHON3_PATH"))
+        vpython_virtualenv_root = d.getVar("VPYTHON_VIRTUALENV_ROOT")
 
         ud.basecmd = f'export DEPOT_TOOLS_UPDATE=0; \
             export CURL_CA_BUNDLE={curl_ca_bundle}; \
             export PATH="{depot_tools_path}:{python3_folder}:$PATH"; \
+            export VPYTHON_VIRTUALENV_ROOT="{vpython_virtualenv_root}"; \
             gclient config --spec \'{gclient_config}\' && \
             gclient sync --force {sync_opt} --revision {srcrev} {parallel_make} -v'
 

--- a/recipes-devtools/depot-tools/depot-tools-native_git.bb
+++ b/recipes-devtools/depot-tools/depot-tools-native_git.bb
@@ -21,6 +21,7 @@ do_configure() {
     cd ${S}
     export DEPOT_TOOLS_UPDATE=0
     export PATH=${S}:$PATH
+    export VPYTHON_VIRTUALENV_ROOT=${VPYTHON_VIRTUALENV_ROOT}
 
     gclient --version
 }

--- a/recipes-devtools/depot-tools/depot-tools-native_git.bb
+++ b/recipes-devtools/depot-tools/depot-tools-native_git.bb
@@ -22,6 +22,7 @@ do_configure() {
     export DEPOT_TOOLS_UPDATE=0
     export PATH=${S}:$PATH
     export VPYTHON_VIRTUALENV_ROOT=${VPYTHON_VIRTUALENV_ROOT}
+    export CIPD_CACHE_DIR="${WORKDIR}/cipd"
 
     gclient --version
 }

--- a/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
+++ b/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
@@ -102,6 +102,12 @@ python do_unpack:append() {
     env['PATH']           = f'{source_dir}/bin:{path}'
     env['PUB_CACHE']      = f'{source_dir}/.pub-cache'
 
+    workdir = d.getVar('WORKDIR')
+    # required for dart: https://github.com/dart-lang/sdk/issues/41560
+    env['HOME'] = f'{workdir}'
+    # required for flutter: https://github.com/flutter/flutter/issues/59430
+    env['XDG_CONFIG_HOME'] = f'{workdir}'
+
     http_proxy = d.getVar('http_proxy')
     if http_proxy != None:
         env['http_proxy']     = f'{http_proxy}'


### PR DESCRIPTION
Fix another set of host contamination issues and proxy problems.

I think having a common python method to export all of these variables, or a bash shim to inject these variables for any native invocation of flutter or dart may also be useful. I'm not really sure what would be the better solution but having these variables all over the place is not great.

Because dart doesn't even follow the basic XDG standards we have to do something a little drastic to make sure it doesn't affect the host machine. We have to override HOME temporarily so that it can lookup it's config. I really don't like this as:

1. It just looks gross
2. It has the potential to interfere with other commands being executed in that same environment.

Open to suggestions there.