### PR TITLE
Add INSANE_SKIP for flutter-sdk

### DIFF
--- a/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
+++ b/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
@@ -174,6 +174,8 @@ ALLOW_EMPTY:${PN} = "1"
 
 FILES:${PN} = "${datadir}/flutter/sdk"
 
-INSANE_SKIP:${PN} += "already-stripped file-rdeps"
+INSANE_SKIP:${PN} += "already-stripped file-rdeps libdir"
+INSANE_SKIP:${PN}-dbg += "libdir"
+INSANE_SKIP:class-nativesdk += "buildpaths"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
There are multiple QA checks that fail when adding nativesdk-flutter-sdk to an sdk. We skip these knowing that it might leak build paths to consumers of our sdk