### PR TITLE
appstream-dart-flathub-catalog: add recipe for appstream_dart example app

### DIFF
--- a/dynamic-layers/clang-layer/recipes-graphics/flutter-apps/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
+++ b/dynamic-layers/clang-layer/recipes-graphics/flutter-apps/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
@@ -1,0 +1,143 @@
+#
+# Copyright (c) 2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2026 Ahmed Wafdy. All rights reserved.
+#
+SUMMARY = "flathub_catalog"
+DESCRIPTION = "Flutter Linux desktop app demonstrating the appstream_dart package."
+AUTHOR = "Joel Winarske"
+HOMEPAGE = "https://github.com/meta-flutter/appstream_dart"
+BUGTRACKER = "https://github.com/meta-flutter/appstream_dart/issues"
+SECTION = "graphics"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=641bdc36389b26ea9787acb6844e4b22"
+
+SRCREV = "ff1840cf8139af72c45f8ff5e1c85182bb2c5ad9"
+SRC_URI = "gitsm://github.com/meta-flutter/appstream_dart.git;branch=main;protocol=https"
+
+S = "${WORKDIR}/git"
+
+DEPENDS += " \
+    compiler-rt \
+    libcxx \
+    ninja-native \
+    sqlite3 \
+"
+
+FLUTTER_APPLICATION_PATH = "example/flathub_catalog"
+PUBSPEC_APPNAME = "flathub_catalog"
+FLUTTER_APPLICATION_INSTALL_SUFFIX = "appstream-dart-example-flathub-catalog"
+
+TOOLCHAIN = "clang"
+TOOLCHAIN_NATIVE = "clang"
+TC_CXX_RUNTIME = "llvm"
+PREFERRED_PROVIDER_llvm = "clang"
+PREFERRED_PROVIDER_llvm-native = "clang-native"
+PREFERRED_PROVIDER_libgcc = "compiler-rt"
+LIBCPLUSPLUS = "-stdlib=libc++"
+
+# Order matters: cmake must be inherited before flutter-app so that
+# flutter-app's do_compile (flutter build) and do_install (bundle install)
+# win over cmake's EXPORT_FUNCTIONS versions. cmake still provides
+# do_configure (its sole definer) and cmake_do_compile, used by the
+# do_cmake_compile task below to build libappstream.so for the target.
+inherit cmake flutter-app pkgconfig
+
+# scarthgap's flutter-app.inc defaults FLUTTER_BUILD_ARGS to "bundle" with no
+# --target-platform, so `flutter build` resolves native assets for the default
+# (android) target: the bundled NativeAssetsManifest.json lists the sqlite3
+# system asset under android_arm instead of linux_arm64, and the app fails at
+# runtime with "No available native assets" when drift opens the DB. Force the
+# Linux target arch (aarch64 -> arm64) so the asset lands under linux_arm64.
+# Newer meta-flutter does this in the class; backport it here via gn-utils.
+require conf/include/gn-utils.inc
+FLUTTER_BUILD_ARGS:append = " --target-platform linux-${@gn_target_arch_name(d)}"
+
+# APPSTREAM_HOOK_BUILD=ON keeps libappstream.so in the CMake build dir (${B}),
+# where do_install picks it up, instead of staging it into the source tree.
+# BUILD_TESTING=OFF avoids building the C++ test suite for the target.
+EXTRA_OECMAKE += "\
+    -D BUILD_TESTING=OFF \
+    -D APPSTREAM_HOOK_BUILD=ON \
+"
+
+# appstream_dart's native-asset hook runs its own CMake build during `flutter
+# build`; we want it to stand down so do_cmake_compile (cmake.bbclass, with the
+# OE cross toolchain) is the single producer of libappstream.so. Dart runs
+# native-asset hooks in a hermetic environment, so an env var would never reach
+# the hook; instead the hook (>= SRCREV ff1840c, PR #10) reads a 'skip_native_build'
+# hooks user-define, which do_inject_user_defines adds to pubspec.yaml below (the
+# same channel used for sqlite3).
+
+# The sqlite3 Dart package (pulled in via drift) defaults to downloading a
+# prebuilt libsqlite3 from GitHub during `flutter build`, which fails in the
+# network-isolated do_compile. Tell its build hook to resolve sqlite3 from the
+# system library instead (DynamicLoadingSystem -> dlopen libsqlite3.so at
+# runtime). user_defines are read from the app being built and must live in its
+# pubspec.yaml -- pubspec_overrides.yaml only accepts dependency_overrides /
+# resolution / workspace, so append the hooks section to pubspec.yaml itself.
+#
+# Run as a dedicated task between do_patch and do_archive_pub_cache so the edit
+# is in place before do_archive_pub_cache performs the first, network-enabled
+# dependency resolution. (do_patch itself is a python task, so it cannot take a
+# shell :append.) Editing pubspec.yaml after that first resolution makes the
+# offline pub get in do_compile re-resolve, which tries to fetch security
+# advisories from pub.dev and fails with no network. The added hooks section
+# carries no dependency change, so the lockfile is unaffected.
+do_inject_user_defines() {
+    # Remove any pubspec_overrides.yaml a prior build of this recipe may have
+    # left behind: pub rejects a `hooks:` section there, and a stale one breaks
+    # `flutter pub get` even after the source is otherwise unchanged.
+    rm -f ${S}/${FLUTTER_APPLICATION_PATH}/pubspec_overrides.yaml
+    if ! grep -q '^hooks:' ${S}/${FLUTTER_APPLICATION_PATH}/pubspec.yaml; then
+        cat >> ${S}/${FLUTTER_APPLICATION_PATH}/pubspec.yaml <<'EOF'
+
+hooks:
+  user_defines:
+    sqlite3:
+      source: system
+    appstream_dart:
+      skip_native_build: true
+EOF
+    fi
+}
+addtask inject_user_defines after do_patch before do_archive_pub_cache
+do_inject_user_defines[dirs] = "${S}"
+
+# libsqlite3.so is resolved from the system at runtime (sqlite3 source: system
+# above, and libappstream.so links it), so it must be present on the image.
+RDEPENDS:${PN} += "libsqlite3"
+
+#
+# avoid conflict with flutter-app's do_compile
+#
+
+python do_cmake_compile() {
+    bb.build.exec_func('cmake_do_compile', d)
+}
+addtask cmake_compile after do_compile before do_install
+do_cmake_compile[dirs] = "${B}"
+
+#
+# append to flutter-app's do_install()
+#
+do_install:append() {
+    install -d ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib
+    cp ${B}/libappstream.so \
+        ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/
+
+    # Dart looks for libsqite3.so
+    ln -sf /usr/lib/libsqlite3.so.0 \
+        ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/libsqlite3.so
+}
+
+FILES:${PN} += "\
+    ${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/ \
+"
+
+FILES:${PN}-dbg += "\
+    ${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib/.debug/libappstream.so \
+"
+
+INSANE_SKIP:${PN} += " libdir"
+INSANE_SKIP:${PN}-dbg += " libdir"


### PR DESCRIPTION
Add a Flutter Linux desktop recipe building the `flathub_catalog` example from [meta-flutter/appstream_dart](https://github.com/meta-flutter/appstream_dart) (pinned to v0.3.0, SRCREV `ff1840c`).

The app combines a Flutter bundle with a CMake-built native library (`libappstream.so`) and a drift/sqlite3 stack, which needs several pieces of wiring to build offline under OE:

- Inherit `cmake` before `flutter-app` so flutter-app's `do_compile`/`do_install` win, while reusing cmake's `do_configure` and `cmake_do_compile` to build `libappstream.so` for the target via a dedicated `do_cmake_compile` task.
- Force the Linux target arch into `FLUTTER_BUILD_ARGS` so native assets resolve under `linux_arm64` rather than the default android target.
- Inject a pubspec.yaml `hooks`/`user_defines` section (sqlite3 `source: system`, appstream_dart `skip_native_build`) in a task between `do_patch` and `do_archive_pub_cache`, so the network-isolated `do_compile` resolves sqlite3 from the system lib and skips the package's own native build.
- Install `libappstream.so` into the bundle, symlink `libsqlite3.so`, and RDEPEND on `libsqlite3`.