### PR TITLE
Add flutter-wayland-so.bb to Support flutter_elinux_wayland.so Embedder

### DIFF
--- a/.github/workflows/scarthgap-qemuarm-linux-dummy.yml
+++ b/.github/workflows/scarthgap-qemuarm-linux-dummy.yml
@@ -230,6 +230,14 @@ jobs:
           bitbake flutter-x11-client -c do_cleansstate
           bitbake flutter-x11-client
 
+      - name: Build Sony Wayland Client .so
+        shell: bash
+        working-directory: ../scarthgap-linux-dummy
+        run: |
+          . ./poky/oe-init-build-env
+          bitbake flutter-wayland-so -c do_cleansstate
+          bitbake flutter-wayland-so
+
       - name: Build flutter-samples-material-3-demo
         shell: bash
         working-directory: ../scarthgap-linux-dummy

--- a/.github/workflows/scarthgap-qemuarm64-linux-dummy.yml
+++ b/.github/workflows/scarthgap-qemuarm64-linux-dummy.yml
@@ -231,6 +231,14 @@ jobs:
           bitbake flutter-x11-client -c do_cleansstate
           bitbake flutter-x11-client
 
+      - name: Build Sony Wayland Client .so
+        shell: bash
+        working-directory: ../scarthgap-linux-dummy
+        run: |
+          . ./poky/oe-init-build-env
+          bitbake flutter-wayland-so -c do_cleansstate
+          bitbake flutter-wayland-so
+
       - name: Build flutter-samples-material-3-demo
         shell: bash
         working-directory: ../scarthgap-linux-dummy

--- a/.github/workflows/scarthgap-qemux86-64-linux-dummy.yml
+++ b/.github/workflows/scarthgap-qemux86-64-linux-dummy.yml
@@ -213,6 +213,14 @@ jobs:
           bitbake flutter-x11-client -c do_cleansstate
           bitbake flutter-x11-client
 
+      - name: Build Sony Wayland Client .so
+        shell: bash
+        working-directory: ../scarthgap-linux-dummy
+        run: |
+          . ./poky/oe-init-build-env
+          bitbake flutter-wayland-so -c do_cleansstate
+          bitbake flutter-wayland-so
+
       - name: Build flutter-samples-material-3-demo
         shell: bash
         working-directory: ../scarthgap-linux-dummy

--- a/recipes-graphics/sony/flutter-wayland-so.bb
+++ b/recipes-graphics/sony/flutter-wayland-so.bb
@@ -1,0 +1,24 @@
+#
+# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+#
+
+DESCRIPTION = "Flutter Embedder with Wayland Client Backend as shared object (.so)."
+CVE_PRODUCT = "flutter_elinux_wayland.so"
+
+REQUIRED_DISTRO_FEATURES += "wayland"
+
+require sony-flutter.inc
+
+DEPENDS += "\
+    wayland \
+    wayland-native \
+    "
+
+EXTRA_OECMAKE += "-DBUILD_ELINUX_SO=ON"
+
+do_install() {
+    install -d ${D}${libdir}
+    install -m 0755 ${B}/libflutter_elinux_wayland.so ${D}${libdir}
+}
+
+FILES:${PN} = "${libdir}"


### PR DESCRIPTION
This patch introduces a new recipe flutter-wayland-so.bb to support building the flutter_elinux_wayland.so shared library embedder. While the current meta-flutter layer officially supports only flutter-client, Sony's upstream Flutter embedder also supports building a shared object (.so) variant, which this recipe enables.

@jwinarske 
As per your comment in the below pull request i created the commit for scarthgap.
https://github.com/meta-flutter/meta-flutter/pull/669
Please review from your end once.
