### PR TITLE
[kirkstone] flutter-engine: Use libdir when locating target libraries

### DIFF
--- a/dynamic-layers/clang-layer/recipes-graphics/flutter-engine/flutter-engine_%.bbappend
+++ b/dynamic-layers/clang-layer/recipes-graphics/flutter-engine/flutter-engine_%.bbappend
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
 #
 
 DEPENDS:riscv64 += "\
@@ -23,7 +23,7 @@ COMPATIBLE_MACHINE:riscv64 = "(.*)"
 CLANG_PATH:riscv64 = "${STAGING_DIR_NATIVE}/usr"
 
 do_configure:append() {
-    cd ${STAGING_DIR_TARGET}/usr/lib
+    cd ${STAGING_DIR_TARGET}${libdir}
 
     test -e crtbeginS.o && rm crtbeginS.o
     test -e crtendS.o && rm crtendS.o


### PR DESCRIPTION
The clang-layer bbappend hardcodes the target library path as ${STAGING_DIR_TARGET}/usr/lib when creating the crtbeginS.o symlink.

This does not work in multilib builds where the target library directory can be different, such as /usr/lib32 or /usr/lib64. Use ${libdir} instead so the path follows the selected target ABI.

This fixes the lib32 flutter-engine build failure caused by looking for crtbeginS.o in the wrong library directory.


(cherry picked from commit 902259e)