### PR TITLE
fix building workspace packages

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -403,6 +403,7 @@ def versiontuple(v):
 def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_path, staging_dir_target, source_root, env):
     import glob
     import shutil
+    import json
 
     # determine build type based on what flutter-engine installed.
     datadir = d.getVar('datadir')
@@ -477,7 +478,12 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
             app_aot_extra = d.getVar("APP_AOT_EXTRA")
             app_aot_entry_file = d.getVar("APP_AOT_ENTRY_FILE")
 
+            workspace_ref_json = f'{source_dir}/{flutter_application_path}/.dart_tool/pub/workspace_ref.json'
             package_config_json = f'{source_dir}/{flutter_application_path}/.dart_tool/package_config.json'
+            if os.path.isfile(workspace_ref_json):
+                with open(workspace_ref_json, 'r') as f:
+                    workspace_ref_json_content = json.load(f)
+                    package_config_json = f'{os.path.dirname(workspace_ref_json)}/{workspace_ref_json_content["workspaceRoot"]}/.dart_tool/package_config.json'
 
             if not new_build_scheme:
                 dart_runtime = f'{flutter_sdk}/bin/cache/dart-sdk/bin/dart'


### PR DESCRIPTION
Hey @jwinarske ,

dart/flutter recently introduced workspaces which AFAIU, basically makes dart treat a mono-repo containing a lot of packages, like it was a single package. That speeds up analysis a bit.

It does change some things in the build, more precisely the `package_config.json` is now not in the directory of the app that should be built, but in the workspace root.

Luckily dart creates a `workspace_ref.json` file that indicates where the `package_config.json` can be found.

This patch makes workspace packages build fine for us, without any other changes in the app recipes.

Can also create PRs for the other yocto releases.