### PR TITLE
gn.py: use protocol not proto in SRC_URI

### DIFF
--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -18,7 +18,7 @@ BBFILE_PATTERN_flutter-layer := "^${LAYERDIR}/"
 BBFILE_PRIORITY_flutter-layer = "12"
 
 LAYERDEPENDS_flutter-layer = "core openembedded-layer"
-LAYERSERIES_COMPAT_flutter-layer = "whinlatter"
+LAYERSERIES_COMPAT_flutter-layer = "whinlatter wrynose"
 
 addpylib ${LAYERDIR}/lib gn
 addpylib ${LAYERDIR}/lib cipd

--- a/lib/gn.py
+++ b/lib/gn.py
@@ -32,10 +32,10 @@ class GN(FetchMethod):
         return False
 
     def urldata_init(self, ud, d):
-        # syntax: gn://<URL>;gn_name=<NAME>;destdir=<D>;proto=<PROTO>
+        # syntax: gn://<URL>;gn_name=<NAME>;destdir=<D>;protocol=<PROTO>
         name = ud.parm.get("gn_name", ".")
         ud.destdir = ud.parm.get("destdir", d.getVar("S"))
-        proto = ud.parm.get("proto", "https")
+        proto = ud.parm.get("protocol", "https")
 
         ud.basename = "*"
 

--- a/meta-flutter-apps/conf/layer.conf
+++ b/meta-flutter-apps/conf/layer.conf
@@ -21,7 +21,7 @@ LAYERRECOMMENDS_flutter-apps-layer = " \
     meta-tensorflow \
 "
 
-LAYERSERIES_COMPAT_flutter-apps-layer = "whinlatter"
+LAYERSERIES_COMPAT_flutter-apps-layer = "whinlatter wrynose"
 
 BBFILES_DYNAMIC += " \
     gnome-layer:${LAYERDIR}/dynamic-layers/gnome-layer/*/*/*.bb \


### PR DESCRIPTION
It uses https by default, but if someone uses e.g. ssh, then using "protocol" in SRC_URI doesn't work with gn:// but "proto" is deprecated since bitbake 1.16 from 2012 and each recipe using this triggers multiple warnings from:
https://git.openembedded.org/bitbake/commit/?h=1.16&id=53e6b630f0463d2d07cdaa9c9eb36794dc9b6b69