### PR TITLE
appstream-dart-flathub-catalog: skip native build via hooks user-define

### DIFF
--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
@@ -89,13 +89,9 @@ EOF
 addtask inject_user_defines after do_patch before do_archive_pub_cache
 do_inject_user_defines[dirs] = "${S}"
 
-# The sqlite3 Dart package (source: system) resolves libsqlite3 via
-# dlopen("libsqlite3.so") at runtime; the do_install:append below provides
-# that unversioned name in the bundle lib dir, pointing at the system
-# libsqlite3.so.0. Depend on the runtime shared-library package that ships it.
-# Use libsqlite3-0, not the bare "libsqlite3" name, which resolves to
-# libsqlite3-dev and trips the dev-deps QA check.
-RDEPENDS:${PN} += "libsqlite3-0"
+# libsqlite3.so is resolved from the system at runtime (sqlite3 source: system
+# above, and libappstream.so links it), so it must be present on the image.
+RDEPENDS:${PN} += "libsqlite3"
 
 #
 # avoid conflict with flutter-app's do_compile

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-appstream-dart-flathub-catalog_0.3.0.bb
@@ -12,7 +12,7 @@ SECTION = "graphics"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=641bdc36389b26ea9787acb6844e4b22"
 
-SRCREV = "c53d5c8a9ba048cdca572ba41fb517a830a3b9aa"
+SRCREV = "ff1840cf8139af72c45f8ff5e1c85182bb2c5ad9"
 SRC_URI = "gitsm://github.com/meta-flutter/appstream_dart.git;branch=main;protocol=https"
 
 DEPENDS += " \
@@ -50,11 +50,13 @@ EXTRA_OECMAKE += "\
     -D APPSTREAM_HOOK_BUILD=ON \
 "
 
-# The appstream_dart build hook runs its own CMake build during `flutter
-# build`. SKIP_NATIVE_BUILD makes it stand down so do_cmake_compile
-# (cmake.bbclass, with the OE cross toolchain) is the single producer of
-# libappstream.so for the target.
-export SKIP_NATIVE_BUILD = "1"
+# appstream_dart's native-asset hook runs its own CMake build during `flutter
+# build`; we want it to stand down so do_cmake_compile (cmake.bbclass, with the
+# OE cross toolchain) is the single producer of libappstream.so. Dart runs
+# native-asset hooks in a hermetic environment, so an env var would never reach
+# the hook; instead the hook (>= SRCREV ff1840c, PR #10) reads a 'skip_native_build'
+# hooks user-define, which do_inject_user_defines adds to pubspec.yaml below (the
+# same channel used for sqlite3).
 
 # The sqlite3 Dart package (pulled in via drift) defaults to downloading a
 # prebuilt libsqlite3 from GitHub during `flutter build`, which fails in the
@@ -83,6 +85,8 @@ hooks:
   user_defines:
     sqlite3:
       source: system
+    appstream_dart:
+      skip_native_build: true
 EOF
     fi
 }


### PR DESCRIPTION
## Summary

The `SKIP_NATIVE_BUILD` env var never reached appstream_dart's native-asset hook, since Dart runs hooks in a hermetic environment. This switches to the `skip_native_build` hooks user-define, injected into `pubspec.yaml` by `do_inject_user_defines` (the same channel already used for sqlite3), so the hook stands down and `do_cmake_compile` remains the single producer of `libappstream.so` for the target.

Requires appstream_dart >= `ff1840c` (PR #10), which reads the user-define; SRCREV is bumped accordingly.

Also included: revert of the earlier libsqlite3-0 dependency/symlink change.

## Test plan

- Build the recipe and confirm `libappstream.so` is produced solely by `do_cmake_compile` (cross toolchain), with the native-asset hook standing down.