### PR TITLE
[dunfell] Roll ivi-homescreen/flutter-auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+Feb 10, 2025
+1. roll ivi-homescreen/flutter-auto
+
 Jan 17, 2025
 1. roll ivi-homescreen/flutter-auto
 

--- a/recipes-graphics/toyota/flutter-auto_2.0.bb
+++ b/recipes-graphics/toyota/flutter-auto_2.0.bb
@@ -22,8 +22,8 @@ DEPENDS += "\
 
 REQUIRED_DISTRO_FEATURES = "wayland"
 
-HOMESCREEN_COMMIT ??= "2341312e5118a9b96a3f0e7c13a2813b4a7e779c"
-PLUGINS_COMMIT ??= "f2a7336c34ed4720742a42245b84de56729d56e3"
+HOMESCREEN_COMMIT ??= "76962625feab002fe1630736bc7ba5225a642940"
+PLUGINS_COMMIT ??= "bb262cb39413e5083c1ecec6397f24e8e5ec1648"
 
 SRC_URI = "\
     gitsm://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=v2.0;name=homescreen \
@@ -141,7 +141,7 @@ PACKAGECONFIG[examples] = "-DBUILD_EXAMPLES=ON, -DBUILD_EXAMPLES=OFF"
 PACKAGECONFIG[verbose] = "-DCMAKE_BUILD_TYPE=Debug -DDEBUG_PLATFORM_MESSAGES=ON, -DDEBUG_PLATFORM_MESSAGES=OFF"
 
 EXTRA_OECMAKE += "\
-    -D PLUGINS_DIR=${S}/ivi-homescreen-plugins/plugins/plugins \
+    -D PLUGINS_DIR=${S}/ivi-homescreen-plugins/plugins \
     -D EXE_OUTPUT_NAME=${PN} \
     -D ENABLE_LTO=ON \
     -D BUILD_UNIT_TESTS=OFF \

--- a/recipes-graphics/toyota/ivi-homescreen_2.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_2.0.bb
@@ -22,8 +22,8 @@ DEPENDS += "\
 
 REQUIRED_DISTRO_FEATURES = "wayland"
 
-HOMESCREEN_COMMIT ??= "2341312e5118a9b96a3f0e7c13a2813b4a7e779c"
-PLUGINS_COMMIT ??= "f2a7336c34ed4720742a42245b84de56729d56e3"
+HOMESCREEN_COMMIT ??= "76962625feab002fe1630736bc7ba5225a642940"
+PLUGINS_COMMIT ??= "bb262cb39413e5083c1ecec6397f24e8e5ec1648"
 
 SRC_URI = "\
     gitsm://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=v2.0;name=homescreen \
@@ -138,7 +138,7 @@ PACKAGECONFIG[examples] = "-DBUILD_EXAMPLES=ON, -DBUILD_EXAMPLES=OFF"
 PACKAGECONFIG[verbose] = "-DCMAKE_BUILD_TYPE=Debug -DDEBUG_PLATFORM_MESSAGES=ON, -DDEBUG_PLATFORM_MESSAGES=OFF"
 
 EXTRA_OECMAKE += "\
-    -D PLUGINS_DIR=${S}/ivi-homescreen-plugins/plugins/plugins \
+    -D PLUGINS_DIR=${S}/ivi-homescreen-plugins/plugins \
     -D EXE_OUTPUT_NAME=homescreen \
     -D ENABLE_LTO=ON \
     -D BUILD_UNIT_TESTS=OFF \


### PR DESCRIPTION
ivi-homescreen
* [fix] platform_view touch bad variant
* Move thread detection into compiler
* Roll waypp
* compiler logic
* Vulkan Header compatibility
* clang link with libc++
* LLVM_CONFIG cmake variable
* add_compile_options for clang
* string conversion deprecation fix
* Add wm_capabilities to xdg_toplevel_listener
* Add conditional configure_bounds
* roll waypp
* Remove -Werror
* compiler fix
* compiler fixes
* roll waypp

ivi-homescreen-plugins
* Adjustments -return if lib is null
-add warning for on_dispose
* Add toolchain::toolchain target to common targets (#93)
* Add Wayland/EGL compile defs, addresses build error
* runtime load pdfium/rive_text library -remove link time requirement
-only load plugin is shared library is present
* Make pdf linking absolute
* Unused parameter fix
* Init pointer tidy
* Removing previous unique_ptrs and cleaning up raw pointer on scene deserialization.
* codeql fixes
* Werror fixes
* Create codeql.yml
* changes for -Werror
* Compiler flag fixes