### PR TITLE
flutter-apps: wonderous-app-wonders: Fix source directory for git fetcher

### DIFF
--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/gskinnerteam-flutter-wonderous-app-wonders_2.2.4.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/gskinnerteam-flutter-wonderous-app-wonders_2.2.4.bb
@@ -20,6 +20,8 @@ FLUTTER_APPLICATION_INSTALL_SUFFIX = "gskinnerteam-flutter-wonderous-app-wonders
 PUBSPEC_IGNORE_LOCKFILE = "1"
 FLUTTER_APPLICATION_PATH = ""
 
+S = "${WORKDIR}/git"
+
 inherit flutter-app
 
 do_compile[network] = "1"


### PR DESCRIPTION
The git fetcher unpacks sources into ${WORKDIR}/git, but S was not set accordingly. This causes do_compile to fail due to an invalid source directory and prevents LICENSE from being found during license checks.

Set S = "${WORKDIR}/git" to fix the source path.