### PR TITLE
common: Do not copy parent directories in archive_pub

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -237,7 +237,7 @@ python do_archive_pub_cache() {
     run_command(d, 'flutter pub get --enforce-lockfile', app_root, env)
     run_command(d, 'flutter pub get --enforce-lockfile --offline', app_root, env)
 
-    cp_cmd = f'mkdir -p {pub_cache}/.project | true; cp -r .* {pub_cache}/.project/ | true;'
+    cp_cmd = f'mkdir -p {pub_cache}/.project | true; cp -rT . {pub_cache}/.project/ | true;'
     run_command(d, cp_cmd, app_root, env)
 
     bb_number_threads = d.getVar("BB_NUMBER_THREADS", multiprocessing.cpu_count()).strip()


### PR DESCRIPTION
Using `cp -r .*` will also include the parent directory `..`, which causes more files to be copied than needed.
Use -T option instead to just copy the current directory as a whole.