### PR TITLE
ci-build: cap parallelism globally, not recipe by recipe

### DIFF
--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -82,6 +82,23 @@ INHERIT:remove = "create-spdx"
 # a populated sstate restores these instead of building them, which is why it
 # surfaces on first builds and hides afterwards.
 #
-# Only these two recipes are capped; everything else keeps full parallelism.
+# Capping only the two recipes with evidence against them was too narrow: with
+# LLVM held back, highway became the peak and was killed the same way, its
+# assembler input truncated mid-write:
+#
+#   {standard input}: Error: open CFI at the end of file
+#   x86_64-oe-linux-g++: fatal error: Killed signal terminated program cc1plus
+#
+# highway instantiates the same templates across many instruction sets, so its
+# translation units rival LLVM's. Chasing recipes one at a time just moves the
+# peak, so cap globally and keep the tighter LLVM limit as an exception.
+#
+# 32 cores against 60G is roughly 1.9G per job at full width, which is under
+# what these translation units want. 16 doubles that headroom and still uses
+# the machine.
+BB_NUMBER_THREADS = "16"
+PARALLEL_MAKE = "-j 16"
+
 PARALLEL_MAKE:pn-clang-native = "-j 8"
 PARALLEL_MAKE:pn-llvm-native = "-j 8"
+PARALLEL_MAKE:pn-highway = "-j 8"


### PR DESCRIPTION
#786 capped `clang-native` and `llvm-native`. That fixed those two and **moved the problem**: with LLVM held back, `highway` became the memory peak and was killed identically on #781's next run —

```
{standard input}: Error: open CFI at the end of file
x86_64-oe-linux-g++: fatal error: Killed signal terminated program cc1plus
```

Truncated assembler input, i.e. `cc1plus` killed mid-write.

`highway` instantiates the same templates across many instruction sets, so its translation units rival LLVM's. There's no reason to think it's the last such recipe, and capping them one at a time just relocates the peak.

### Change

```
BB_NUMBER_THREADS = "16"
PARALLEL_MAKE = "-j 16"

PARALLEL_MAKE:pn-clang-native = "-j 8"
PARALLEL_MAKE:pn-llvm-native = "-j 8"
PARALLEL_MAKE:pn-highway = "-j 8"
```

32 cores against 60G is ~1.9G per job at full width, under what these translation units want. 16 doubles the headroom and still uses the machine.

**Verified with `bitbake -e`:**

```
clang-native     PARALLEL_MAKE="-j 8"
llvm-native      PARALLEL_MAKE="-j 8"
highway          PARALLEL_MAKE="-j 8"
flutter-engine   PARALLEL_MAKE="-j 16"
```

### Trade-off, stated plainly

This costs wall-clock on recipes that were never the problem. A slower build that finishes beats a faster one that gets killed — and the four release branches all start from an empty sstate, where every one of these is built rather than restored.

### Evidence from #781

| run | LLVM cap | result |
|---|---|---|
| `bd2a4c5f` | no | 3/4 fail — `llvm-native`, `clang-native`, `highway` |
| `39500ca7` | yes | 3/4 fail — **`highway`** on x86-64 and riscv64 |
| both | — | `qemuarm` passed each time (15m28s) |

Needs backporting to #781/#782/#783/#784 once merged; dunfell needs the underscore form.