### PR TITLE
ci: run runner-maintenance without a container

### DIFF
--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -35,28 +35,18 @@ jobs:
 
   maintenance:
 
+    # Deliberately no container: this needs no build image, and a container
+    # job bind-mounts _work/_actions, which only exists once a workflow has
+    # used an action. Running natively on the runner avoids that entirely and
+    # is already the uid that owns the tree.
     runs-on: [self-hosted, linux]
-
-    container:
-      image: ghcr.io/meta-flutter/meta-flutter/ubuntu-24-dev:main
-      options:
-        --read-only
-        --log-driver=none
-        --user 1001:1001
-        --userns keep-id:uid=1001,gid=1001
-        --security-opt label=disable
-        --pids-limit=-1
-        --storage-opt overlay.mount_program=/usr/bin/fuse-overlayfs
-        --storage-opt overlay.mountopt=nodev,metacopy=on,noxattrs=1
-        -v /mnt/raid10/github-ci/download:/home/dev/dl:Z
-        -v /mnt/raid10/github-ci/sstate:/home/dev/sstate:Z
 
     steps:
 
       - name: Report
         shell: bash
         run: |
-          BUILD=../master-linux-dummy/build
+          BUILD="${GITHUB_WORKSPACE}/../master-linux-dummy/build"
           echo "runner user: $(id -un) ($(id -u))"
           if [ ! -d "$BUILD" ]; then
             echo "::notice::$BUILD does not exist, nothing to do"
@@ -81,7 +71,7 @@ jobs:
             echo "::error::action=wipe-tmp requires confirm=wipe; nothing removed"
             exit 1
           fi
-          BUILD=../master-linux-dummy/build
+          BUILD="${GITHUB_WORKSPACE}/../master-linux-dummy/build"
           if [ ! -d "$BUILD/tmp" ]; then
             echo "::notice::build/tmp already absent"
             exit 0


### PR DESCRIPTION
Fixes the first dispatch of #777, which failed before any step ran:

```
Error: statfs /mnt/raid10/actions-runner/_work/_actions: no such file or directory
##[error]Exit code 125 returned from process: file name '/usr/bin/docker'
```

### Cause

A container job bind-mounts `_work/_actions`, which the runner only materialises once a workflow has used an action. Every other workflow here opens with `actions/checkout@v4`, so it's normally present — `runner-maintenance` has no `uses:` step and hit the gap. Confirmed `_work/_actions` is absent on the runner right now.

### Fix

Adding a checkout would paper over it, but the container earns nothing here: this job needs no build image, no sysroots, no toolchain — only `du`, `find` and `rm`. Dropping it removes the image pull *and* the bind-mounts along with the failure, and it still runs as uid 1001, which owns the tree.

Also references the build tree through `$GITHUB_WORKSPACE` rather than a relative path, since without a checkout nothing guarantees the working directory.

Everything else is unchanged: still defaults to `report`, still requires `confirm=wipe` for the destructive path, path still fixed in the workflow rather than an input.

Unblocks the `build/tmp` cleanup that `qemuarm`/`qemuarm64` on #773 need.