### PR TITLE
ivi-homescreen/flutter-auto flatpak

### DIFF
--- a/meta-flutter-apps/dynamic-layers/gnome-layer/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-flatpak-flutter-example_1.0.0.bb
+++ b/meta-flutter-apps/dynamic-layers/gnome-layer/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-flatpak-flutter-example_1.0.0.bb
@@ -23,5 +23,6 @@ FLUTTER_APPLICATION_PATH = "packages/flatpak/example"
 inherit flutter-app
 
 RDEPENDS:${PN} += " \
+    flatpak \
     xdg-desktop-portal-gnome \
 "

--- a/recipes-graphics/toyota/flutter-auto_2.0.bb
+++ b/recipes-graphics/toyota/flutter-auto_2.0.bb
@@ -29,7 +29,7 @@ DEPENDS += "\
 REQUIRED_DISTRO_FEATURES = "wayland"
 
 HOMESCREEN_COMMIT ??= "dd6d9224de807e24f0f9150e5a2e4ee1b896ac3c"
-PLUGINS_COMMIT ??= "69ba7e8b23cf841c7cd488bdff1432fb6c650734"
+PLUGINS_COMMIT ??= "63ae75a907ec1b374db40243b23bda17136c61eb"
 
 SRC_URI = "\
     gitsm://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=v2.0;name=homescreen \

--- a/recipes-graphics/toyota/ivi-homescreen_2.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_2.0.bb
@@ -29,7 +29,7 @@ DEPENDS += "\
 REQUIRED_DISTRO_FEATURES = "wayland"
 
 HOMESCREEN_COMMIT ??= "dd6d9224de807e24f0f9150e5a2e4ee1b896ac3c"
-PLUGINS_COMMIT ??= "69ba7e8b23cf841c7cd488bdff1432fb6c650734"
+PLUGINS_COMMIT ??= "63ae75a907ec1b374db40243b23bda17136c61eb"
 
 SRC_URI = "\
     gitsm://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=v2.0;name=homescreen \


### PR DESCRIPTION
-workaround for issue seen on rpi4-64 flatpak where libxml2 fails to parse appstream.xml.tz -updated flatpak plugin README with notes regarding running on a Yocto image