### PR TITLE
flutter-engine: add FLUTTER_ENGINE_STRIP

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -149,6 +149,8 @@ FLUTTER_ENGINE_DEBUG_PREFIX_MAP ?= " \
 "
 FLUTTER_ENGINE_DEBUG_FLAGS ?= "-g -feliminate-unused-debug-types ${FLUTTER_ENGINE_DEBUG_PREFIX_MAP}"
 
+FLUTTER_ENGINE_STRIP ??= "release"
+
 do_configure() {
     
     # prevent tmp path warning
@@ -200,6 +202,12 @@ do_install() {
 
         install -D -m 0644 ${S}/${BUILD_DIR}/so.unstripped/libflutter_engine.so \
             ${D}${FLUTTER_ENGINE_INSTALL_PREFIX}/${MODE}/lib/libflutter_engine.so
+
+        case "$FLUTTER_ENGINE_STRIP" in
+        *$MODE*)
+            ${STRIP} ${D}${FLUTTER_ENGINE_INSTALL_PREFIX}/$MODE/lib/libflutter_engine.so
+            ;;
+        esac
 
         if ${@bb.utils.contains('PACKAGECONFIG', 'desktop-embeddings', 'true', 'false', d)}; then
             install -D -m 0644 ${S}/${BUILD_DIR}/so.unstripped/libflutter_linux_gtk.so \


### PR DESCRIPTION
which strips the engine lib in a configurable way. By default only release profile is stripped.

It will save ~250MB of disk space when used on the target