### PR TITLE
kirkstone: cap parallelism, derived from memory

### DIFF
--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -35,3 +35,54 @@ IMAGE_INSTALL:append = " \
 # Disable SPDX generation to avoid do_create_spdx task failures
 # when using shared sstate and allarch packages
 INHERIT:remove = "create-spdx"
+
+# ***************************************
+# Cap parallelism by memory, not by core count.
+#
+# clang-native and llvm-native are the memory peak of a cold build. At one job
+# per core they get far enough to be expensive and then die:
+#
+#   g++: fatal error: Killed signal terminated program cc1plus
+#
+# That is the OOM killer, not a compiler fault. It cost three of four jobs on a
+# release branch whose sstate was nearly empty, and one on master. Anything with
+# a populated sstate restores these instead of building them, which is why it
+# surfaces on first builds and hides afterwards.
+#
+# Capping only the two recipes with evidence against them was too narrow: with
+# LLVM held back, highway became the peak and was killed the same way, its
+# assembler input truncated mid-write:
+#
+#   {standard input}: Error: open CFI at the end of file
+#   x86_64-oe-linux-g++: fatal error: Killed signal terminated program cc1plus
+#
+# highway instantiates the same templates across many instruction sets, so its
+# translation units rival LLVM's. Chasing recipes one at a time just moves the
+# peak, so cap globally and keep the tighter LLVM limit as an exception.
+#
+# The limit that matters is memory per job, not cores. A 32-core/60G runner is
+# 1.9G per job at full width, which is under what these translation units want;
+# a 48-core/128G runner is 2.7G, still short of it. Deriving the cap from RAM
+# gives both machines a working figure from one setting, and any future runner
+# the same, where a fixed number would either waste the larger host or keep
+# OOM-ing the smaller one. It also survives the workflows' "rm -rf build/conf",
+# which is why this is not per-host tuning in local.conf.
+#
+#   32 cores /  60G -> 15 general, 7 LLVM
+#   48 cores / 128G -> 32 general, 16 LLVM
+#
+# Both are read from the host rather than the cgroup, which is correct here:
+# the CI containers are started without --memory or --cpus, so they see all of
+# it. Override CI_BUILD_JOBS or CI_BUILD_JOBS_LLVM to pin a runner by hand.
+CI_BUILD_CPUS ??= "${@len(os.sched_getaffinity(0))}"
+CI_BUILD_MEM_GB ??= "${@os.sysconf('SC_PAGE_SIZE') * os.sysconf('SC_PHYS_PAGES') // 1024 ** 3}"
+
+CI_BUILD_JOBS ??= "${@max(1, min(int(d.getVar('CI_BUILD_CPUS')), int(d.getVar('CI_BUILD_MEM_GB')) // 4))}"
+CI_BUILD_JOBS_LLVM ??= "${@max(1, min(int(d.getVar('CI_BUILD_CPUS')), int(d.getVar('CI_BUILD_MEM_GB')) // 8))}"
+
+BB_NUMBER_THREADS = "${CI_BUILD_JOBS}"
+PARALLEL_MAKE = "-j ${CI_BUILD_JOBS}"
+
+PARALLEL_MAKE:pn-clang-native = "-j ${CI_BUILD_JOBS_LLVM}"
+PARALLEL_MAKE:pn-llvm-native = "-j ${CI_BUILD_JOBS_LLVM}"
+PARALLEL_MAKE:pn-highway = "-j ${CI_BUILD_JOBS_LLVM}"


### PR DESCRIPTION
Backport of #789 to `kirkstone`.

**This branch has no parallelism cap at all** — #786/#787 landed on master only. That is backwards from where it is needed: release branches are the ones with cold sstate, and cold sstate is exactly when `clang-native`, `llvm-native` and `highway` get built rather than restored.

The failure mode is confirmed on this branch, not hypothetical — from run 32617294008 on #781:

```
| x86_64-oe-linux-g++: fatal error: Killed signal terminated program cc1plus
| {standard input}: Error: open CFI at the end of file; missing .cfi_endproc directive
ERROR: Task (.../highway_1.3.0.bb:do_compile) failed with exit code '1'
```

That is the OOM killer, not a compiler fault.

Cores are not the constraint, memory is. This derives the cap from RAM at 4G per job generally and 8G for the recipes that have been killed:

| host | cores | RAM | general | LLVM |
|---|---|---|---|---|
| runner 1 | 32 | 60G | 15 | 7 |
| runner 2 | 48 | 128G | 32 | 16 |

A fixed number cannot serve both runners: holding 48 cores to 16 wastes two thirds of the machine, while full width is 2.7G per job — still under what these translation units want. Deriving it also survives CI wiping `build/conf` every run, which is why this is not per-host tuning in `local.conf`.

Overrides use `:pn-` to match the bitbake this branch's CI actually clones.

### Verification

Driven through bitbake's own `ConfHandler` rather than assumed — confirms inline python works in a conf file, `os` is in scope, `??=` resolves, the `pn-` overrides apply, and a manual pin via `CI_BUILD_JOBS` wins. Across host sizes, including the degenerate case the `max(1, ...)` guard exists for:

```
32 cores /  60G -> threads 15  general -j 15  llvm -j 7
48 cores / 128G -> threads 32  general -j 32  llvm -j 16
 8 cores /  16G -> threads 4   general -j 4   llvm -j 2
 4 cores /   3G -> threads 1   general -j 1   llvm -j 1
```

Config-only. Worth landing ahead of the 3.47.1 PR on this branch so that run picks up the cap via the PR merge ref.