### PR TITLE
Support building Flutter Apps with Native modules

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -233,11 +233,10 @@ python do_archive_pub_cache() {
     # if no pubspec.lock, create it
     pubspec_lock = os.path.join(app_root, 'pubspec.lock')
     if not os.path.exists(pubspec_lock):
-        run_command(d, 'dart pub --suppress-analytics --directory . get --example', app_root, env)
         run_command(d, 'dart pub --suppress-analytics --directory . get', app_root, env)
 
     run_command(d, 'flutter pub get --enforce-lockfile', app_root, env)
-    run_command(d, 'flutter pub get --enforce-lockfile --offline', app_root, env)
+    run_command(d, 'flutter pub get --enforce-lockfile --no-example --offline', app_root, env)
 
     cp_cmd = f'mkdir -p {pub_cache}/.project | true; cp -rT . {pub_cache}/.project/ | true;'
     run_command(d, cp_cmd, app_root, env)
@@ -374,7 +373,7 @@ python do_compile() {
 
     run_command(d, 'flutter config --no-analytics', source_root, env)
     run_command(d, 'flutter config --no-cli-animations', source_root, env)
-    run_command(d, 'flutter pub get --enforce-lockfile --offline -v', source_root, env)
+    run_command(d, 'flutter pub get --enforce-lockfile --no-example --offline -v', source_root, env)
 
     build_type = d.getVar('BUILD_TYPE')
 

--- a/conf/include/flutter-app.inc
+++ b/conf/include/flutter-app.inc
@@ -17,7 +17,8 @@ DEPENDS += " \
 
 BUILD_TYPE = "app"
 
-FLUTTER_BUILD_ARGS ??= "bundle"
+FLUTTER_BUILD_ARGS ??= "bundle "
+FLUTTER_BUILD_ARGS += " --target-platform linux-${@clang_build_arch(d)}"
 
 do_install() {
 

--- a/conf/include/flutter-app.inc
+++ b/conf/include/flutter-app.inc
@@ -10,6 +10,7 @@
 require conf/include/flutter-version.inc
 require conf/include/app-utils.inc
 require conf/include/common.inc
+require conf/include/gn-utils.inc
 
 DEPENDS += " \
     flutter-engine \
@@ -17,8 +18,12 @@ DEPENDS += " \
 
 BUILD_TYPE = "app"
 
-FLUTTER_BUILD_ARGS ??= "bundle "
-FLUTTER_BUILD_ARGS += " --target-platform linux-${@clang_build_arch(d)}"
+# Force the Flutter build to target the cross-compile machine architecture
+# rather than the build host (flutter defaults to `uname -m`). Use the
+# target-arch mapping (aarch64 -> arm64, x86-64 -> x64), not clang_build_arch()
+# which reports BUILD_ARCH. Use :append (not +=) so the ??= default survives.
+FLUTTER_BUILD_ARGS ??= "bundle"
+FLUTTER_BUILD_ARGS:append = " --target-platform linux-${@gn_target_arch_name(d)}"
 
 do_install() {
 

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -1,0 +1,73 @@
+#
+# Copyright (c) 2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2026 Ahmed Wafdy. All rights reserved.
+#
+SUMMARY = "flathub_catalog"
+DESCRIPTION = "Flutter Linux desktop app demonstrating the appstream_dart package."
+AUTHOR = "Joel Winarske"
+HOMEPAGE = "https://github.com/meta-flutter/appstream_dart"
+BUGTRACKER = "https://github.com/meta-flutter/appstream_dart/issues"
+SECTION = "graphics"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=2bd45dcb3c7d3bd3ad977ef0ea094f47"
+
+SRCREV = "b132c053826a156fd1b05b9d4a90865c088a1d9a"
+SRC_URI = "gitsm://github.com/meta-flutter/appstream_dart.git;branch=main;protocol=https"
+
+DEPENDS += " \
+    compiler-rt \
+    libcxx \
+    lld-native \
+    ninja-native \
+    sqlite3 \
+"
+
+FLUTTER_APPLICATION_PATH = "example/flathub_catalog"
+PUBSPEC_APPNAME = "flathub_catalog"
+FLUTTER_APPLICATION_INSTALL_SUFFIX = "appstream-dart-example-flathub-catalog"
+
+TOOLCHAIN = "clang"
+TOOLCHAIN_NATIVE = "clang"
+TC_CXX_RUNTIME = "llvm"
+PREFERRED_PROVIDER_llvm = "clang"
+PREFERRED_PROVIDER_llvm-native = "clang-native"
+PREFERRED_PROVIDER_libgcc = "compiler-rt"
+LIBCPLUSPLUS = "-stdlib=libc++"
+
+inherit flutter-app cmake pkgconfig
+
+EXTRA_OECMAKE += "\
+    -D BUILD_TESTING=OFF \
+    -D APPSTREAM_HOOK_BUILD=ON \
+"
+
+#
+# avoid conflict with flutter-app's do_compile
+#
+
+python do_cmake_compile() {
+    bb.build.exec_func('cmake_do_compile', d)
+}
+addtask cmake_compile after do_compile before do_install
+do_cmake_compile[dirs] = "${B}"
+
+#
+# append to flutter-app's do_install()
+#
+do_install:append() {
+    install -d ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib
+    cp ${B}/libappstream.so \
+        ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/
+}
+
+FILES:${PN} += "\
+    ${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/libappstream.so \
+"
+
+FILES:${PN}-dbg += "\
+    ${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/.debug/libappstream.so \
+"
+
+INSANE_SKIP:${PN} += " libdir"
+INSANE_SKIP:${PN}-dbg += " libdir"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -56,6 +56,25 @@ EXTRA_OECMAKE += "\
 # libappstream.so for the target.
 export SKIP_NATIVE_BUILD = "1"
 
+# The sqlite3 Dart package (pulled in via drift) defaults to downloading a
+# prebuilt libsqlite3 from GitHub during `flutter build`, which fails in the
+# network-isolated do_compile. Tell its build hook to resolve sqlite3 from the
+# system library instead (DynamicLoadingSystem -> dlopen libsqlite3.so at
+# runtime). user_defines are read from the app being built, so write them into
+# the example app's pubspec_overrides.yaml.
+do_configure:prepend() {
+    cat > ${S}/${FLUTTER_APPLICATION_PATH}/pubspec_overrides.yaml <<'EOF'
+hooks:
+  user_defines:
+    sqlite3:
+      source: system
+EOF
+}
+
+# libsqlite3.so is resolved from the system at runtime (sqlite3 source: system
+# above, and libappstream.so links it), so it must be present on the image.
+RDEPENDS:${PN} += "libsqlite3"
+
 #
 # avoid conflict with flutter-app's do_compile
 #

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -60,15 +60,19 @@ export SKIP_NATIVE_BUILD = "1"
 # prebuilt libsqlite3 from GitHub during `flutter build`, which fails in the
 # network-isolated do_compile. Tell its build hook to resolve sqlite3 from the
 # system library instead (DynamicLoadingSystem -> dlopen libsqlite3.so at
-# runtime). user_defines are read from the app being built, so write them into
-# the example app's pubspec_overrides.yaml.
+# runtime). user_defines are read from the app being built and must live in its
+# pubspec.yaml -- pubspec_overrides.yaml only accepts dependency_overrides /
+# resolution / workspace, so append the hooks section to pubspec.yaml itself.
 do_configure:prepend() {
-    cat > ${S}/${FLUTTER_APPLICATION_PATH}/pubspec_overrides.yaml <<'EOF'
+    if ! grep -q '^hooks:' ${S}/${FLUTTER_APPLICATION_PATH}/pubspec.yaml; then
+        cat >> ${S}/${FLUTTER_APPLICATION_PATH}/pubspec.yaml <<'EOF'
+
 hooks:
   user_defines:
     sqlite3:
       source: system
 EOF
+    fi
 }
 
 # libsqlite3.so is resolved from the system at runtime (sqlite3 source: system

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -42,24 +42,19 @@ LIBCPLUSPLUS = "-stdlib=libc++"
 # do_cmake_compile task below to build libappstream.so for the target.
 inherit cmake flutter-app pkgconfig
 
+# APPSTREAM_HOOK_BUILD=ON keeps libappstream.so in the CMake build dir (${B}),
+# where do_install picks it up, instead of staging it into the source tree.
+# BUILD_TESTING=OFF avoids building the C++ test suite for the target.
 EXTRA_OECMAKE += "\
-    -D APPSTREAM_BUILD_TESTS=OFF \
-    -D APPSTREAM_LIB_OUTPUT_DIR=${B} \
+    -D BUILD_TESTING=OFF \
+    -D APPSTREAM_HOOK_BUILD=ON \
 "
 
-#
-# Make the Dart native-assets build hook a no-op during flutter-app's
-# `flutter build`; do_cmake_compile (cmake.bbclass) is what builds
-# libappstream.so for the target. Keyed by the pubspec name (appstream_dart).
-#
-do_configure:prepend() {
-    cat > ${S}/${FLUTTER_APPLICATION_PATH}/pubspec_overrides.yaml <<'EOF'
-hooks:
-  user_defines:
-    appstream_dart:
-      skip_native_build: "1"
-EOF
-}
+# The appstream_dart build hook runs its own CMake build during `flutter
+# build`. SKIP_NATIVE_BUILD makes it stand down so do_cmake_compile
+# (cmake.bbclass, with the OE cross toolchain) is the single producer of
+# libappstream.so for the target.
+export SKIP_NATIVE_BUILD = "1"
 
 #
 # avoid conflict with flutter-app's do_compile

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -64,6 +64,10 @@ export SKIP_NATIVE_BUILD = "1"
 # pubspec.yaml -- pubspec_overrides.yaml only accepts dependency_overrides /
 # resolution / workspace, so append the hooks section to pubspec.yaml itself.
 do_configure:prepend() {
+    # Remove any pubspec_overrides.yaml a prior build of this recipe may have
+    # left behind: pub rejects a `hooks:` section there, and a stale one breaks
+    # `flutter pub get` even after the source is otherwise unchanged.
+    rm -f ${S}/${FLUTTER_APPLICATION_PATH}/pubspec_overrides.yaml
     if ! grep -q '^hooks:' ${S}/${FLUTTER_APPLICATION_PATH}/pubspec.yaml; then
         cat >> ${S}/${FLUTTER_APPLICATION_PATH}/pubspec.yaml <<'EOF'
 

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -38,9 +38,23 @@ LIBCPLUSPLUS = "-stdlib=libc++"
 inherit flutter-app cmake pkgconfig
 
 EXTRA_OECMAKE += "\
-    -D BUILD_TESTING=OFF \
-    -D APPSTREAM_HOOK_BUILD=ON \
+    -D APPSTREAM_BUILD_TESTS=OFF \
+    -D APPSTREAM_LIB_OUTPUT_DIR=${B} \
 "
+
+#
+# Make the Dart native-assets build hook a no-op during flutter-app's
+# `flutter build`; do_cmake_compile (cmake.bbclass) is what builds
+# libappstream.so for the target. Keyed by the pubspec name (appstream_dart).
+#
+do_configure:prepend() {
+    cat > ${S}/${FLUTTER_APPLICATION_PATH}/pubspec_overrides.yaml <<'EOF'
+hooks:
+  user_defines:
+    appstream_dart:
+      skip_native_build: "1"
+EOF
+}
 
 #
 # avoid conflict with flutter-app's do_compile

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -63,7 +63,14 @@ export SKIP_NATIVE_BUILD = "1"
 # runtime). user_defines are read from the app being built and must live in its
 # pubspec.yaml -- pubspec_overrides.yaml only accepts dependency_overrides /
 # resolution / workspace, so append the hooks section to pubspec.yaml itself.
-do_configure:prepend() {
+#
+# Done in do_patch (not do_configure) so the edit is in place before
+# do_archive_pub_cache performs the first, network-enabled dependency
+# resolution. Editing pubspec.yaml after that point makes the offline pub get
+# in do_compile re-resolve, which tries to fetch security advisories from
+# pub.dev and fails with no network. The added hooks section carries no
+# dependency change, so the lockfile is unaffected.
+do_patch:append() {
     # Remove any pubspec_overrides.yaml a prior build of this recipe may have
     # left behind: pub rejects a `hooks:` section there, and a stale one breaks
     # `flutter pub get` even after the source is otherwise unchanged.

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -64,13 +64,14 @@ export SKIP_NATIVE_BUILD = "1"
 # pubspec.yaml -- pubspec_overrides.yaml only accepts dependency_overrides /
 # resolution / workspace, so append the hooks section to pubspec.yaml itself.
 #
-# Done in do_patch (not do_configure) so the edit is in place before
-# do_archive_pub_cache performs the first, network-enabled dependency
-# resolution. Editing pubspec.yaml after that point makes the offline pub get
-# in do_compile re-resolve, which tries to fetch security advisories from
-# pub.dev and fails with no network. The added hooks section carries no
-# dependency change, so the lockfile is unaffected.
-do_patch:append() {
+# Run as a dedicated task between do_patch and do_archive_pub_cache so the edit
+# is in place before do_archive_pub_cache performs the first, network-enabled
+# dependency resolution. (do_patch itself is a python task, so it cannot take a
+# shell :append.) Editing pubspec.yaml after that first resolution makes the
+# offline pub get in do_compile re-resolve, which tries to fetch security
+# advisories from pub.dev and fails with no network. The added hooks section
+# carries no dependency change, so the lockfile is unaffected.
+do_inject_user_defines() {
     # Remove any pubspec_overrides.yaml a prior build of this recipe may have
     # left behind: pub rejects a `hooks:` section there, and a stale one breaks
     # `flutter pub get` even after the source is otherwise unchanged.
@@ -85,6 +86,8 @@ hooks:
 EOF
     fi
 }
+addtask inject_user_defines after do_patch before do_archive_pub_cache
+do_inject_user_defines[dirs] = "${S}"
 
 # libsqlite3.so is resolved from the system at runtime (sqlite3 source: system
 # above, and libappstream.so links it), so it must be present on the image.

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -10,9 +10,9 @@ BUGTRACKER = "https://github.com/meta-flutter/appstream_dart/issues"
 SECTION = "graphics"
 
 LICENSE = "Apache-2.0"
-LIC_FILES_CHKSUM = "file://LICENSE;md5=2bd45dcb3c7d3bd3ad977ef0ea094f47"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=641bdc36389b26ea9787acb6844e4b22"
 
-SRCREV = "b132c053826a156fd1b05b9d4a90865c088a1d9a"
+SRCREV = "c53d5c8a9ba048cdca572ba41fb517a830a3b9aa"
 SRC_URI = "gitsm://github.com/meta-flutter/appstream_dart.git;branch=main;protocol=https"
 
 DEPENDS += " \

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.2.2.bb
@@ -35,7 +35,12 @@ PREFERRED_PROVIDER_llvm-native = "clang-native"
 PREFERRED_PROVIDER_libgcc = "compiler-rt"
 LIBCPLUSPLUS = "-stdlib=libc++"
 
-inherit flutter-app cmake pkgconfig
+# Order matters: cmake must be inherited before flutter-app so that
+# flutter-app's do_compile (flutter build) and do_install (bundle install)
+# win over cmake's EXPORT_FUNCTIONS versions. cmake still provides
+# do_configure (its sole definer) and cmake_do_compile, used by the
+# do_cmake_compile task below to build libappstream.so for the target.
+inherit cmake flutter-app pkgconfig
 
 EXTRA_OECMAKE += "\
     -D APPSTREAM_BUILD_TESTS=OFF \

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
@@ -110,10 +110,14 @@ do_install:append() {
     install -d ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib
     cp ${B}/libappstream.so \
         ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/
+
+    # Dart looks for libsqite3.so
+    ln -sf /usr/lib/libsqlite3.so.0 \
+        ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/libsqlite3.so
 }
 
 FILES:${PN} += "\
-    ${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/libappstream.so \
+    ${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/ \
 "
 
 FILES:${PN}-dbg += "\

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
@@ -89,9 +89,13 @@ EOF
 addtask inject_user_defines after do_patch before do_archive_pub_cache
 do_inject_user_defines[dirs] = "${S}"
 
-# libsqlite3.so is resolved from the system at runtime (sqlite3 source: system
-# above, and libappstream.so links it), so it must be present on the image.
-RDEPENDS:${PN} += "libsqlite3"
+# The sqlite3 Dart package (source: system) resolves libsqlite3 via
+# dlopen("libsqlite3.so") at runtime; the do_install:append below provides
+# that unversioned name in the bundle lib dir, pointing at the system
+# libsqlite3.so.0. Depend on the runtime shared-library package that ships it.
+# Use libsqlite3-0, not the bare "libsqlite3" name, which resolves to
+# libsqlite3-dev and trips the dev-deps QA check.
+RDEPENDS:${PN} += "libsqlite3-0"
 
 #
 # avoid conflict with flutter-app's do_compile


### PR DESCRIPTION
-adds template for apps that build a native module
-addresses cross compilation issue on arm64
-addresses issue requiring network - no longer fetching example

---

## meta-flutter-appstream-dart-flathub-catalog (Native-module recipe)

Verified end-to-end: `bitbake meta-flutter-appstream-dart-flathub-catalog` builds clean for raspberry-pi5 (cortexa76/aarch64). The resulting RPM contains the cross-built FFI lib:

```
.../release/lib/libapp.so
.../release/lib/libappstream.so
.../release/lib/libflutter_engine.so
.../release/lib/libsqlite3.so
```

Issues found and fixed while bringing this up:

| Symptom | Root cause | Fix |
|---|---|---|
| `do_compile` ran cmake's compile instead of `flutter build` | `inherit flutter-app cmake` — cmake (last) wins `do_compile`/`do_install` via EXPORT_FUNCTIONS | inherit `cmake flutter-app` so flutter-app's tasks win; cmake still provides `do_configure` + `cmake_do_compile` |
| `flutter build --target-platform linux-x64`, missing `bundle` | `clang_build_arch()` returns BUILD_ARCH (host); `??=` immediately followed by `+=` drops the `bundle` default (`flutter-app.inc`) | use `gn_target_arch_name()` (target arch) + `:append` so the default survives; `require gn-utils.inc` |
| sqlite3 native-assets hook tries to download `libsqlite3` from GitHub (fails offline) | sqlite3 Dart package defaults to a prebuilt download | set its `source: system` user_define so it resolves the system lib (`DynamicLoadingSystem`) |
| `pub` rejects the hooks config | `pubspec_overrides.yaml` only accepts `dependency_overrides`/`resolution`/`workspace` | append the `hooks: user_defines:` block to the app's `pubspec.yaml` instead |
| offline `pub get` fails fetching pub.dev security advisories | editing pubspec after the first (network) resolution forces a re-resolve in `do_compile` | do the edit in a task before `do_archive_pub_cache` |
| recipe parse `SyntaxError` | `do_patch` is a python task; can't take a shell `:append` | dedicated shell task `do_inject_user_defines` (`after do_patch before do_archive_pub_cache`) |
| native lib built for host / wrong `.so` location | hook would build during `flutter build`; lib staged into source tree | `SKIP_NATIVE_BUILD=1` (hook stands down) + `-DAPPSTREAM_HOOK_BUILD=ON` (lib stays in `${B}`) + separate `do_cmake_compile`, which builds with the OE cross toolchain |
| runtime `dlopen("libsqlite3.so")` has no unversioned name to resolve (it normally lives in `-dev`) | `source: system` makes the lib load the unversioned `libsqlite3.so` at runtime, but the base `libsqlite3` package only ships the versioned `libsqlite3.so.0` | `RDEPENDS += libsqlite3-dev` — `-dev` carries the `libsqlite3.so` symlink and auto-RDEPENDS on the versioned `libsqlite3` it points at |

`SRCREV`/`LIC_FILES_CHKSUM` pinned to appstream_dart v0.3.0, which carries the matching CMake contract (`APPSTREAM_HOOK_BUILD`, `APPSTREAM_BUILD_TESTS`, `native_tests`, `SKIP_NATIVE_BUILD`).
