### PR TITLE
ci: unblock master and stop trivial changes triggering full builds

### DIFF
--- a/.github/workflows/qemuarm-linux-dummy.yml
+++ b/.github/workflows/qemuarm-linux-dummy.yml
@@ -3,6 +3,17 @@ name: master-qemuarm-linux-dummy
 on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
+    # Each job is a 45-60 minute build and the runner is sequential, so one
+    # pull request costs several hours of runner time. Skip that for changes
+    # that cannot affect a build. Anything under conf/, classes/, lib/,
+    # recipes-*/ or the build workflows themselves still triggers a full run.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'tools/**'
+      - '.github/workflows/runner-maintenance.yml'
+      - '.gitignore'
+      - 'LICENSE'
   release:
     types: [ published, created, edited ]
 

--- a/.github/workflows/qemuarm64-linux-dummy.yml
+++ b/.github/workflows/qemuarm64-linux-dummy.yml
@@ -3,6 +3,17 @@ name: master-qemuarm64-linux-dummy
 on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
+    # Each job is a 45-60 minute build and the runner is sequential, so one
+    # pull request costs several hours of runner time. Skip that for changes
+    # that cannot affect a build. Anything under conf/, classes/, lib/,
+    # recipes-*/ or the build workflows themselves still triggers a full run.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'tools/**'
+      - '.github/workflows/runner-maintenance.yml'
+      - '.gitignore'
+      - 'LICENSE'
   release:
     types: [ published, created, edited ]
 

--- a/.github/workflows/qemuriscv64.yml
+++ b/.github/workflows/qemuriscv64.yml
@@ -3,6 +3,17 @@ name: master-qemuriscv64
 on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
+    # Each job is a 45-60 minute build and the runner is sequential, so one
+    # pull request costs several hours of runner time. Skip that for changes
+    # that cannot affect a build. Anything under conf/, classes/, lib/,
+    # recipes-*/ or the build workflows themselves still triggers a full run.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'tools/**'
+      - '.github/workflows/runner-maintenance.yml'
+      - '.gitignore'
+      - 'LICENSE'
   release:
     types: [ published, created, edited ]
 

--- a/.github/workflows/qemux86-64-linux-dummy.yml
+++ b/.github/workflows/qemux86-64-linux-dummy.yml
@@ -3,6 +3,17 @@ name: master-qemux86-64-linux-dummy
 on:
   pull_request:
     types: [ opened, synchronize, reopened, closed ]
+    # Each job is a 45-60 minute build and the runner is sequential, so one
+    # pull request costs several hours of runner time. Skip that for changes
+    # that cannot affect a build. Anything under conf/, classes/, lib/,
+    # recipes-*/ or the build workflows themselves still triggers a full run.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'tools/**'
+      - '.github/workflows/runner-maintenance.yml'
+      - '.gitignore'
+      - 'LICENSE'
   release:
     types: [ published, created, edited ]
 

--- a/.github/workflows/runner-maintenance.yml
+++ b/.github/workflows/runner-maintenance.yml
@@ -35,28 +35,18 @@ jobs:
 
   maintenance:
 
+    # Deliberately no container: this needs no build image, and a container
+    # job bind-mounts _work/_actions, which only exists once a workflow has
+    # used an action. Running natively on the runner avoids that entirely and
+    # is already the uid that owns the tree.
     runs-on: [self-hosted, linux]
-
-    container:
-      image: ghcr.io/meta-flutter/meta-flutter/ubuntu-24-dev:main
-      options:
-        --read-only
-        --log-driver=none
-        --user 1001:1001
-        --userns keep-id:uid=1001,gid=1001
-        --security-opt label=disable
-        --pids-limit=-1
-        --storage-opt overlay.mount_program=/usr/bin/fuse-overlayfs
-        --storage-opt overlay.mountopt=nodev,metacopy=on,noxattrs=1
-        -v /mnt/raid10/github-ci/download:/home/dev/dl:Z
-        -v /mnt/raid10/github-ci/sstate:/home/dev/sstate:Z
 
     steps:
 
       - name: Report
         shell: bash
         run: |
-          BUILD=../master-linux-dummy/build
+          BUILD="${GITHUB_WORKSPACE}/../master-linux-dummy/build"
           echo "runner user: $(id -un) ($(id -u))"
           if [ ! -d "$BUILD" ]; then
             echo "::notice::$BUILD does not exist, nothing to do"
@@ -81,7 +71,7 @@ jobs:
             echo "::error::action=wipe-tmp requires confirm=wipe; nothing removed"
             exit 1
           fi
-          BUILD=../master-linux-dummy/build
+          BUILD="${GITHUB_WORKSPACE}/../master-linux-dummy/build"
           if [ ! -d "$BUILD/tmp" ]; then
             echo "::notice::build/tmp already absent"
             exit 0

--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -16,7 +16,7 @@ INIT_MANAGER = "systemd"
 DISTRO_FEATURES:remove = "sysvinit usbgadget ptest xen"
 DISTRO_FEATURES:append = " systemd x11 wayland opengl pam polkit pipewire pulseaudio"
 
-DISTRO_FEATURES_BACKFILL_CONSIDERED = ""
+DISTRO_FEATURES_OPTED_OUT = ""
 
 PREFERRED_PROVIDER_virtual/kernel = "linux-dummy"
 


### PR DESCRIPTION
Replaces #778 and #779, combined because each PR costs several hours of sequential runner time and these aren't worth three rounds of it.

**Merge without waiting for CI.** This PR's own checks will fail until it lands — that's the bug it fixes.

### 1. Unblock master (was #779)

```
ERROR: Variable DISTRO_FEATURES_BACKFILL_CONSIDERED has been renamed to
DISTRO_FEATURES_OPTED_OUT (file: .../conf/distro/include/ci-build.inc)
```

All four jobs die in `Configure build` after ~35s, before bitbake starts. **Every PR against master is blocked.**

```diff
-DISTRO_FEATURES_BACKFILL_CONSIDERED = ""
+DISTRO_FEATURES_OPTED_OUT = ""
```

Latent since oe-core did the rename — invisible while `openembedded-core` was pinned at a 2026-06-13 revision, fatal once #774 made the fetch step re-clone it. #774 working as designed.

### 2. Fix runner-maintenance (was #778)

Failed at `docker create` with exit 125: a container job bind-mounts `_work/_actions`, which the runner only creates once a workflow has used an action, and this one has no `uses:` step. The container earned nothing — the job needs `du`, `find`, `rm` — so it now runs natively on the runner, which is already uid 1001, the uid that owns the tree.

### 3. Stop trivial changes triggering four builds

```yaml
paths-ignore:
  - '**/*.md'
  - 'docs/**'
  - 'tools/**'
  - '.github/workflows/runner-maintenance.yml'
  - '.gitignore'
  - 'LICENSE'
```

At 45-60 min per job on a sequential runner, a README fix currently costs 3-4 hours. Anything under `conf/`, `classes/`, `lib/`, `recipes-*/` — or the build workflows themselves — still triggers a full run.

### Also worth considering (not included)

A `concurrency` group with `cancel-in-progress: true` would stop superseded runs from occupying the runner. I left it out deliberately: cancelling bitbake mid-write is the most plausible origin of the truncated `sstate-control/index-qemuarm64` that broke `qemuarm64` for weeks. Happy to add it if you'd rather have the throughput.