### PR TITLE
retain partial sync on fetch error

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,9 +104,12 @@ Note: when using SDK you may need to add the following after installation:
 
 ## General Yocto Notes
 
-When building on systems with GCC version > than uninative in Yocto distro add the following to conf/local.conf
+* When building on systems with GCC version > than uninative in Yocto distro add the following to conf/local.conf
 
     INHERIT:remove = "uninative"
+
+
+* The initial fetch with Flutter build will download over 14GB of source code. Running `bitbake -C cleanall flutter-engine` will clear the download cache. However, if an error occurs, the download cache remains intact, allowing you to resume the fetch later.
 
 ## Flutter Workspace Automation
 

--- a/lib/gn.py
+++ b/lib/gn.py
@@ -89,11 +89,13 @@ class GN(FetchMethod):
         bb.utils.mkdirhier(ud.syncpath)
         os.chdir(ud.syncpath)
 
+        ud.trying_to_fetch_with_gclient = True
         logger.debug2(f'Fetching {ud.url} using command "{ud.basecmd}"')
         bb.fetch2.check_network_access(d, ud.basecmd, ud.url)
         runfetchcmd(ud.basecmd, d, quiet, workdir=None)
         logger.debug2(f'Packing {ud.url} using command "{ud.packcmd}"')
         runfetchcmd(ud.packcmd, d, quiet, workdir=None)
+        ud.trying_to_fetch_with_gclient = False
 
     def localpath(self, ud, d):
         """
@@ -113,7 +115,6 @@ class GN(FetchMethod):
 
         uri = ud.url.split(";")[0]
 
-        ud.trying_to_fetch_with_gclient = True
         self._rungnclient(ud, d, False)
 
         # Sanity check since wget can pretend it succeed when it didn't


### PR DESCRIPTION
If an error occurs during the gclient sync, we aim to retain the partial sync directory.
This helps prevent the need to re-fetch a large amount of source code only to encounter the same network issue again.
The sync directory can grow up to 14GB.
However, it will still be deleted when running bitbake -c cleanall.


To test the change, you can start a clean build of the `flutter-engine`. And before the do_fetch has finished, disconnect the network.(via control panel or any other means).
The do_fetch would fail, however the partial download would be retained in  `${DL_DIR}/gn`, so restarting the build with the network should continue fetching dependencies.