### PR TITLE
[flutter-engine] fix HWCAP2 macro redefinition on ARM/AArch64 only (revised #645)

### DIFF
--- a/recipes-graphics/flutter-engine/files/0001-fix-boringssl-hwcap2-redefined-arm.patch
+++ b/recipes-graphics/flutter-engine/files/0001-fix-boringssl-hwcap2-redefined-arm.patch
@@ -1,0 +1,43 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Akihiko Komada <aki1770@gmail.com>
+Date: Sun, 29 Mar 2026 00:00:00 +0900
+Subject: [PATCH] [flutter/third_party/boringssl] fix HWCAP2 macro redefinition on ARM
+
+Wrap HWCAP2_AES, HWCAP2_PMULL, HWCAP2_SHA1, and HWCAP2_SHA2 in
+#ifndef guards to prevent -Werror,-Wmacro-redefined failures when
+building against ARM sysroots (e.g. Yocto/Kirkstone) whose
+bits/hwcap-32.h already defines these macros.
+
+Fixes: https://github.com/meta-flutter/meta-flutter/issues/645
+
+Upstream-Status: Inappropriate [specific to older pinned boringssl rev;
+upstream has since renamed these to CRYPTO_HWCAP2_* in newer commits]
+
+Signed-off-by: Akihiko Komada <aki1770@gmail.com>
+---
+ engine/src/flutter/third_party/boringssl/src/crypto/cpu_arm_linux.h | 10 +++++++++-
+ 1 file changed, 9 insertions(+), 1 deletion(-)
+
+diff --git a/engine/src/flutter/third_party/boringssl/src/crypto/cpu_arm_linux.h b/engine/src/flutter/third_party/boringssl/src/crypto/cpu_arm_linux.h
+--- a/engine/src/flutter/third_party/boringssl/src/crypto/cpu_arm_linux.h
++++ b/engine/src/flutter/third_party/boringssl/src/crypto/cpu_arm_linux.h
+@@ -33,10 +33,20 @@ extern "C" {
+
+ // See /usr/include/asm/hwcap.h on an ARM installation for the source of
+ // these values.
+-#define HWCAP2_AES (1 << 0)
+-#define HWCAP2_PMULL (1 << 1)
+-#define HWCAP2_SHA1 (1 << 2)
+-#define HWCAP2_SHA2 (1 << 3)
++#ifndef HWCAP2_AES
++#define HWCAP2_AES (1 << 0)
++#endif
++#ifndef HWCAP2_PMULL
++#define HWCAP2_PMULL (1 << 1)
++#endif
++#ifndef HWCAP2_SHA1
++#define HWCAP2_SHA1 (1 << 2)
++#endif
++#ifndef HWCAP2_SHA2
++#define HWCAP2_SHA2 (1 << 3)
++#endif

--- a/recipes-graphics/flutter-engine/flutter-engine_git.bbappend
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bbappend
@@ -1,0 +1,15 @@
+#
+# Fix HWCAP2 macro redefinition that prevents libwebrtc from compiling
+# for ARM/AArch64 when the sysroot's bits/hwcap-32.h already defines
+# these macros.
+#
+# Scoped to aarch64 and arm targets only — x86_64 builds are unaffected
+# and must not receive this patch (fixes breakage from PR #748).
+#
+# Fixes: https://github.com/meta-flutter/meta-flutter/issues/645
+#
+
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI:append:aarch64 = " file://0001-fix-boringssl-hwcap2-redefined-arm.patch"
+SRC_URI:append:arm = " file://0001-fix-boringssl-hwcap2-redefined-arm.patch"


### PR DESCRIPTION
Revised version of #748, which was reverted in #750 because it applied the patch unconditionally and broke x86_64 builds.

## Change

Scope the HWCAP2 patch to `aarch64` and `arm` targets only using BitBake arch overrides:

```bitbake
SRC_URI:append:aarch64 = " file://0001-fix-boringssl-hwcap2-redefined-arm.patch"
SRC_URI:append:arm     = " file://0001-fix-boringssl-hwcap2-redefined-arm.patch"
```

x86_64 builds are unaffected — they do not receive the patch.

## Problem (unchanged from #748)

On ARM Yocto sysroots (e.g. Kirkstone), `bits/hwcap-32.h` already defines `HWCAP2_AES`, `HWCAP2_PMULL`, `HWCAP2_SHA1`, and `HWCAP2_SHA2`. boringssl's `cpu_arm_linux.h` redefines them unconditionally, causing `-Werror,-Wmacro-redefined` build failures when compiling libwebrtc for ARM.

The patch wraps the four definitions in `#ifndef` guards — no functional change on ARM, compile fix on conflicting sysroots.

## Why #748 broke x86_64

On x86_64, `bits/hwcap-32.h` does **not** define these macros, so boringssl's definitions are required and correct. Applying the `#ifndef` guards unconditionally on x86_64 is harmless in isolation, but the `.bbappend` caused `FILESEXTRAPATHS` to be set globally, pulling in the patch file for all architectures and triggering unexpected behaviour in the x86_64 recipe flow.

This revision avoids that by using per-architecture `SRC_URI:append` overrides.

Fixes #645.