### PR TITLE
sony-flutter: replace EXCLUDE_FROM_SHLIBS with PRIVATE_LIBS

### DIFF
--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -67,7 +67,6 @@ do_configure:prepend() {
     ln -sf ${FLUTTER_ENGINE_PATH}/lib/libflutter_engine.so ${S}/build/libflutter_engine.so
 }
 
-do_package_qa[noexec] = "1"
 PRIVATE_LIBS:${PN} = "libflutter_engine.so"
 
 RDEPENDS:${PN} += "flutter-engine"

--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -68,7 +68,7 @@ do_configure:prepend() {
 }
 
 do_package_qa[noexec] = "1"
-EXCLUDE_FROM_SHLIBS = "1"
+PRIVATE_LIBS:${PN} = "libflutter_engine.so"
 
 RDEPENDS:${PN} += "flutter-engine"
 


### PR DESCRIPTION
EXCLUDE_FROM_SHLIBS = "1" disables the whole shlibs scan for the sony embedders, so packages like flutter-wayland-client end up with no RDEPENDS on their EGL/wayland providers and fail at runtime in images where nothing else pulls them in.

The variable was only there to avoid "Multiple shlib providers" errors on libflutter_engine.so, which the engine installs once per runtime mode:
```
ERROR: flutter-wayland-client: Multiple shlib providers for libflutter_engine.so:
flutter-engine, flutter-engine, flutter-engine (used by files: .../usr/bin/flutter-client)
```
PRIVATE_LIBS skips just that soname while keeping the rest of the scan. Before/after on qemuarm64 with the default engine PACKAGECONFIG (debug profile release):
```
before: RDEPENDS: flutter-engine libuv libxkbcommon xkeyboard-config
after:  RDEPENDS: flutter-engine libuv libxkbcommon (>= 1.13.1) xkeyboard-config
          glibc libegl-mesa (>= 26.0.6) libgcc libstdc++ wayland (>= 1.25.0)
```
 With the dependencies fixed, do_package_qa also passes, so the second commit re-enables it.