### PR TITLE
Building flutter-pi depends on libsystemd

### DIFF
--- a/recipes-graphics/flutter-pi/flutter-pi_git.bb
+++ b/recipes-graphics/flutter-pi/flutter-pi_git.bb
@@ -21,6 +21,7 @@ DEPENDS += "\
     libinput \
     libxkbcommon \
     virtual/egl \
+    systemd \
    "
 
 RDEPENDS:${PN} += "\
@@ -33,7 +34,7 @@ RRECOMMENDS:${PN} += "\
     liberation-fonts \
     "
 
-REQUIRED_DISTRO_FEATURES = "opengl"
+REQUIRED_DISTRO_FEATURES = "opengl systemd"
 
 SRC_REPO ??= "github.com/ardera/flutter-pi.git"
 SRC_REPO_BRANCH ??= "master"


### PR DESCRIPTION
Building flutter-pi recipe will fail if systemd is not declared in `DEPENDS` and it is built before systemd. This commit addresses the issue by ensuring systemd is built before flutter-pi.