### PR TITLE
ivi-homescreen: check commercial flag

### DIFF
--- a/recipes-graphics/toyota/ivi-homescreen_2.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_2.0.bb
@@ -54,7 +54,7 @@ PACKAGECONFIG ??= "\
     go_router \
     secure-storage \
     url_launcher \
-    video_player_linux \
+    ${@bb.utils.contains('LICENSE_FLAGS_ACCEPTED', 'commercial', 'video_player_linux', '', d)} \
     desktop_window_linux \
     "
 


### PR DESCRIPTION
for video_player_linux ffmpeg is required,
which requires LICENSE_FLAGS_ACCEPTED
commercial to be set