### PR TITLE
roll ivi-homescreen/flutter-auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+Dec 17, 2024
+1. roll ivi-homescreen + plugins
+2. roll flutter-auto + plugins
+
 Nov 4, 2024
 1. libwebrtc
 2. roll depot_tools

--- a/recipes-graphics/toyota/flutter-auto_2.0.bb
+++ b/recipes-graphics/toyota/flutter-auto_2.0.bb
@@ -22,8 +22,8 @@ DEPENDS += "\
 
 REQUIRED_DISTRO_FEATURES = "wayland"
 
-HOMESCREEN_COMMIT ??= "d68b3ea867c81bc2b8295589ed3f6284c71b8f24"
-PLUGINS_COMMIT ??= "78836a2fe640a02ce462f2da7c853dad9effa405"
+HOMESCREEN_COMMIT ??= "bd892a66639ebadbf10a8027e07967edb3c467fd"
+PLUGINS_COMMIT ??= "bbcf71a9e90e55ca4b63229b9be4e6ba995eb241"
 
 SRC_URI = "\
     gitsm://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=v2.0;name=homescreen \
@@ -141,6 +141,7 @@ PACKAGECONFIG[examples] = "-DBUILD_EXAMPLES=ON, -DBUILD_EXAMPLES=OFF"
 PACKAGECONFIG[verbose] = "-DCMAKE_BUILD_TYPE=Debug -DDEBUG_PLATFORM_MESSAGES=ON, -DDEBUG_PLATFORM_MESSAGES=OFF"
 
 EXTRA_OECMAKE += "\
+    -D PLUGINS_DIR=${S}/ivi-homescreen-plugins/plugins/plugins \
     -D EXE_OUTPUT_NAME=${PN} \
     -D ENABLE_LTO=ON \
     -D BUILD_UNIT_TESTS=OFF \

--- a/recipes-graphics/toyota/ivi-homescreen_2.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_2.0.bb
@@ -22,8 +22,8 @@ DEPENDS += "\
 
 REQUIRED_DISTRO_FEATURES = "wayland"
 
-HOMESCREEN_COMMIT ??= "d68b3ea867c81bc2b8295589ed3f6284c71b8f24"
-PLUGINS_COMMIT ??= "78836a2fe640a02ce462f2da7c853dad9effa405"
+HOMESCREEN_COMMIT ??= "bd892a66639ebadbf10a8027e07967edb3c467fd"
+PLUGINS_COMMIT ??= "bbcf71a9e90e55ca4b63229b9be4e6ba995eb241"
 
 SRC_URI = "\
     gitsm://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=v2.0;name=homescreen \
@@ -138,6 +138,7 @@ PACKAGECONFIG[examples] = "-DBUILD_EXAMPLES=ON, -DBUILD_EXAMPLES=OFF"
 PACKAGECONFIG[verbose] = "-DCMAKE_BUILD_TYPE=Debug -DDEBUG_PLATFORM_MESSAGES=ON, -DDEBUG_PLATFORM_MESSAGES=OFF"
 
 EXTRA_OECMAKE += "\
+    -D PLUGINS_DIR=${S}/ivi-homescreen-plugins/plugins/plugins \
     -D EXE_OUTPUT_NAME=homescreen \
     -D ENABLE_LTO=ON \
     -D BUILD_UNIT_TESTS=OFF \


### PR DESCRIPTION
KeyboardHook segfault fix
-only repros on a Clang Release build.
 Clang Debug, GCC Debug/Release do not repro
-instead of accessing struct member in completion handler, pass variable by value
-optimize Flutter messenger code to prevent extra copies

Wayland Event Thread
-add thread to enable wayland blocking call
-disables polling of wayland events

Configuration update
-fix sefault if not passing a bundle path
-update README

refactor plugins
-remove NODISCARD and MAYBE_UNUSED macros
-move plugin specific code to external plugins repo -clean up test cases
-roll waypp