### PR TITLE
Update Pubspec Lockfile Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,8 @@ Yocto Layer for Google Flutter related projects.
 | `FLUTTER_APP_RUNTIME_MODES`          | Allows overriding modes that install app. Default is `release`.                                                                     |
 | `FLUTTER_APPLICATION_INSTALL_PREFIX` | Install prefix for flutter application install. Overriding enables installing into user directory. Default is `${datadir}/flutter`. |
 | `FLUTTER_APPLICATION_INSTALL_SUFFIX` | Install suffix for flutter application install. Default is "${PUBSPEC_APPNAME}".                                                    |
+| `PUBSPEC_IGNORE_LOCKFILE`            | Delete the `pubspec.lock` file during the build process                                                                             |
+| `PUBSPEC_ENFORCE_LOCKFILE`           | Run `flutter pub get` with the `--enforce-lockfile` flag, preventing dependencies from being upgraded during build`                 |
 
 ### Supported Engine Variants
 

--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -28,6 +28,9 @@ FLUTTER_INSTALL_DIR = "${FLUTTER_APPLICATION_INSTALL_PREFIX}/${FLUTTER_APPLICATI
 PUB_CACHE = "${WORKDIR}/pub_cache"
 PUB_CACHE_ARCHIVE = "flutter-pub-cache-${PN}-${SRCPV}-${FLUTTER_SDK_TAG}.tar.bz2"
 
+PUBSPEC_IGNORE_LOCKFILE ??= "0"
+PUBSPEC_ENFORCE_LOCKFILE ??= "0"
+
 FLUTTER_SDK = "${STAGING_DIR_NATIVE}/usr/share/flutter/sdk"
 
 require conf/include/clang-utils.inc
@@ -108,13 +111,13 @@ python do_archive_pub_cache() {
 
     app_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_APPLICATION_PATH"))
 
-
-    #
-    # Remove pubspec.lock file if present
-    #
-    pubspec_lock = os.path.join(app_root, 'pubspec.lock')
-    if os.path.exists(pubspec_lock):
-        run_command(d, 'rm -rf pubspec.lock', app_root, env)
+    if d.getVar("PUBSPEC_IGNORE_LOCKFILE") == "1":
+        #
+        # Remove pubspec.lock file if present
+        #
+        pubspec_lock = os.path.join(app_root, 'pubspec.lock')
+        if os.path.exists(pubspec_lock):
+            run_command(d, 'rm -rf pubspec.lock', app_root, env)
 
     #
     # App hook to include something in archive 
@@ -139,8 +142,12 @@ python do_archive_pub_cache() {
     run_command(d, 'flutter config --no-analytics', app_root, env)
     run_command(d, 'flutter config --no-cli-animations', app_root, env)
     run_command(d, 'flutter clean', app_root, env)
-    run_command(d, 'flutter pub get', app_root, env)
-    run_command(d, 'flutter pub get --offline', app_root, env)
+    if d.getVar("PUBSPEC_ENFORCE_LOCKFILE") == "1":
+        run_command(d, 'flutter pub get --enforce-lockfile', app_root, env)
+        run_command(d, 'flutter pub get --offline --enforce-lockfile', app_root, env)
+    else:
+        run_command(d, 'flutter pub get', app_root, env)
+        run_command(d, 'flutter pub get --offline', app_root, env)
 
     cp_cmd = \
         'mkdir -p %s/.project | true; ' \
@@ -242,6 +249,9 @@ python do_compile() {
     if pubspec_appname != pubspec_yaml_appname:
         bb.fatal("Set PUBSPEC_APPNAME to match name value in pubspec.yaml")
 
+    if d.getVar("PUBSPEC_IGNORE_LOCKFILE") == "1" and d.getVar("PUBSPEC_ENFORCE_LOCKFILE") == "1":
+        bb.fatal("Both PUBSPEC_IGNORE_LOCKFILE and PUBSPEC_ENFORCE_LOCKFILE are set which is invalid")
+
     flutter_sdk = d.getVar('FLUTTER_SDK')
 
     env = os.environ
@@ -276,12 +286,13 @@ def build_web(d, source_root, env):
     if os.path.exists(build_folder):
         run_command(d, 'flutter clean', source_root, env)
 
-    #
-    # Remove pubspec.lock file if present
-    #
-    pubspec_lock = os.path.join(source_root, 'pubspec.lock')
-    if os.path.exists(pubspec_lock):
-        run_command(d, 'rm -rf pubspec.lock', source_root, env)
+    if d.getVar("PUBSPEC_IGNORE_LOCKFILE") == "1":
+        #
+        # Remove pubspec.lock file if present
+        #
+        pubspec_lock = os.path.join(app_root, 'pubspec.lock')
+        if os.path.exists(pubspec_lock):
+            run_command(d, 'rm -rf pubspec.lock', app_root, env)
 
     flutter_build_args = d.getVar('FLUTTER_BUILD_ARGS')
     run_command(d, f'flutter build web {flutter_build_args}', source_root, env)
@@ -312,15 +323,19 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
         if os.path.exists(build_folder):
             run_command(d, 'flutter clean -v', source_root, env)
 
-        #
-        # Remove pubspec.lock file if present
-        #
-        pubspec_lock = os.path.join(source_root, 'pubspec.lock')
-        if os.path.exists(pubspec_lock):
-            run_command(d, 'rm -rf pubspec.lock', source_root, env)
+        if d.getVar("PUBSPEC_IGNORE_LOCKFILE") == "1":
+            #
+            # Remove pubspec.lock file if present
+            #
+            pubspec_lock = os.path.join(app_root, 'pubspec.lock')
+            if os.path.exists(pubspec_lock):
+                run_command(d, 'rm -rf pubspec.lock', app_root, env)
 
         run_command(d, 'flutter config --no-cli-animations', source_root, env)
-        run_command(d, 'flutter pub get --offline -v', source_root, env)
+        if d.getVar("PUBSPEC_ENFORCE_LOCKFILE") == "1":
+            run_command(d, 'flutter pub get --offline --enforce-lockfile -v', source_root, env)
+        else:
+            run_command(d, 'flutter pub get --offline -v', source_root, env)
         
         if runtime_mode == 'jit_release':
             cmd = (f'flutter build {flutter_build_args} --local-engine -v')


### PR DESCRIPTION
Fix for the issue identified in #484. Adds options that allow each recipe to select whether to ignore the pubspec lockfile, or to fully enforce the dependencies in it. This provides flexibility for each recipe to handle the lockfile in a manner that works best for that specific app.

This adds two variables that can be set in recipes:

* `PUBSPEC_IGNORE_LOCKFILE` causes the `pubspec.lock` file to be deleted as part of the build process.
* `PUBSPEC_ENFORCE_LOCKFILE` causes `flutter pub get` to be run with the `--enforce-lockfile` flag, requiring the exact versions of dependencies in the lockfile to be used.

Both default to `"0"` so the default behaviour will be the same as a normal run of `flutter pub get`, using the lockfile as normal if it's present.