### PR TITLE
sony-flutter: replace EXCLUDE_FROM_SHLIBS with PRIVATE_LIBS

### DIFF
--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -67,7 +67,6 @@ do_configure:prepend() {
     ln -sf ${FLUTTER_ENGINE_PATH}/lib/libflutter_engine.so ${S}/build/libflutter_engine.so
 }
 
-do_package_qa[noexec] = "1"
 PRIVATE_LIBS:${PN} = "libflutter_engine.so"
 
 RDEPENDS:${PN} += "flutter-engine"

--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -68,7 +68,7 @@ do_configure:prepend() {
 }
 
 do_package_qa[noexec] = "1"
-EXCLUDE_FROM_SHLIBS = "1"
+PRIVATE_LIBS:${PN} = "libflutter_engine.so"
 
 RDEPENDS:${PN} += "flutter-engine"
 


### PR DESCRIPTION
Backport of #764 to wrynose. 
As discussed in #764, opening the wrynose backport here.

The same lines are present here and
flutter-engine still installs per runtime mode, so dropping
EXCLUDE_FROM_SHLIBS the naive way trips the same error:

Multiple shlib providers for libflutter_engine.so:
flutter-engine, flutter-engine, flutter-engine

PRIVATE_LIBS skips just that soname and restores the rest of the
shlibs scan.