### PR TITLE
ci-build: rename DISTRO_FEATURES_BACKFILL_CONSIDERED

### DIFF
--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -16,7 +16,7 @@ INIT_MANAGER = "systemd"
 DISTRO_FEATURES:remove = "sysvinit usbgadget ptest xen"
 DISTRO_FEATURES:append = " systemd x11 wayland opengl pam polkit pipewire pulseaudio"
 
-DISTRO_FEATURES_BACKFILL_CONSIDERED = ""
+DISTRO_FEATURES_OPTED_OUT = ""
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
 


### PR DESCRIPTION
**Every pull request against `master` is currently failing CI**, including #778. One line fixes it.

```
ERROR: Variable DISTRO_FEATURES_BACKFILL_CONSIDERED has been renamed to
DISTRO_FEATURES_OPTED_OUT (file: .../meta-flutter/conf/distro/include/ci-build.inc)
```

All four jobs die in `Configure build` after ~35s, before bitbake starts.

### Why now

This has been latent since oe-core did the rename. CI couldn't see it because `openembedded-core` was pinned at a **2026-06-13** revision — the fetch step's `rm -rf` omitted it, so the clone failed silently every run and the stale checkout was reused.

#774 fixed that. The layer is now re-cloned each run, CI gets a current oe-core, and the old variable name fails immediately. So this is #774 working as designed and surfacing a real incompatibility, not a regression from it.

### The change

```diff
-DISTRO_FEATURES_BACKFILL_CONSIDERED = ""
+DISTRO_FEATURES_OPTED_OUT = ""
```

Value unchanged — an empty opt-out list, i.e. nothing excluded from backfill.

The same commit is part of #773, but that's a large branch and this single line is what unblocks everything else. Cherry-picked from it, so #773 will drop it automatically on rebase.