### PR TITLE
ci-build: cap the LLVM builds' parallelism

### DIFF
--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -67,3 +67,21 @@ IMAGE_INSTALL:append = " \
 # Disable SPDX generation to avoid do_create_spdx task failures
 # when using shared sstate and allarch packages
 INHERIT:remove = "create-spdx"
+
+# ***************************************
+# Cap the LLVM builds' parallelism.
+#
+# clang-native and llvm-native are the memory peak of a cold build. At the
+# runner's default of one job per core they get far enough to be expensive and
+# then die:
+#
+#   g++: fatal error: Killed signal terminated program cc1plus
+#
+# That is the OOM killer, not a compiler fault. It cost three of four jobs on a
+# release branch whose sstate was nearly empty, and one on master. Anything with
+# a populated sstate restores these instead of building them, which is why it
+# surfaces on first builds and hides afterwards.
+#
+# Only these two recipes are capped; everything else keeps full parallelism.
+PARALLEL_MAKE:pn-clang-native = "-j 8"
+PARALLEL_MAKE:pn-llvm-native = "-j 8"


### PR DESCRIPTION
`clang-native` and `llvm-native` are the memory peak of a cold build. At one job per core on the runner they get far enough to be expensive, then die:

```
g++: fatal error: Killed signal terminated program cc1plus
```

That's the **OOM killer**, not a compiler fault.

### Why it matters now

| build | result |
|---|---|
| #781 wrynose, first build | **3 of 4 jobs** killed — `llvm-native`, `clang-native`, plus `highway` linking |
| #785 on master | `clang-native` killed |
| #781 `qemuarm` (ran last, quiet box) | passed |

A populated sstate *restores* these recipes instead of building them, which is why this hides on master (29G sstate) and bites on a release branch (873M). **Every release branch will meet it**, since each starts from an empty sstate of its own — so this blocks the wrynose/scarthgap/kirkstone/dunfell rollout.

### The change

```
PARALLEL_MAKE:pn-clang-native = "-j 8"
PARALLEL_MAKE:pn-llvm-native = "-j 8"
```

**Verified with `bitbake -e`** that the override lands on exactly those two and nothing else:

```
clang-native     PARALLEL_MAKE="-j 8"
llvm-native      PARALLEL_MAKE="-j 8"
flutter-engine   PARALLEL_MAKE="-j 24"     ← unchanged
```

8 is a floor, not a tuned value — LLVM's heaviest translation units want on the order of a gigabyte each, so it leaves headroom on a 60G host that's also holding a build tree.

### Caveat on attribution

At least the first wrynose failure had help: I was building flutter_scene examples (cargo + Flutter toolchain) on the same host during that job's window. The last leg, with the box quiet, passed. So the cap is warranted but the host isn't quite as marginal as three failures suggest.