### PR TITLE
sony-flutter: replace EXCLUDE_FROM_SHLIBS with PRIVATE_LIBS

### DIFF
--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -69,7 +69,6 @@ do_configure:prepend() {
     ln -sf ${FLUTTER_ENGINE_PATH}/lib/libflutter_engine.so ${S}/build/libflutter_engine.so
 }
 
-do_package_qa[noexec] = "1"
 PRIVATE_LIBS:${PN} = "libflutter_engine.so"
 
 RDEPENDS:${PN} += "flutter-engine"

--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -70,7 +70,7 @@ do_configure:prepend() {
 }
 
 do_package_qa[noexec] = "1"
-EXCLUDE_FROM_SHLIBS = "1"
+PRIVATE_LIBS:${PN} = "libflutter_engine.so"
 
 RDEPENDS:${PN} += "flutter-engine"
 


### PR DESCRIPTION
Backport of #764 to kirkstone.
The EXCLUDE_FROM_SHLIBS / do_package_qa lines are present and the engine
installs per mode, so dropping EXCLUDE_FROM_SHLIBS naively trips
"Multiple shlib providers for libflutter_engine.so". PRIVATE_LIBS skips
that soname and restores the rest of the scan.

Tested 
on poky kirkstone
qemux86-64. flutter-wayland-client RDEPENDS gains
libegl-mesa (>= 22.0.3) and wayland, and do_package/QA are clean.
