### PR TITLE
Always write verbose commands' output from flutter commands to bitbake logs

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -61,9 +61,11 @@ def run_command(d, cmd, cwd, env):
 
     bb.note(f'Running [{cmd}] in {cwd}')
     (retval, output) = getstatusoutput(cmd, cwd, env)
+
+    formatted_output = '\n  ' + output.replace('\n','\n  ')
+    bb.note(f'Output:{formatted_output}')
+
     if retval:
-        formatted_output = '\n  ' + output.replace('\n','\n  ')
-        bb.note(f'Output:{formatted_output}')
         bb.fatal(f'{cmd} failed: {retval}')
 
 def md5_update_from_dir(directory, hash):


### PR DESCRIPTION
All flutter builds are currently run with verbose logging, but the logs don't end up in bitbake logs.

Writing these to the logs doesn't have notable performance issues for me. But I need this in the logs to debug e.g. cases where builds take very long but do finally succeed. My (non-public) app has such an issue when I try to build it offline. Since offline builds are currently the default, users should have the possibility to troubleshoot such issues via logs.