### PR TITLE
flutter-auto: check for systemd DISTRO_FEATURES

### DIFF
--- a/recipes-graphics/toyota/flutter-auto_2.0.bb
+++ b/recipes-graphics/toyota/flutter-auto_2.0.bb
@@ -49,7 +49,7 @@ PACKAGECONFIG ??= "\
     client-xdg \
     client-agl-shell \
     \
-    wdt_systemd \
+    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'wdt_systemd', '', d)} \
     \
     nav_render_view \
     \


### PR DESCRIPTION
as default packageconfig wdt_systemd pulls in systemd, as a dependency, but that requires systemd in
DISTRO_FEATURES.
Add a check to fix that