### PR TITLE
pdfium: bump pdfium to 139.0.7228.0

### DIFF
--- a/recipes-graphics/pdfium/files/sysroot-fix-path.patch
+++ b/recipes-graphics/pdfium/files/sysroot-fix-path.patch
@@ -1,0 +1,16 @@
+Upstream-Status: Inappropriate
+diff --git a/build/config/linux/pkg_config.gni b/build/config/linux/pkg_config.gni
+index f8a4bbe72..6d73623c3 100644
+--- a/build/config/linux/pkg_config.gni
++++ b/build/config/linux/pkg_config.gni
+@@ -60,9 +60,7 @@ common_pkg_config_args = []
+ 
+ # Chrome OS uses custom pkg_config wrappers that require absolute paths as inputs.
+ # See https://chromium-review.googlesource.com/c/chromium/src/+/6506002
+-_pkg_config_requires_abs_path =
+-    pkg_config != "" ||
+-    (current_toolchain == host_toolchain && host_pkg_config != "")
++_pkg_config_requires_abs_path = true
+ 
+ # Chrome-adjacent repos might be using different sysroot versions (e.g. ANGLE).
+ _enable_cache =

--- a/recipes-graphics/pdfium/files/v8_init.patch
+++ b/recipes-graphics/pdfium/files/v8_init.patch
@@ -1,9 +1,9 @@
 Upstream-Status: Inappropriate
 diff --git a/fpdfsdk/fpdf_view.cpp b/fpdfsdk/fpdf_view.cpp
-index 6b0a1c161..7a8788676 100644
+index 58a42e289..5c97b7e4e 100644
 --- a/fpdfsdk/fpdf_view.cpp
 +++ b/fpdfsdk/fpdf_view.cpp
-@@ -57,6 +57,9 @@
+@@ -58,6 +58,9 @@
  
  #ifdef PDF_ENABLE_V8
  #include "fxjs/cfx_v8_array_buffer_allocator.h"
@@ -13,7 +13,7 @@ index 6b0a1c161..7a8788676 100644
  #endif
  
  #ifdef PDF_ENABLE_XFA
-@@ -117,6 +120,11 @@ namespace {
+@@ -118,6 +121,11 @@ namespace {
  
  bool g_bLibraryInitialized = false;
  
@@ -25,9 +25,9 @@ index 6b0a1c161..7a8788676 100644
  void SetRendererType(FPDF_RENDERER_TYPE public_type) {
    // Internal definition of renderer types must stay updated with respect to
    // the public definition, such that all public definitions can be mapped to
-@@ -229,6 +237,22 @@ FPDF_InitLibraryWithConfig(const FPDF_LIBRARY_CONFIG* config) {
-   if (g_bLibraryInitialized)
+@@ -237,6 +245,22 @@ FPDF_InitLibraryWithConfig(const FPDF_LIBRARY_CONFIG* config) {
      return;
+   }
  
 +#ifdef PDF_ENABLE_V8
 +  g_platform = v8::platform::NewDefaultPlatform().release();
@@ -48,7 +48,7 @@ index 6b0a1c161..7a8788676 100644
    FX_InitializeMemoryAllocators();
    CFX_Timer::InitializeGlobals();
    CFX_GEModule::Create(config ? config->m_pUserFontPaths : nullptr);
-@@ -242,14 +266,13 @@ FPDF_InitLibraryWithConfig(const FPDF_LIBRARY_CONFIG* config) {
+@@ -250,14 +274,12 @@ FPDF_InitLibraryWithConfig(const FPDF_LIBRARY_CONFIG* config) {
    CPDFXFA_ModuleInit();
  #endif  // PDF_ENABLE_XFA
  
@@ -59,17 +59,16 @@ index 6b0a1c161..7a8788676 100644
 +#if PDF_ENABLE_V8
 +  IJS_Runtime::Initialize(0, g_isolate, g_platform);
 +#endif  // PDF_ENABLE_V8
-+
-+  if (config && config->version >= 4)
-+    SetRendererType(config->m_RendererType);
  
--    if (config->version >= 4)
+-    if (config->version >= 4) {
 -      SetRendererType(config->m_RendererType);
--  }
+-    }
++  if (config && config->version >= 4) {
++    SetRendererType(config->m_RendererType);
+   }
    g_bLibraryInitialized = true;
  }
- 
-@@ -275,6 +298,19 @@ FPDF_EXPORT void FPDF_CALLCONV FPDF_DestroyLibrary() {
+@@ -285,6 +307,19 @@ FPDF_EXPORT void FPDF_CALLCONV FPDF_DestroyLibrary() {
    CFX_Timer::DestroyGlobals();
    FX_DestroyMemoryAllocators();
  
@@ -88,4 +87,3 @@ index 6b0a1c161..7a8788676 100644
 +
    g_bLibraryInitialized = false;
  }
-

--- a/recipes-graphics/pdfium/pdfium_139.0.7228.0.bb
+++ b/recipes-graphics/pdfium/pdfium_139.0.7228.0.bb
@@ -22,12 +22,13 @@ DEPENDS += "\
     ninja-native \
     "
 
-SRCREV = "2b675cf15ab4b68bf1ed4e0511ba2479e11f1605"
+SRCREV = "4e4d7a14a4d9d484feb4a4770a892cd964cfd968"
 SRC_URI = "\
     gn://pdfium.googlesource.com/pdfium.git \
     file://public_headers.patch \
     file://shared_library.patch \
     file://v8_init.patch \
+    file://sysroot-fix-path.patch \
     file://toolchain.gn.in \
     "
 


### PR DESCRIPTION
This PR bumps `pdfium` version to `139.0.7228.0`.

Problem `#2` when building on `aarch64`: https://github.com/meta-flutter/meta-flutter/issues/411#issuecomment-2955621158
