### PR TITLE
ivi-homescreen/flutter-auto

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+March 14, 2025
+1. roll ivi-homescreen/flutter-auto
+   -Remove FPS overlay
+    Resolves long standing NXP weston protocol errror
+    Better to use weston debug feature that prints FPS of all surfaces
+   -Cursor Disable - using nullptr instead of surface
+
 Feb 10, 2025
 1. roll ivi-homescreen/flutter-auto
 2. roll Flutter SDK - 3.27.4

--- a/recipes-graphics/toyota/flutter-auto_2.0.bb
+++ b/recipes-graphics/toyota/flutter-auto_2.0.bb
@@ -25,8 +25,8 @@ DEPENDS += "\
 
 REQUIRED_DISTRO_FEATURES = "wayland"
 
-HOMESCREEN_COMMIT ??= "76962625feab002fe1630736bc7ba5225a642940"
-PLUGINS_COMMIT ??= "821431140d3beeb1ae799e8687f5b0c21210ba0e"
+HOMESCREEN_COMMIT ??= "10a9cdf27d862173c3ff5f85cf67663421f905ec"
+PLUGINS_COMMIT ??= "77018f5d9bfca3283115ec8f0655bfa43a2cd991"
 
 SRC_URI = "\
     gitsm://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=v2.0;name=homescreen \

--- a/recipes-graphics/toyota/ivi-homescreen_2.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_2.0.bb
@@ -25,8 +25,8 @@ DEPENDS += "\
 
 REQUIRED_DISTRO_FEATURES = "wayland"
 
-HOMESCREEN_COMMIT ??= "76962625feab002fe1630736bc7ba5225a642940"
-PLUGINS_COMMIT ??= "821431140d3beeb1ae799e8687f5b0c21210ba0e"
+HOMESCREEN_COMMIT ??= "10a9cdf27d862173c3ff5f85cf67663421f905ec"
+PLUGINS_COMMIT ??= "77018f5d9bfca3283115ec8f0655bfa43a2cd991"
 
 SRC_URI = "\
     gitsm://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=v2.0;name=homescreen \


### PR DESCRIPTION
-Remove FPS overlay
 Resolves long standing NXP weston protocol errror
 Better to use new weston debug feature that prints FPS of *all* surfaces
-Cursor Disable - using nullptr instead of surface