### PR TITLE
ci: clone openembedded-core, bitbake and meta-yocto from GitHub

### DIFF
--- a/.github/workflows/qemuarm-linux-dummy.yml
+++ b/.github/workflows/qemuarm-linux-dummy.yml
@@ -69,9 +69,9 @@ jobs:
           # actually observed.
           pids=""
           for repo in \
-              https://git.openembedded.org/bitbake.git \
-              https://git.openembedded.org/openembedded-core.git \
-              https://git.yoctoproject.org/meta-yocto.git \
+              https://github.com/openembedded/bitbake.git \
+              https://github.com/openembedded/openembedded-core.git \
+              https://github.com/yoctoproject/meta-yocto.git \
               https://github.com/openembedded/meta-openembedded.git \
               https://github.com/jwinarske/meta-drm.git \
               https://github.com/jwinarske/meta-vulkan.git ; do

--- a/.github/workflows/qemuarm64-linux-dummy.yml
+++ b/.github/workflows/qemuarm64-linux-dummy.yml
@@ -69,9 +69,9 @@ jobs:
           # actually observed.
           pids=""
           for repo in \
-              https://git.openembedded.org/bitbake.git \
-              https://git.openembedded.org/openembedded-core.git \
-              https://git.yoctoproject.org/meta-yocto.git \
+              https://github.com/openembedded/bitbake.git \
+              https://github.com/openembedded/openembedded-core.git \
+              https://github.com/yoctoproject/meta-yocto.git \
               https://github.com/openembedded/meta-openembedded.git \
               https://github.com/jwinarske/meta-drm.git \
               https://github.com/jwinarske/meta-vulkan.git ; do

--- a/.github/workflows/qemuriscv64.yml
+++ b/.github/workflows/qemuriscv64.yml
@@ -69,9 +69,9 @@ jobs:
           # actually observed.
           pids=""
           for repo in \
-              https://git.openembedded.org/bitbake.git \
-              https://git.openembedded.org/openembedded-core.git \
-              https://git.yoctoproject.org/meta-yocto.git \
+              https://github.com/openembedded/bitbake.git \
+              https://github.com/openembedded/openembedded-core.git \
+              https://github.com/yoctoproject/meta-yocto.git \
               https://github.com/openembedded/meta-openembedded.git \
               https://github.com/jwinarske/meta-drm.git \
               https://github.com/jwinarske/meta-vulkan.git ; do

--- a/.github/workflows/qemux86-64-linux-dummy.yml
+++ b/.github/workflows/qemux86-64-linux-dummy.yml
@@ -69,9 +69,9 @@ jobs:
           # actually observed.
           pids=""
           for repo in \
-              https://git.openembedded.org/bitbake.git \
-              https://git.openembedded.org/openembedded-core.git \
-              https://git.yoctoproject.org/meta-yocto.git \
+              https://github.com/openembedded/bitbake.git \
+              https://github.com/openembedded/openembedded-core.git \
+              https://github.com/yoctoproject/meta-yocto.git \
               https://github.com/openembedded/meta-openembedded.git \
               https://github.com/jwinarske/meta-drm.git \
               https://github.com/jwinarske/meta-vulkan.git ; do


### PR DESCRIPTION
Every layer in the fetch step already came from GitHub except three, which came from `git.openembedded.org` and `git.yoctoproject.org`.

Those hosts aren't consistently reachable from the runner. The release-branch workflows cloned two of them over `git://` (port 9418) and failed outright:

```
fatal: unable to connect to git.yoctoproject.org:
fatal: unable to connect to git.openembedded.org:
```

```diff
-https://git.openembedded.org/bitbake.git
-https://git.openembedded.org/openembedded-core.git
-https://git.yoctoproject.org/meta-yocto.git
+https://github.com/openembedded/bitbake.git
+https://github.com/openembedded/openembedded-core.git
+https://github.com/yoctoproject/meta-yocto.git
```

Now the step depends on one host rather than three.

**Verified the mirrors carry every branch in use**, not just master:

| mirror | branches confirmed |
|---|---|
| `openembedded/bitbake` | master, 1.46, 2.0, 2.8, 2.18 |
| `openembedded/openembedded-core` | master, dunfell, kirkstone, scarthgap, wrynose |
| `yoctoproject/meta-yocto` | master, dunfell, kirkstone, scarthgap, wrynose |

This matters more now that #774 makes the fetch step *report* a failed clone instead of swallowing it — an unreachable host becomes a red job rather than a silently stale layer.

The same change is applied on the four release-branch PRs (#781, #782, #783, #784), which need it for their own bitbake version branches.

Workflow-only, so `paths-ignore` from #780 means it costs no build round.