### PR TITLE
Add flutter-wayland-so.bb to Support flutter_elinux_wayland.so Embedder

### DIFF
--- a/recipes-graphics/sony/flutter-wayland-so.bb
+++ b/recipes-graphics/sony/flutter-wayland-so.bb
@@ -17,7 +17,7 @@ EXTRA_OECMAKE += "-DBUILD_ELINUX_SO=ON"
 
 do_install() {
     install -d ${D}${libdir}
-    install -m 0755 ${WORKDIR}/build/libflutter_elinux_wayland.so ${D}${bindir}
+    install -m 0755 ${WORKDIR}/build/libflutter_elinux_wayland.so ${D}${libdir}
 }
 
 FILES:${PN} = "${libdir}"

--- a/recipes-graphics/sony/flutter-wayland-so.bb
+++ b/recipes-graphics/sony/flutter-wayland-so.bb
@@ -1,0 +1,23 @@
+#
+# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+#
+
+DESCRIPTION = "Build .so file of the Flutter embedding for eLinux with Wayland."
+CVE_PRODUCT = "flutter_elinux_wayland.so"
+
+REQUIRED_DISTRO_FEATURES += "wayland"
+
+require sony-flutter.inc
+
+DEPENDS += "\
+    wayland \
+    wayland-native \
+    "
+EXTRA_OECMAKE += "-DBUILD_ELINUX_SO=ON"
+
+do_install() {
+    install -d ${D}${libdir}
+    install -m 0755 ${WORKDIR}/build/libflutter_elinux_wayland.so ${D}${bindir}
+}
+
+FILES:${PN} = "${libdir}"


### PR DESCRIPTION
This patch introduces a new recipe flutter-wayland-so.bb to support building the flutter_elinux_wayland.so shared library embedder. While the current meta-flutter layer officially supports only flutter-client, Sony's upstream Flutter embedder also supports building a shared object (.so) variant, which this recipe enables.