### PR TITLE
pdfium: fix building in arm64 hosts

### DIFF
--- a/recipes-graphics/pdfium/pdfium_139.0.7228.0.bb
+++ b/recipes-graphics/pdfium/pdfium_139.0.7228.0.bb
@@ -40,7 +40,18 @@ inherit gn-fetcher pkgconfig
 require conf/include/gn-utils.inc
 
 # For gn.bbclass
-GN_CUSTOM_VARS ?= '{"checkout_configuration": "small"}'
+# Trick `gclient sync`. Download some binary in order to satisfy dependencies.
+# Check reasoning at:
+# - https://github.com/meta-flutter/meta-flutter/issues/411#issuecomment-2955621158
+# Keep this workaround while the following issue is unsolved:
+# - https://issues.chromium.org/issues/424205782
+GN_CUSTOM_VARS ?= '\
+{\
+    "reclient_package": "gn/gn/", \
+    "reclient_version": "git_revision:b99a82ca8ee957da829d6313b818b99df8e7ccb8", \
+    "checkout_configuration": "small" \
+}'
+
 EXTRA_GN_SYNC ?= "--shallow --no-history -R -D"
 
 EXTRA_CXXFLAGS = ""


### PR DESCRIPTION
'buildtools/reclient' in DEPS sets its package name as 'package': Var('reclient_package') + '${{platform}}'. This means that when building on arm64 hosts the package name will solve to `infra/rbe/client/linux-arm64`, which does not exist:

- https://chrome-infra-packages.appspot.com/p/infra_internal/rbe/client

The same issue was found in chromium and the solution was to enable this package conditionally for non linux-arm64 hosts:

- https://issues.chromium.org/issues/40277110
- https://chromium.googlesource.com/chromium/src/+/d2c1621d8e02c804b67cf1722595754114cb9aa%5E%21/#F1

This PR adds a workaround to solve this issue by using `vars` to replace the binary name and version with one that is available for both arm64 and x86_64 platforms, satisfying the dependencies when `gclient sync` runs.

It will not affect the build as `reclient` is not used.

Check:
- https://github.com/meta-flutter/meta-flutter/issues/411#issuecomment-2955621158