### PR TITLE
flutter-app: pub workspace support, and the flutter_scene smoke_render recipe

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -10,6 +10,13 @@ DEPENDS += " \
     "
 
 FLUTTER_APPLICATION_PATH ??= ""
+
+# Directory pub resolves from, relative to S. Defaults to the application, which
+# is where a standalone package resolves. A pub workspace member resolves from
+# the workspace root instead -- its own directory has no lockfile and pub
+# refuses to operate there -- so such a recipe points this at the root and
+# leaves FLUTTER_APPLICATION_PATH on the member.
+FLUTTER_PUB_ROOT ??= "${FLUTTER_APPLICATION_PATH}"
 FLUTTER_PREBUILD_CMD ??= ""
 
 PUB_CACHE_EXTRA_ARCHIVE_CMD ??= ""
@@ -186,6 +193,10 @@ python do_archive_pub_cache() {
                 return
 
     app_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_APPLICATION_PATH"))
+    # pub runs here; for a workspace member this is the workspace root rather
+    # than the application. The cache is still keyed on the application, since
+    # that identifies what is being built -- one pub root can host several.
+    pub_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_PUB_ROOT"))
     localfile = get_pub_cache_archive_name(d, app_root)
     localpath = os.path.join(d.getVar("DL_DIR"), localfile)
 
@@ -203,10 +214,10 @@ python do_archive_pub_cache() {
     # Remove pubspec.lock file if present
     #
     if d.getVar("PUBSPEC_IGNORE_LOCKFILE") == "1":
-        pubspec_lock = os.path.join(app_root, 'pubspec.lock')
+        pubspec_lock = os.path.join(pub_root, 'pubspec.lock')
         if os.path.exists(pubspec_lock):
             bb.note('Deleting the pubspec.lock due to PUBSPEC_IGNORE_LOCKFILE = "1"')
-            run_command(d, 'rm -rf pubspec.lock', app_root, env)
+            run_command(d, 'rm -rf pubspec.lock', pub_root, env)
         else:
             bb.note('The pubspec.lock file is not present')
 
@@ -226,20 +237,22 @@ python do_archive_pub_cache() {
     #
     # go online to fetch, then mark offline
     #
-    run_command(d, 'flutter config --no-analytics', app_root, env)
-    run_command(d, 'flutter config --no-cli-animations', app_root, env)
-    run_command(d, 'flutter clean', app_root, env)
+    run_command(d, 'flutter config --no-analytics', pub_root, env)
+    run_command(d, 'flutter config --no-cli-animations', pub_root, env)
+    run_command(d, 'flutter clean', pub_root, env)
 
     # if no pubspec.lock, create it
-    pubspec_lock = os.path.join(app_root, 'pubspec.lock')
+    pubspec_lock = os.path.join(pub_root, 'pubspec.lock')
     if not os.path.exists(pubspec_lock):
-        run_command(d, 'dart pub --suppress-analytics --directory . get', app_root, env)
+        run_command(d, 'dart pub --suppress-analytics --directory . get', pub_root, env)
 
-    run_command(d, 'flutter pub get --enforce-lockfile', app_root, env)
-    run_command(d, 'flutter pub get --enforce-lockfile --no-example --offline', app_root, env)
+    run_command(d, 'flutter pub get --enforce-lockfile', pub_root, env)
+    run_command(d, 'flutter pub get --enforce-lockfile --no-example --offline', pub_root, env)
 
+    # The resolution artifacts (.dart_tool and friends) are written where pub
+    # ran, which for a workspace member is the root rather than the member.
     cp_cmd = f'mkdir -p {pub_cache}/.project | true; cp -rT . {pub_cache}/.project/ | true;'
-    run_command(d, cp_cmd, app_root, env)
+    run_command(d, cp_cmd, pub_root, env)
 
     bb_number_threads = d.getVar("BB_NUMBER_THREADS", multiprocessing.cpu_count()).strip()
     pack_cmd = f'tar -I \"pbzip2 -p{bb_number_threads}\" -cf {localpath} ./'
@@ -272,6 +285,8 @@ python do_restore_pub_cache() {
     from   bb.fetch2 import UnpackError
 
     app_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_APPLICATION_PATH"))
+    # Mirrors the archive side: the resolution tree goes back where pub ran.
+    pub_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_PUB_ROOT"))
 
     workspace = d.getVar('WORKDIR')
     file = os.path.join(workspace, 'PUB_CACHE_ARCHIVE')
@@ -297,13 +312,13 @@ python do_restore_pub_cache() {
 
     # restore flutter pub get artifacts
     cmd = \
-        f'mv .project/.dart_tool {app_root}/ | true; ' \
-        f'mv .project/.packages {app_root}/ | true; ' \
-        f'mv .project/.dart_tool {app_root}/ | true; ' \
-        f'mv .project/.flutter-plugins {app_root}/ | true; ' \
-        f'mv .project/.flutter-plugins-dependencies {app_root}/ | true; ' \
-        f'mv .project/.metadata {app_root}/ | true; ' \
-        f'mv .project/.packages {app_root}/ | true; ' \
+        f'mv .project/.dart_tool {pub_root}/ | true; ' \
+        f'mv .project/.packages {pub_root}/ | true; ' \
+        f'mv .project/.dart_tool {pub_root}/ | true; ' \
+        f'mv .project/.flutter-plugins {pub_root}/ | true; ' \
+        f'mv .project/.flutter-plugins-dependencies {pub_root}/ | true; ' \
+        f'mv .project/.metadata {pub_root}/ | true; ' \
+        f'mv .project/.packages {pub_root}/ | true; ' \
         'rm -rf .project'
     bb.note(f'Running [{cmd}] in {unpackdir}')
     ret = subprocess.call(cmd, preexec_fn=subprocess_setup, shell=True, cwd=unpackdir)

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/bdero-flutter-scene-smoke-render_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/bdero-flutter-scene-smoke-render_1.0.0.bb
@@ -1,0 +1,48 @@
+#
+# Copyright (c) 2026 Joel Winarske. All rights reserved.
+#
+SUMMARY = "smoke_render"
+DESCRIPTION = "Deterministic render smoke tests for flutter_scene. Draws a set \
+of fixed scenes through Flutter GPU and Impeller, each asserting a sane frame \
+(centre coverage, clear corners), which is the cheapest way to catch a broken \
+backend or a scene that drew nothing."
+AUTHOR = "Brandon DeRosier"
+HOMEPAGE = "https://github.com/bdero/flutter_scene"
+BUGTRACKER = "https://github.com/bdero/flutter_scene/issues"
+SECTION = "graphics"
+
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=bd3b5df74c82765dfbbb94cbc5e3b7ff"
+
+SRCREV = "93d420be938213d19744723f8f6bb56be301187d"
+SRC_URI = "git://github.com/bdero/flutter_scene.git;branch=master;protocol=https"
+
+# smoke_render is a pub workspace member: it declares `resolution: workspace`
+# and the repository root owns the lockfile. Resolve from the root and build
+# the member. Without this pub refuses to operate in the member directory.
+#
+# The distinction matters beyond mechanics: the app depends on
+# flutter_scene ^0.23.0 by version, and the repository carries its own
+# packages/flutter_scene at 0.23.0. Workspace resolution binds to that local
+# copy, which is what the example is developed against; resolving the member
+# standalone would silently take the published 0.23.0 instead.
+FLUTTER_PUB_ROOT = ""
+FLUTTER_APPLICATION_PATH = "examples/smoke_render"
+PUBSPEC_APPNAME = "smoke_render"
+FLUTTER_APPLICATION_INSTALL_SUFFIX = "flutter-scene-example-smoke-render"
+
+# The build hook compiles the scene materials and shader bundles through
+# impellerc, which flutter-engine ships in engine_sdk.zip. flutter_scene depends
+# on code_assets as well as data_assets, so a hook may emit native code; the
+# native class covers that and is otherwise equivalent.
+inherit flutter-app-native
+
+# Flutter GPU content needs Impeller on Vulkan at run time. ivi-homescreen
+# reaches the engine switch with:
+#
+#   homescreen --backend wayland-vulkan --enable-impeller \
+#              --engine-arg=--enable-flutter-gpu -b <bundle>
+#
+# so the image needs a Vulkan driver for its GPU. That is a machine choice
+# rather than something this recipe can express, which is why it is a comment
+# and not an RDEPENDS.


### PR DESCRIPTION
Groundwork for building applications that are **pub workspace members**. Landing it separately from the recipe that needs it, since it touches code shared by **191 app recipes**.

### Problem

A workspace member can't be resolved from its own directory — the lockfile lives at the workspace root and pub refuses to operate in the member. Every pub step ran in `${S}/${FLUTTER_APPLICATION_PATH}`, so such an app couldn't be built at all.

### Change

`FLUTTER_PUB_ROOT` — the directory pub resolves from, defaulting to the application:

```
FLUTTER_PUB_ROOT ??= "${FLUTTER_APPLICATION_PATH}"
```

| moves to pub root | stays on the application |
|---|---|
| `flutter config`, `flutter clean` | pub cache **archive name** |
| lockfile handling | `PUB_CACHE_EXTRA_ARCHIVE_CMD` hook |
| both `pub get` invocations | |
| copy + restore of the resolution tree | |

The resolution tree moves because pub writes `.dart_tool` **where it ran**, not in the member — archive and restore have to stay symmetric or a workspace build loses its resolution.

Keying the cache on the *application* is deliberate: one pub root can host several applications, so keying on the root would have them share an entry.

### Verified, not assumed

**Default is a no-op** — `bitbake -e` on three existing recipes, including a nested path:

```
jwinarske-bluez-native-flutter-ble-scanner   app='example/flutter_ble_scanner'          pub=same
flatpak-minimal-appstream-dart-flathub-catalog app='example/flathub_catalog'            pub=same
toyota-connected-…-camera-linux-camera-example app='packages/camera/camera_linux/example' pub=same
```

Full tree parses (5366 recipes).

### One real cost

`do_archive_pub_cache`'s signature changes, because the task body reads one more variable — measured on an unmodified recipe:

```
without: ef76fa4fd698f979
with:    5d1813d67f1e3066
```

So **every app recipe re-archives its pub cache once**. That's a re-resolve and repack, not a rebuild, and it's unavoidable for any edit to a shared task — but it's a real cost on the next build after this merges.