### PR TITLE
switch to fork of Sony embedded Linux embedder

### DIFF
--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -4,8 +4,8 @@
 
 SUMMARY = "Embedded Linux embedding for Flutter"
 AUTHOR = "Sony Group Corporation"
-HOMEPAGE = "https://github.com/sony/flutter-embedded-linux"
-BUGTRACKER = "https://github.com/sony/flutter-embedded-linux/issues"
+HOMEPAGE = "https://github.com/flutter-elinux/flutter-embedded-linux"
+BUGTRACKER = "https://github.com/flutter-elinux/flutter-embedded-linux/issues"
 SECTION = "graphics"
 LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=d45359c88eb146940e4bede4f08c821a"
@@ -25,11 +25,11 @@ RDEPENDS:${PN} += " \
 
 REQUIRED_DISTRO_FEATURES += "opengl"
 
-SRC_REPO ??= "github.com/sony/flutter-embedded-linux.git"
+SRC_REPO ??= "github.com/flutter-elinux/flutter-embedded-linux.git"
 SRC_REPO_BRANCH ??= "master"
 
 SRC_URI = "git://${SRC_REPO};protocol=https;branch=${SRC_REPO_BRANCH}"
-SRCREV ??= "1653fa656bf9fe9fa5f84789a59b0c07671a8fc8"
+SRCREV ??= "7668680782f2981a89464546163cbb267d0a572a"
 
 inherit pkgconfig cmake features_check
 


### PR DESCRIPTION
Sony is no longer maintaining their embedded Linux embedder (sony/flutter-elinux#289). Switch to a community fork, which supports Flutter 3.38.3.

cc @martinetd
 