### PR TITLE
gn-fetcher: support premirrors

### DIFF
--- a/lib/gn.py
+++ b/lib/gn.py
@@ -18,6 +18,7 @@ import urllib
 from   bb.fetch2 import FetchMethod
 from   bb.fetch2 import FetchError
 from   bb.fetch2 import UnpackError
+from   bb.fetch2 import trusted_network
 from   bb.fetch2 import logger
 from   bb.fetch2 import runfetchcmd
 from   bb.fetch2 import subprocess_setup
@@ -97,6 +98,17 @@ class GN(FetchMethod):
 
         ud.localfile = d.getVar("PN") + '-' + d.getVar("PV") + "-" + srcrev + "-" + config_hash + ".tar.bz2"
         ud.localpath = os.path.join(d.getVar("WORKDIR"), ud.localfile)
+
+        # The packed tree is the only artifact this fetcher produces, so it is
+        # also the thing worth mirroring. Naming it here lets bitbake build
+        # mirror URIs against the tarball filename rather than against the gn://
+        # url, which is what makes PREMIRRORS/MIRRORS usable -- and with it
+        # BB_FETCH_PREMIRRORONLY, so a build with no access to the upstream
+        # repositories can still fetch. Unlike the git fetcher there is no
+        # separate clone directory to mirror alongside it, so there is nothing
+        # for BB_GENERATE_MIRROR_TARBALLS to gate: the tarball is always written.
+        ud.fullmirror = os.path.join(d.getVar("DL_DIR"), ud.localfile)
+        ud.mirrortarballs = [ud.localfile]
 
         ud.trying_to_fetch_with_gclient = False
 
@@ -182,6 +194,24 @@ class GN(FetchMethod):
         runfetchcmd(ud.packcmd, d, quiet, workdir=None)
 
         ud.trying_to_fetch_with_gclient = False
+
+    def supports_checksum(self, urldata):
+        # The tarball is repacked from a gclient sync and is not bit-identical
+        # between runs -- the tree keeps its .git directories, which the flutter
+        # build needs for git rev-parse. Like the other VCS fetchers, this one
+        # cannot offer a stable SRC_URI checksum.
+        return False
+
+    def try_premirror(self, ud, d):
+        # Without this, a premirror-only build cannot fetch at all.
+        if bb.utils.to_boolean(d.getVar("BB_FETCH_PREMIRRORONLY")):
+            return True
+        # Going upstream is destined to fail when the network is untrusted, so
+        # consult premirrors first.
+        if not trusted_network(d, ud.url):
+            return True
+        # Otherwise only bother when we do not already have the tarball.
+        return not os.path.exists(ud.localpath)
 
     def localpath(self, ud, d):
         """


### PR DESCRIPTION
The gn fetcher never told bitbake that the tree it packs is a mirrorable artifact, so `PREMIRRORS`/`MIRRORS` were only matched against the `gn://` url itself. In practice they didn't apply, `BB_FETCH_PREMIRRORONLY` couldn't be satisfied, and a build without access to the upstream repositories couldn't fetch the engine at all.

### Change

- **`ud.mirrortarballs`** — set to the packed tarball name, so bitbake builds mirror uris against that filename rather than the `gn://` url. Unlike the git fetcher there's no separate clone dir to mirror alongside it, so nothing for `BB_GENERATE_MIRROR_TARBALLS` to gate; the tarball is always written.
- **`supports_checksum() → False`** — the tarball is repacked from a gclient sync and isn't bit-identical between runs, because the tree keeps the `.git` directories the flutter build needs for `git rev-parse`. Same position as the other VCS fetchers.
- **`try_premirror()`** — follows the git fetcher: always consult premirrors under `BB_FETCH_PREMIRRORONLY` or an untrusted network, otherwise only when the tarball isn't already in `DL_DIR`.

### Verified end to end

With a local mirror seeded and **both `BB_NO_NETWORK=1` and `BB_FETCH_PREMIRRORONLY=1`**:

```
NOTE: recipe flutter-engine-3.47.1-r0: task do_fetch: Succeeded
downloads/flutter-engine-3.47.1-<srcrev>-<confighash>.tar.bz2 -> <mirror>/flutter/...
```

Before the change, the identical configuration fell through to `Trying Upstream` and failed with `NetworkAccess('gn://github.com/flutter/flutter.git', ...)`.

### Writing the mirror entry

Two things worth knowing, both found while testing:

1. oe-core's mirror sanity check (`meta/lib/oe/sanity.py`) has a **hardcoded protocol list** predating out-of-tree fetchers, without `gn` — so naming `gn://` explicitly warns. Use the generic `.*://.*` pattern, as OE's own default `PREMIRRORS` does.
2. The mirror layout follows the url path, so the tarball for `gn://github.com/flutter/flutter.git` belongs under `<mirror>/flutter/`.

### Relationship to #269

The premirror groundwork was proposed in #269 by @camaronut; this reimplements it against the current fetcher, which has since gained `gclient_config`, `EXTRA_GN_SYNC` and the config hash from #773.

The **reproducibility half of #269 is deliberately left out**:
- The tarball can't be made reproducible while the `.git` directories have to stay — the premise doesn't hold (see #271).
- The `.packages` and `package_config.json` files it rewrote **no longer exist** in a current engine tree (checked a 3.47.1 tree: zero of each). `.packages` has been deprecated in Dart for years.
- `SOURCE_DATE_EPOCH` isn't meaningful during `do_fetch` — `do_deploy_source_date_epoch` is `addtask ... after do_patch`, so `urldata_init` would get the fallback, not a real epoch.
- Rewriting files during fetch also mutates a tree that's now cached under a key that knows nothing about those edits.

**Depends on #773** (based on `jw/flutter-3.47.1-ihs-v3`), which rewrites the same `ud.localfile` line. GitHub will retarget to `master` when #773 merges.