### PR TITLE
flutter-engine: add whitespace around assignments

### DIFF
--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -134,9 +134,9 @@ GN_TUNE_ARGS:append:armv7 = "arm_tune = \"${@gn_get_tune_features(d)}\""
 GN_TUNE_ARGS:append:armv7a = "arm_tune = \"${@gn_get_tune_features(d)}\""
 GN_TUNE_ARGS:append:armv7ve = "arm_tune = \"${@gn_get_tune_features(d)}\""
 
-TMP_OUT_DIR="${@get_gn_tmp_out_dir(d)}"
+TMP_OUT_DIR = "${@get_gn_tmp_out_dir(d)}"
 
-GN_ARGS_LESS_RUNTIME_MODES="${@get_gn_args_less_runtime(d)}"
+GN_ARGS_LESS_RUNTIME_MODES = "${@get_gn_args_less_runtime(d)}"
 
 FLUTTER_ENGINE_INSTALL_PREFIX ??= "${datadir}/flutter/${FLUTTER_SDK_VERSION}"
 
@@ -153,8 +153,8 @@ FLUTTER_ENGINE_DEBUG_FLAGS ?= "-g -feliminate-unused-debug-types ${FLUTTER_ENGIN
 FLUTTER_ENGINE_CXX_LIBC_FLAGS ?= ""
 FLUTTER_ENGINE_CXX_LIBC_FLAGS:append:libc-musl = "-D_LIBCPP_HAS_MUSL_LIBC"
 
-WAYLAND_IS_PRESENT="${@bb.utils.filter('DISTRO_FEATURES', 'wayland', d)}"
-X11_IS_PRESENT="${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)}"
+WAYLAND_IS_PRESENT = "${@bb.utils.filter('DISTRO_FEATURES', 'wayland', d)}"
+X11_IS_PRESENT = "${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)}"
 VULKAN_HEADER_GNI = "${S}/flutter/build_overrides/vulkan_headers.gni"
 
 


### PR DESCRIPTION
With:
https://lists.openembedded.org/g/bitbake-devel/message/17508 there are WARNINGs like:

```
WARNING: meta-flutter/recipes-graphics/flutter-engine/flutter-engine_git.bb:137 has a lack of whitespace around the assignment: 'TMP_OUT_DIR="${@get_gn_tmp_out_dir(d)}"'
WARNING: meta-flutter/recipes-graphics/flutter-engine/flutter-engine_git.bb:139 has a lack of whitespace around the assignment: 'GN_ARGS_LESS_RUNTIME_MODES="${@get_gn_args_less_runtime(d)}"'
WARNING: meta-flutter/recipes-graphics/flutter-engine/flutter-engine_git.bb:156 has a lack of whitespace around the assignment: 'WAYLAND_IS_PRESENT="${@bb.utils.filter('DISTRO_FEATURES', 'wayland', d)}"'
WARNING: meta-flutter/recipes-graphics/flutter-engine/flutter-engine_git.bb:157 has a lack of whitespace around the assignment: 'X11_IS_PRESENT="${@bb.utils.filter('DISTRO_FEATURES', 'x11', d)}"'
```