### PR TITLE
ci: re-clone every layer and fail the fetch step on clone errors

### DIFF
--- a/.github/workflows/qemuarm-linux-dummy.yml
+++ b/.github/workflows/qemuarm-linux-dummy.yml
@@ -52,13 +52,32 @@ jobs:
           # cloned at. poky is kept to clear any legacy checkout.
           rm -rf poky bitbake openembedded-core meta-yocto \
                  meta-openembedded meta-drm meta-vulkan
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/bitbake.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/openembedded-core.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/openembedded/meta-openembedded.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-drm.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-vulkan.git &
-          wait
+          # 'wait' with no operands always returns 0, so a failed clone used to
+          # leave the step green and the build ran against a missing or stale
+          # layer. Collect the pids and wait on each one so the exit status is
+          # actually observed.
+          pids=""
+          for repo in \
+              https://git.openembedded.org/bitbake.git \
+              https://git.openembedded.org/openembedded-core.git \
+              https://git.yoctoproject.org/meta-yocto.git \
+              https://github.com/openembedded/meta-openembedded.git \
+              https://github.com/jwinarske/meta-drm.git \
+              https://github.com/jwinarske/meta-vulkan.git ; do
+              git clone -b ${{ env.YOCTO_BRANCH }} --single-branch "$repo" &
+              pids="$pids $!:$repo"
+          done
+
+          rc=0
+          for entry in $pids; do
+              pid=${entry%%:*}
+              repo=${entry#*:}
+              if ! wait "$pid"; then
+                  echo "::error::clone failed: $repo"
+                  rc=1
+              fi
+          done
+          exit $rc
 
       - name: Configure build
         shell: bash

--- a/.github/workflows/qemuarm-linux-dummy.yml
+++ b/.github/workflows/qemuarm-linux-dummy.yml
@@ -44,12 +44,18 @@ jobs:
           cd ../master-linux-dummy
           pwd
           ls -la
-          rm -rf poky meta-openembedded meta-drm meta-vulkan
+          # every layer cloned below must be listed here: this is a
+          # persistent self-hosted runner, and 'git clone' into an
+          # existing directory fails. Those failures are swallowed by
+          # the backgrounded clones and bare 'wait', so an omitted
+          # layer silently freezes at whatever revision it was first
+          # cloned at. poky is kept to clear any legacy checkout.
+          rm -rf poky bitbake openembedded-core meta-yocto \
+                 meta-openembedded meta-drm meta-vulkan
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/bitbake.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/openembedded-core.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/openembedded/meta-openembedded.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-drm.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-vulkan.git &
           wait

--- a/.github/workflows/qemuarm64-linux-dummy.yml
+++ b/.github/workflows/qemuarm64-linux-dummy.yml
@@ -52,13 +52,32 @@ jobs:
           # cloned at. poky is kept to clear any legacy checkout.
           rm -rf poky bitbake openembedded-core meta-yocto \
                  meta-openembedded meta-drm meta-vulkan
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/bitbake.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/openembedded-core.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/openembedded/meta-openembedded.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-drm.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-vulkan.git &
-          wait
+          # 'wait' with no operands always returns 0, so a failed clone used to
+          # leave the step green and the build ran against a missing or stale
+          # layer. Collect the pids and wait on each one so the exit status is
+          # actually observed.
+          pids=""
+          for repo in \
+              https://git.openembedded.org/bitbake.git \
+              https://git.openembedded.org/openembedded-core.git \
+              https://git.yoctoproject.org/meta-yocto.git \
+              https://github.com/openembedded/meta-openembedded.git \
+              https://github.com/jwinarske/meta-drm.git \
+              https://github.com/jwinarske/meta-vulkan.git ; do
+              git clone -b ${{ env.YOCTO_BRANCH }} --single-branch "$repo" &
+              pids="$pids $!:$repo"
+          done
+
+          rc=0
+          for entry in $pids; do
+              pid=${entry%%:*}
+              repo=${entry#*:}
+              if ! wait "$pid"; then
+                  echo "::error::clone failed: $repo"
+                  rc=1
+              fi
+          done
+          exit $rc
 
       - name: Configure build
         shell: bash

--- a/.github/workflows/qemuarm64-linux-dummy.yml
+++ b/.github/workflows/qemuarm64-linux-dummy.yml
@@ -44,12 +44,18 @@ jobs:
           cd ../master-linux-dummy
           pwd
           ls -la
-          rm -rf poky meta-openembedded meta-drm meta-vulkan
+          # every layer cloned below must be listed here: this is a
+          # persistent self-hosted runner, and 'git clone' into an
+          # existing directory fails. Those failures are swallowed by
+          # the backgrounded clones and bare 'wait', so an omitted
+          # layer silently freezes at whatever revision it was first
+          # cloned at. poky is kept to clear any legacy checkout.
+          rm -rf poky bitbake openembedded-core meta-yocto \
+                 meta-openembedded meta-drm meta-vulkan
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/bitbake.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/openembedded-core.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/openembedded/meta-openembedded.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-drm.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-vulkan.git &
           wait

--- a/.github/workflows/qemuriscv64.yml
+++ b/.github/workflows/qemuriscv64.yml
@@ -52,13 +52,32 @@ jobs:
           # cloned at. poky is kept to clear any legacy checkout.
           rm -rf poky bitbake openembedded-core meta-yocto \
                  meta-openembedded meta-drm meta-vulkan
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/bitbake.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/openembedded-core.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/openembedded/meta-openembedded.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-drm.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-vulkan.git &
-          wait
+          # 'wait' with no operands always returns 0, so a failed clone used to
+          # leave the step green and the build ran against a missing or stale
+          # layer. Collect the pids and wait on each one so the exit status is
+          # actually observed.
+          pids=""
+          for repo in \
+              https://git.openembedded.org/bitbake.git \
+              https://git.openembedded.org/openembedded-core.git \
+              https://git.yoctoproject.org/meta-yocto.git \
+              https://github.com/openembedded/meta-openembedded.git \
+              https://github.com/jwinarske/meta-drm.git \
+              https://github.com/jwinarske/meta-vulkan.git ; do
+              git clone -b ${{ env.YOCTO_BRANCH }} --single-branch "$repo" &
+              pids="$pids $!:$repo"
+          done
+
+          rc=0
+          for entry in $pids; do
+              pid=${entry%%:*}
+              repo=${entry#*:}
+              if ! wait "$pid"; then
+                  echo "::error::clone failed: $repo"
+                  rc=1
+              fi
+          done
+          exit $rc
 
       - name: Configure build
         shell: bash

--- a/.github/workflows/qemuriscv64.yml
+++ b/.github/workflows/qemuriscv64.yml
@@ -44,12 +44,18 @@ jobs:
           cd ../master-linux-dummy
           pwd
           ls -la
-          rm -rf poky meta-openembedded meta-drm meta-vulkan
+          # every layer cloned below must be listed here: this is a
+          # persistent self-hosted runner, and 'git clone' into an
+          # existing directory fails. Those failures are swallowed by
+          # the backgrounded clones and bare 'wait', so an omitted
+          # layer silently freezes at whatever revision it was first
+          # cloned at. poky is kept to clear any legacy checkout.
+          rm -rf poky bitbake openembedded-core meta-yocto \
+                 meta-openembedded meta-drm meta-vulkan
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/bitbake.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/openembedded-core.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/openembedded/meta-openembedded.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-drm.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-vulkan.git &
           wait

--- a/.github/workflows/qemux86-64-linux-dummy.yml
+++ b/.github/workflows/qemux86-64-linux-dummy.yml
@@ -52,13 +52,32 @@ jobs:
           # cloned at. poky is kept to clear any legacy checkout.
           rm -rf poky bitbake openembedded-core meta-yocto \
                  meta-openembedded meta-drm meta-vulkan
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/bitbake.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/openembedded-core.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/openembedded/meta-openembedded.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-drm.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-vulkan.git &
-          wait
+          # 'wait' with no operands always returns 0, so a failed clone used to
+          # leave the step green and the build ran against a missing or stale
+          # layer. Collect the pids and wait on each one so the exit status is
+          # actually observed.
+          pids=""
+          for repo in \
+              https://git.openembedded.org/bitbake.git \
+              https://git.openembedded.org/openembedded-core.git \
+              https://git.yoctoproject.org/meta-yocto.git \
+              https://github.com/openembedded/meta-openembedded.git \
+              https://github.com/jwinarske/meta-drm.git \
+              https://github.com/jwinarske/meta-vulkan.git ; do
+              git clone -b ${{ env.YOCTO_BRANCH }} --single-branch "$repo" &
+              pids="$pids $!:$repo"
+          done
+
+          rc=0
+          for entry in $pids; do
+              pid=${entry%%:*}
+              repo=${entry#*:}
+              if ! wait "$pid"; then
+                  echo "::error::clone failed: $repo"
+                  rc=1
+              fi
+          done
+          exit $rc
 
       - name: Configure build
         shell: bash

--- a/.github/workflows/qemux86-64-linux-dummy.yml
+++ b/.github/workflows/qemux86-64-linux-dummy.yml
@@ -44,12 +44,18 @@ jobs:
           cd ../master-linux-dummy
           pwd
           ls -la
-          rm -rf poky meta-openembedded meta-drm meta-vulkan
+          # every layer cloned below must be listed here: this is a
+          # persistent self-hosted runner, and 'git clone' into an
+          # existing directory fails. Those failures are swallowed by
+          # the backgrounded clones and bare 'wait', so an omitted
+          # layer silently freezes at whatever revision it was first
+          # cloned at. poky is kept to clear any legacy checkout.
+          rm -rf poky bitbake openembedded-core meta-yocto \
+                 meta-openembedded meta-drm meta-vulkan
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/bitbake.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.openembedded.org/openembedded-core.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/openembedded/meta-openembedded.git &
-          git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://git.yoctoproject.org/meta-yocto.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-drm.git &
           git clone -b ${{ env.YOCTO_BRANCH }} --single-branch https://github.com/jwinarske/meta-vulkan.git &
           wait


### PR DESCRIPTION
Two fixes to the `Fetch poky` step, which can now land independently of #773.

### 1. Re-clone every layer the step clones

`rm -rf` covered only `poky meta-openembedded meta-drm meta-vulkan`, but the step also clones `bitbake`, `openembedded-core` and `meta-yocto`. On a persistent self-hosted runner those directories survive between runs, so their clones fail:

```
fatal: destination path 'openembedded-core' already exists and is not an empty directory.
```

Because the clones are backgrounded and waited on with a bare `wait` (see below), those failures were swallowed and the build silently proceeded against whatever revision the layer was *first* cloned at. `openembedded-core` had been frozen since **2026-06-13, 1047 commits behind master, still on glibc 2.43** — which failed to compile for armv7 and blocked the `qemuarm` job.

`poky` is kept in the list to clear any legacy checkout, though nothing clones it any more. The duplicate `meta-yocto` clone is also dropped — it always failed with the same "already exists" error against its own sibling.

### 2. Fail the step when a clone fails

`wait` with no operands always returns 0, so a failed clone left the step green. Fix (1) removes the cause we hit; this removes the class — a transient network failure would still be swallowed identically.

Collect the clone pids, `wait` on each individually, and report which repository failed via a `::error::` annotation so it surfaces in the job summary.

**Verified** against a stub `git`, both directions: one failing clone names the correct repository and exits 1; an all-success run exits 0. The guarded `if ! wait` is safe under the default `bash -e` shell. YAML validated on all four workflows.

**Behavior change, deliberately:** a transient clone failure now fails the job rather than producing a build against incomplete sources. A red job is recoverable with a rerun; a silently wrong one is not.

Both commits must go together — strict checking without fix (1) would fail on every run, since the stale directories and the duplicate clone both fail by construction.