### PR TITLE
pdfium: remove static compilation of libgcc and libg++

### DIFF
--- a/recipes-graphics/pdfium/files/toolchain.gn.in
+++ b/recipes-graphics/pdfium/files/toolchain.gn.in
@@ -12,7 +12,7 @@ gcc_toolchain("@GN_TARGET_ARCH_NAME@") {
   ld = cxx
 
   @EXTRA_CXXFLAGS@
-  extra_ldflags = "-static-libgcc -static-libstdc++ @LDFLAGS@"
+  extra_ldflags = "@LDFLAGS@"
 
   toolchain_args = {
     current_cpu = "@GN_TARGET_ARCH_NAME@"


### PR DESCRIPTION
The library should not be built with `-static-libgcc` and `-static-libg++` as the rest of Yocto is built to use dynamic libraries.

Mixing static and dynamic C++ runtimes causes crashes during exception handling. When an exception from `pdfium` crosses the boundary to code using the shared `libstdc++`, the runtime environments clash and the program terminates.

This commit removes the static flags, ensuring `pdfium` uses the same dynamic `libstdc++` as the rest of the system, which fixes the underlying issue.

My guess is that this file was copied from the `musl-static` build of the [`pdfium-binaries`](https://github.com/bblanchon/pdfium-binaries project) repo, where those static flags apply, but removing them here was forgotten.