### PR TITLE
ci-build: derive parallelism from memory, not core count

### DIFF
--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -69,11 +69,10 @@ IMAGE_INSTALL:append = " \
 INHERIT:remove = "create-spdx"
 
 # ***************************************
-# Cap the LLVM builds' parallelism.
+# Cap parallelism by memory, not by core count.
 #
-# clang-native and llvm-native are the memory peak of a cold build. At the
-# runner's default of one job per core they get far enough to be expensive and
-# then die:
+# clang-native and llvm-native are the memory peak of a cold build. At one job
+# per core they get far enough to be expensive and then die:
 #
 #   g++: fatal error: Killed signal terminated program cc1plus
 #
@@ -93,12 +92,29 @@ INHERIT:remove = "create-spdx"
 # translation units rival LLVM's. Chasing recipes one at a time just moves the
 # peak, so cap globally and keep the tighter LLVM limit as an exception.
 #
-# 32 cores against 60G is roughly 1.9G per job at full width, which is under
-# what these translation units want. 16 doubles that headroom and still uses
-# the machine.
-BB_NUMBER_THREADS = "16"
-PARALLEL_MAKE = "-j 16"
+# The limit that matters is memory per job, not cores. A 32-core/60G runner is
+# 1.9G per job at full width, which is under what these translation units want;
+# a 48-core/128G runner is 2.7G, still short of it. Deriving the cap from RAM
+# gives both machines a working figure from one setting, and any future runner
+# the same, where a fixed number would either waste the larger host or keep
+# OOM-ing the smaller one. It also survives the workflows' "rm -rf build/conf",
+# which is why this is not per-host tuning in local.conf.
+#
+#   32 cores /  60G -> 15 general, 7 LLVM
+#   48 cores / 128G -> 32 general, 16 LLVM
+#
+# Both are read from the host rather than the cgroup, which is correct here:
+# the CI containers are started without --memory or --cpus, so they see all of
+# it. Override CI_BUILD_JOBS or CI_BUILD_JOBS_LLVM to pin a runner by hand.
+CI_BUILD_CPUS ??= "${@len(os.sched_getaffinity(0))}"
+CI_BUILD_MEM_GB ??= "${@os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES') // 1024 ** 3}"
 
-PARALLEL_MAKE:pn-clang-native = "-j 8"
-PARALLEL_MAKE:pn-llvm-native = "-j 8"
-PARALLEL_MAKE:pn-highway = "-j 8"
+CI_BUILD_JOBS ??= "${@max(1, min(int(d.getVar('CI_BUILD_CPUS')), int(d.getVar('CI_BUILD_MEM_GB')) // 4))}"
+CI_BUILD_JOBS_LLVM ??= "${@max(1, min(int(d.getVar('CI_BUILD_CPUS')), int(d.getVar('CI_BUILD_MEM_GB')) // 8))}"
+
+BB_NUMBER_THREADS = "${CI_BUILD_JOBS}"
+PARALLEL_MAKE = "-j ${CI_BUILD_JOBS}"
+
+PARALLEL_MAKE:pn-clang-native = "-j ${CI_BUILD_JOBS_LLVM}"
+PARALLEL_MAKE:pn-llvm-native = "-j ${CI_BUILD_JOBS_LLVM}"
+PARALLEL_MAKE:pn-highway = "-j ${CI_BUILD_JOBS_LLVM}"


### PR DESCRIPTION
The fixed `-j 16` / `-j 8` caps from #787 were sized against one runner: 32 cores, 60G. A second runner is 48 cores and 128G, and no fixed number suits both — holding 48 cores to 16 wastes two thirds of the machine, while full width is 2.7G per job, still under what an LLVM or highway translation unit wants.

Cores were never the constraint. This derives the cap from RAM at 4G per job generally, 8G for the recipes that have actually been OOM-killed:

| host | cores | RAM | general | LLVM |
|---|---|---|---|---|
| runner 1 | 32 | 60G | 15 | 7 |
| runner 2 | 48 | 128G | 32 | 16 |

The first row is what #787 hand-tuned to, so this is **not a behavior change on the existing runner**. Any future runner gets a working figure with no edit here, which matters because CI wipes `build/conf` every run — per-host tuning in `local.conf` does not survive.

Both figures are read from the host rather than the cgroup, which is correct: the CI containers are started without `--memory` or `--cpus`, so they see all of it.

`CI_BUILD_JOBS` / `CI_BUILD_JOBS_LLVM` stay overridable for a runner that needs pinning by hand.

### Verification

Driven through bitbake's own `ConfHandler` rather than assumed — this confirms inline python works in a conf file, `os` is in scope, `??=` resolves, the `pn-` overrides apply, and a manual pin wins:

```
CI_BUILD_CPUS        = '32'
CI_BUILD_MEM_GB      = '60'
BB_NUMBER_THREADS    = '15'
PARALLEL_MAKE        = '-j 15'
PARALLEL_MAKE[clang-native] = '-j 7'
PARALLEL_MAKE[llvm-native ] = '-j 7'
PARALLEL_MAKE[highway     ] = '-j 7'
PARALLEL_MAKE[zlib        ] = '-j 15'
pinned BB_NUMBER_THREADS = '4'  PARALLEL_MAKE = '-j 4'
```

Across host sizes, including the degenerate case the `max(1, ...)` guard exists for:

```
32 cores /  60G -> threads 15  general -j 15  llvm -j 7
48 cores / 128G -> threads 32  general -j 32  llvm -j 16
 8 cores /  16G -> threads 4   general -j 4   llvm -j 2
 4 cores /   3G -> threads 1   general -j 1   llvm -j 1
64 cores / 512G -> threads 64  general -j 64  llvm -j 64
```

Companion PRs carry this to wrynose, scarthgap, kirkstone and dunfell, which have no cap at all today.