### PR TITLE
license: fix the QA warnings and check declarations against source

### DIFF
--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -19,13 +19,17 @@ DISTRO_FEATURES:append = " systemd x11 wayland opengl pam polkit pipewire pulsea
 DISTRO_FEATURES_OPTED_OUT = ""
 
 # ***************************************
-# CI clones every layer at master. oe-core master tightened the license-format
-# QA to require & rather than AND, and meta-openembedded master has not caught
-# up: coremark, coremark-pro, glmark2 and lmbench all trip it. That is a fatal
-# QA error at parse time, so bitbake halts before reaching any meta-flutter
-# recipe. None of those recipes are built here, so demote the check to a warning
-# rather than let third-party layer skew block CI entirely. This file is CI-only
-# and does not affect QA for meta-flutter's own recipes in a real build.
+# CI clones every layer at master. oe-core master's license-format QA resolves
+# every LicenseRef- in a LICENSE expression, either to a file in
+# COMMON_LICENSE_DIR or through NO_GENERIC_LICENSE, and errors when it cannot.
+# meta-openembedded master has not caught up: coremark and coremark-pro declare
+# LicenseRef-EEMBC-AUA, glmark2 LicenseRef-SGI-1 and lmbench
+# LicenseRef-GPL-2.0-with-lmbench-restriction, none of which oe-core ships and
+# none of which those recipes map with NO_GENERIC_LICENSE. That is a fatal QA
+# error at parse time, so bitbake halts before reaching any meta-flutter recipe.
+# None of those recipes are built here, so demote the check to a warning rather
+# than let third-party layer skew block CI entirely. This file is CI-only and
+# does not affect QA for meta-flutter's own recipes in a real build.
 ERROR_QA:remove = "license-format"
 WARN_QA:append = " license-format"
 
@@ -35,7 +39,7 @@ WARN_QA:append = " license-format"
 # mask them rather than let unrelated layer skew block CI:
 #
 #   recipes-benchmark    coremark, coremark-pro, glmark2, lmbench -- LICENSE
-#                        uses AND, which oe-core's license-format QA now rejects
+#                        names a LicenseRef- that oe-core cannot resolve
 #   zabbix, turbostat,   reference oe.kernel.*, which oe-core no longer makes
 #   vboxguestdrivers     available to recipes (ExpansionError on KERNEL_VERSION).
 #                        These are the only three users in meta-openembedded, so

--- a/meta-flutter-apps/conf/flutter-apps.json
+++ b/meta-flutter-apps/conf/flutter-apps.json
@@ -126,8 +126,8 @@
     {
         "uri": "https://github.com/flutter/games.git",
         "branch": "main",
-        "license_file": "",
-        "license_type": "CLOSED",
+        "license_file": "LICENSE",
+        "license_type": "Apache-2.0 AND BSD-3-Clause AND OFL-1.1",
         "folder": "first-party",
         "author": "Google"
     },
@@ -178,7 +178,7 @@
         "uri": "https://github.com/bernardpumped/ped.git",
         "branch": "next_main",
         "license_file": "COPYING",
-        "license_type": "GPL-3.0",
+        "license_type": "GPL-3.0-or-later",
         "author": "Bernard Craddock",
         "folder": "third-party"
     },

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-ads_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-ads_0.0.1.bb
@@ -9,7 +9,8 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "CLOSED"
+LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"
 SRC_URI = "git://github.com/flutter/games.git;lfs=1;branch=main;protocol=https"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-crossword_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-crossword_0.1.0.bb
@@ -9,7 +9,8 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "CLOSED"
+LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"
 SRC_URI = "git://github.com/flutter/games.git;lfs=1;branch=main;protocol=https"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-multiplayer_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-multiplayer_0.0.1.bb
@@ -9,7 +9,8 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "CLOSED"
+LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"
 SRC_URI = "git://github.com/flutter/games.git;lfs=1;branch=main;protocol=https"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-basic_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-basic_0.0.1.bb
@@ -9,7 +9,8 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "CLOSED"
+LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"
 SRC_URI = "git://github.com/flutter/games.git;lfs=1;branch=main;protocol=https"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-card_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-card_0.0.1.bb
@@ -9,7 +9,8 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "CLOSED"
+LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"
 SRC_URI = "git://github.com/flutter/games.git;lfs=1;branch=main;protocol=https"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-endless-runner_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-endless-runner_0.1.0.bb
@@ -9,7 +9,8 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "CLOSED"
+LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"
 SRC_URI = "git://github.com/flutter/games.git;lfs=1;branch=main;protocol=https"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/bernardpumped-ped-pumped-end-device_1.0.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/bernardpumped-ped-pumped-end-device_1.0.2.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "https://github.com/bernardpumped/ped/tree/agl"
 BUGTRACKER = "https://github.com/bernardpumped/ped/issues"
 SECTION = "graphics"
 
-LICENSE = "GPL-3.0"
+LICENSE = "GPL-3.0-or-later"
 LIC_FILES_CHKSUM = "file://COPYING;md5=e49f4652534af377a713df3d9dec60cb"
 
 SRCREV = "de1c4cf92bf629a0fff0d5462e2ba9575b77de67"

--- a/recipes-devtools/depot-tools/depot-tools-native_git.bb
+++ b/recipes-devtools/depot-tools/depot-tools-native_git.bb
@@ -2,7 +2,7 @@
 # Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
 #
 
-LICENSE = "GPLv3"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c2c05f9bdd5fc0b458037c2d1fb8d95e"
 
 SRC_URI = "git://chromium.googlesource.com/chromium/tools/depot_tools;protocol=https;branch=main"

--- a/recipes-graphics/libwebrtc/libwebrtc_144.7559.09.bb
+++ b/recipes-graphics/libwebrtc/libwebrtc_144.7559.09.bb
@@ -10,7 +10,7 @@ HOMEPAGE = "https://github.com/jwinarske/libwebrtc"
 BUGTRACKER = "https://github.com/jwinarske/libwebrtc/issues"
 SECTION = "graphics"
 
-LICENSE = "BSD-3-Clause & MIT"
+LICENSE = "BSD-3-Clause AND MIT"
 LIC_FILES_CHKSUM = "\
     file://LICENSE;md5=ad296492125bc71530d06234d9bfebe0 \
     file://libwebrtc/LICENSE;md5=166d54ea842ed1a582dabbd844fa4c80 \

--- a/recipes-graphics/rive/rive-text_0.4.11.bb
+++ b/recipes-graphics/rive/rive-text_0.4.11.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "https://github.com/rive-app/rive-flutter"
 BUGTRACKER = "https://github.com/rive-app/rive-flutter"
 SECTION = "devtools"
 
-LICENSE = "MIT & Apache-2.0"
+LICENSE = "Apache-2.0 AND MIT"
 LIC_FILES_CHKSUM = " \
     file://LICENSE;md5=c52243a14a066c83e50525d9ad046678 \
     file://macos/rive-cpp/LICENSE;md5=9a8a5e004196b5614e34130e5558fb6c \

--- a/recipes-graphics/toyota/flutter-auto_2.0.bb
+++ b/recipes-graphics/toyota/flutter-auto_2.0.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "https://github.com/toyota-connected/ivi-homescreen"
 BUGTRACKER = "https://github.com/toyota-connected/ivi-homescreen/issues"
 SECTION = "graphics"
 
-LICENSE = "Apache-2.0 & Apache-2.0"
+LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "\
     file://LICENSE;md5=39ae29158ce710399736340c60147314 \
     file://${S}/ivi-homescreen-plugins/LICENSE;md5=39ae29158ce710399736340c60147314 \

--- a/recipes-graphics/toyota/ivi-homescreen-v3.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-v3.inc
@@ -28,11 +28,12 @@ SECTION = "graphics"
 CVE_PRODUCT = "homescreen"
 
 # The plugins tree (Apache-2.0) and the v4l2-webrtc-codec encoder sources (MIT)
-# are only fetched when they are actually built, so both the licence list and its
-# checksums follow the PACKAGECONFIG.
+# are only fetched when they are actually built, so the checksums follow the
+# PACKAGECONFIG. The license list only has to follow it for the encoder: the
+# plugins tree is Apache-2.0 like the base, and naming it twice is not a second
+# license, just a duplicate operand for oe-core to flag.
 LICENSE = "Apache-2.0\
-${@bb.utils.contains('PACKAGECONFIG', 'disable-plugins', '', ' & Apache-2.0', d)}\
-${@bb.utils.contains_any('PACKAGECONFIG', 'software-sink-encoder backend-headless-egl', ' & MIT', '', d)}"
+${@bb.utils.contains_any('PACKAGECONFIG', 'software-sink-encoder backend-headless-egl', ' AND MIT', '', d)}"
 
 LIC_FILES_CHKSUM = "\
     file://LICENSE;md5=39ae29158ce710399736340c60147314 \

--- a/recipes-graphics/toyota/ivi-homescreen_2.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_2.0.bb
@@ -9,7 +9,7 @@ HOMEPAGE = "https://github.com/toyota-connected/ivi-homescreen"
 BUGTRACKER = "https://github.com/toyota-connected/ivi-homescreen/issues"
 SECTION = "graphics"
 
-LICENSE = "Apache-2.0 & Apache-2.0"
+LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "\
     file://LICENSE;md5=39ae29158ce710399736340c60147314 \
     file://${S}/ivi-homescreen-plugins/LICENSE;md5=39ae29158ce710399736340c60147314 \

--- a/tools/common.py
+++ b/tools/common.py
@@ -312,3 +312,107 @@ def test_internet_connection() -> bool:
         res = True
 
     return res
+
+
+# Phrases that identify a license, matched against the file's text with
+# whitespace collapsed. Titles are spelled without the comma that the
+# cross-references use ("Apache License Version 2.0" as a heading, versus
+# "the GNU Lesser General Public License, Version 2.1" where MPL-2.0 names its
+# secondary licenses) so that naming a license does not read as being it.
+_LICENSE_MARKERS = [
+    ('Apache-2.0',   (('apache license version 2.0',), ())),
+    ('GPL-3.0',      (('gnu general public license version 3',), ())),
+    ('GPL-2.0',      (('gnu general public license version 2',), ())),
+    ('LGPL-3.0',     (('gnu lesser general public license version 3',), ())),
+    ('LGPL-2.1',     (('gnu lesser general public license version 2.1',), ())),
+    ('MPL-2.0',      (('mozilla public license version 2.0',), ())),
+    # BSD-3-Clause is BSD-2-Clause plus non-endorsement, so the two-clause form
+    # is only itself when the third clause is absent.
+    ('BSD-3-Clause', (('redistribution and use in source and binary forms',
+                       'neither the name'), ())),
+    ('BSD-2-Clause', (('redistribution and use in source and binary forms',),
+                      ('neither the name',))),
+    # The SIL Open Font License opens with the same sentence as MIT but grants
+    # over "the Font Software"; flutter/games ships both, so MIT has to key on
+    # its own object to avoid claiming every font license as MIT.
+    ('OFL-1.1',      (('sil open font license',), ())),
+    ('MIT',          (('free of charge, to any person obtaining a copy of this software',), ())),
+    ('ISC',          (('permission to use, copy, modify, and/or distribute this software',), ())),
+]
+
+# Families where the license file alone cannot settle the identifier. A project
+# shipping the GPL ships the same COPYING whether it is "version 3 only" or
+# "version 3 or later" -- that distinction lives in the per-file headers, and
+# the license text's own appendix always shows the or-later wording. So detect
+# the family and accept either variant rather than guess.
+_LICENSE_FAMILIES = {
+    'GPL-3.0':  ('GPL-3.0-only', 'GPL-3.0-or-later'),
+    'GPL-2.0':  ('GPL-2.0-only', 'GPL-2.0-or-later'),
+    'LGPL-3.0': ('LGPL-3.0-only', 'LGPL-3.0-or-later'),
+    'LGPL-2.1': ('LGPL-2.1-only', 'LGPL-2.1-or-later'),
+}
+
+
+def detect_licenses(license_path: str) -> list:
+    """Return the SPDX identifiers a license file's text contains.
+
+    A list, because upstreams routinely ship one file holding several licenses
+    -- flutter/games concatenates the Chromium BSD-3-Clause notice and the full
+    Apache-2.0 text, and a recipe claiming either one alone would be wrong.
+
+    Detection is deliberately conservative: a file matching nothing yields an
+    empty list, so callers can tell "disagrees with the source" from "could not
+    be checked".
+    """
+    try:
+        with open(license_path, 'r', encoding='utf-8', errors='replace') as f:
+            text = f.read().lower()
+    except OSError:
+        return []
+
+    # Collapse whitespace so matching survives the comment prefixes and hard
+    # wrapping that upstreams wrap their license text in.
+    text = ' '.join(text.split())
+
+    found = []
+    for spdx, (required, forbidden) in _LICENSE_MARKERS:
+        if all(m in text for m in required) and not any(m in text for m in forbidden):
+            found.append(spdx)
+    return found
+
+
+def detect_license(license_path: str) -> str:
+    """detect_licenses() as an SPDX expression, e.g. "BSD-3-Clause AND MIT"."""
+    return ' AND '.join(sorted(detect_licenses(license_path)))
+
+
+def license_agrees_with_source(declared: str, detected_list: list) -> bool:
+    """Whether a declared LICENSE value is consistent with the detected text.
+
+    Detection is coarse on purpose. A great many licenses embed the BSD or MIT
+    wording verbatim and then add a clause -- Sendmail, OpenSSL, ZPL and the
+    whole X11 family all read as BSD or MIT to a text match. So a declared
+    identifier counts as agreeing when it is the detected one, a variant of a
+    family the text cannot disambiguate (see _LICENSE_FAMILIES), or a more
+    specific spelling of it (BSD-3-Clause-Clear over BSD-3-Clause).
+
+    What this still catches is the case worth catching: a declared license with
+    no relation at all to the shipped text, which is how depot-tools carried
+    LICENSE = "GPLv3" over BSD-3-Clause.
+    """
+    if not detected_list:
+        return True          # nothing to contradict it
+
+    declared_set = {t for t in declared.replace('(', ' ').replace(')', ' ').split()
+                    if t.upper() not in ('AND', 'OR', '&', '|')}
+
+    for want in detected_list:
+        variants = {want} | set(_LICENSE_FAMILIES.get(want, ()))
+        if declared_set & variants:
+            continue
+        # A more specific spelling of the detected license, or a derivative
+        # that embeds its text.
+        if any(d.startswith(want + '-') or want.startswith(d + '-') for d in declared_set):
+            continue
+        return False
+    return True

--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -315,6 +315,13 @@ def create_recipe(directory,
         f.write('SECTION = "graphics"\n')
         f.write('\n')
 
+        # oe-core warns that a bare CLOSED is deprecated and suggests
+        # LicenseRef-<pn>-CLOSED. Do not take that suggestion here: a license
+        # ref has to resolve, either to a file in COMMON_LICENSE_DIR or through
+        # NO_GENERIC_LICENSE, and an app with no license file upstream has
+        # neither. The ref would then fail license-format, which is an error by
+        # default, so following the advice trades a warning for a broken build.
+        # CLOSED stays until such an app grows a license worth pointing at.
         f.write(f'LICENSE = "{license_type}"\n')
         if license_type != 'CLOSED':
             f.write(f'LIC_FILES_CHKSUM = "file://{license_file};md5={license_md5}"\n')

--- a/tools/roll_meta_flutter.py
+++ b/tools/roll_meta_flutter.py
@@ -12,6 +12,8 @@ import signal
 import subprocess
 import sys
 
+from common import detect_licenses
+from common import license_agrees_with_source
 from common import make_sure_path_exists
 from common import print_banner
 
@@ -34,6 +36,7 @@ def clear_folder(dir_):
 
 def get_repo(repo_path: str, output_path: str,
              uri: str, branch: str, rev: str, license_file: str, license_type: str,
+             validate_license: bool,
              author: str,
              recipe_folder: str,
              package_output_path: str,
@@ -117,9 +120,35 @@ def get_repo(repo_path: str, output_path: str,
             print_banner(f'ERROR: {license_path} is not present')
             exit(1)
 
+        # Check the declared license against the text the recipe will ship.
+        # flutter-apps.json states a license for someone else's repository and
+        # nothing re-checked it once written, which is how depot-tools carried
+        # LICENSE = "GPLv3" over BSD-3-Clause text. Upstreams also relicense and
+        # add licenses between rolls -- flutter/games grew an Apache-2.0 section
+        # and a bundled font's OFL-1.1 -- and a roll is when that surfaces.
+        if validate_license:
+            detected = detect_licenses(license_path)
+            if not detected:
+                print(f'NOTE: {repo_name}: license text not recognized, '
+                      f'leaving "{license_type}" unchecked')
+            elif not license_agrees_with_source(license_type, detected):
+                print_banner(
+                    f'ERROR: {repo_name}: declared license does not match its source\n'
+                    f'  declared: {license_type}\n'
+                    f'  {license_file} contains: {" AND ".join(detected)}\n'
+                    f'Fix license_type in flutter-apps.json, or set '
+                    f'"license_validate": false for a license this check reads wrong.')
+                exit(1)
+
         if license_type != 'CLOSED':
             from create_recipes import get_file_md5
             license_md5 = get_file_md5(license_path)
+
+    elif license_type != 'CLOSED':
+        # A license type with no file to back it cannot produce LIC_FILES_CHKSUM.
+        print_banner(f'ERROR: {repo_name}: license_type "{license_type}" declared '
+                     f'without a license_file')
+        exit(1)
 
     repo_path = os.path.join(repo_path, repo_name)
 
@@ -158,6 +187,7 @@ def get_workspace_repos(repo_path, repos, output_path, package_output_path, patc
                                            rev=r.get('rev'),
                                            license_file=r.get('license_file'),
                                            license_type=r.get('license_type'),
+                                           validate_license=r.get('license_validate', True),
                                            author=r.get('author'),
                                            recipe_folder=r.get('folder'),
                                            ignore_list=r.get('ignore'),


### PR DESCRIPTION
Clears every `license-format` warning on master, fixes #743, and makes the app licenses checkable at roll time instead of trusting a hand-maintained field.

### Old expression syntax

`libwebrtc`, `rive-text`, `flutter-auto` 2.0 and `ivi-homescreen` 2.0/3.0 joined operands with `&` instead of `AND`.

The two Toyota recipes wrote `"Apache-2.0 & Apache-2.0"` — one operand per component, both Apache-2.0. The expression is just `Apache-2.0`; the second operand only ever added a duplicate. `ivi-homescreen-v3.inc` builds its expression from PACKAGECONFIG and the plugins tree contributed that same duplicate, so that clause is dropped and the conditional now only adds the encoder's MIT. The checksums still follow PACKAGECONFIG — two files, one license.

### A wrong license (#743)

`depot-tools-native` declared `GPLv3` — a pre-SPDX spelling, and not the license. The file it already checksums is the Chromium BSD-3-Clause notice:

```
md5 of LICENSE at SRCREV 39b2e4ef = c2c05f9bdd5fc0b458037c2d1fb8d95e
                    recipe expects  c2c05f9bdd5fc0b458037c2d1fb8d95e
```

### Deprecated licenses in generated app recipes

Both fixed in `flutter-apps.json`, with the generated recipes following:

- **bernardpumped/ped** — `GPL-3.0` → `GPL-3.0-or-later`. Its own source headers carry "either version 3 of the License, or (at your option) any later version". (The COPYING file cannot settle this: the GPL's appendix shows that wording in every copy.)
- **flutter/games** — was `CLOSED`, but the repo *does* ship a LICENSE: the Chromium BSD-3-Clause notice, the full Apache-2.0, and a bundled font's OFL-1.1. Now `Apache-2.0 AND BSD-3-Clause AND OFL-1.1`.

**knopp/layer_playground keeps `CLOSED`.** The warning suggests `LicenseRef-<pn>-CLOSED`, but a ref has to resolve — to a file in `COMMON_LICENSE_DIR` or via `NO_GENERIC_LICENSE` — and that repo ships no license at all. Verified against oe-core's resolver:

```
LicenseRef-knopp-layer-playground-layer-playground-CLOSED  unresolved
LicenseRef-PD                                              resolves (oe-core ships it)
```

`license-format` is in `ERROR_QA` by default, so taking that advice would trade a warning for a broken build.

### A correction to ci-build.inc

That same mechanism turns out to be why meta-oe's benchmark recipes are masked. They use `AND` correctly; what fails is an unresolvable ref:

```
coremark, coremark-pro   Apache-2.0 AND LicenseRef-EEMBC-AUA
glmark2                  GPL-3.0-or-later AND LicenseRef-SGI-1
lmbench                  GPL-2.0-only AND LicenseRef-GPL-2.0-with-lmbench-restriction
```

None are shipped by oe-core or mapped with `NO_GENERIC_LICENSE`. The comment blamed `AND`-versus-`&` and was wrong. The mask stands; the reason is corrected.

### Validating against the source

`flutter-apps.json` asserts a license for someone else's repository and nothing re-checked it — which is how depot-tools carried the wrong one. The roll already clones each app, so it now reads the license file it is about to checksum and fails when the declaration bears no relation to the text.

Detection is coarse on purpose, and says so. Many licenses embed the BSD or MIT wording and add a clause, so a declaration agrees when it is the detected license, a variant of a family the text cannot disambiguate, or a more specific spelling. `"license_validate": false` opts an entry out.

### Verification

Every changed expression, through oe-core's own `_parse_legacy_license` and ref resolver:

```
clean  libwebrtc            'BSD-3-Clause AND MIT'
clean  rive-text            'Apache-2.0 AND MIT'
clean  flutter-auto 2.0     'Apache-2.0'
clean  ivi-homescreen v3 (no encoder) 'Apache-2.0'
clean  ivi-homescreen v3 (encoder)    'Apache-2.0 AND MIT'
clean  depot-tools-native   'BSD-3-Clause'
clean  flutter-games x6     'Apache-2.0 AND BSD-3-Clause AND OFL-1.1'
clean  bernardpumped ped    'GPL-3.0-or-later'
warn   knopp layer-playground 'CLOSED'   (deliberate, see above)
```

The detector against oe-core's 803-license corpus — all 11 licenses it knows self-detect, and the OFL-1.1 case is why flutter/games needed three operands rather than the two I first assumed (the SIL OFL opens with MIT's sentence but grants over "the Font Software"):

```
MIT, Apache-2.0, BSD-2-Clause, BSD-3-Clause, ISC, MPL-2.0,
GPL-2.0-only, GPL-3.0-only, LGPL-2.1-only, LGPL-3.0-only, OFL-1.1   all OK
```

And the validator on the real files:

```
reject  depot-tools, the bug in #743         declared GPLv3
accept  depot-tools, fixed                   declared BSD-3-Clause
reject  flutter/games, before                declared CLOSED
reject  flutter/games, BSD only (incomplete) declared BSD-3-Clause
accept  flutter/games, fixed                 declared Apache-2.0 AND BSD-3-Clause AND OFL-1.1
accept  ped, fixed                           declared GPL-3.0-or-later
```

Recipe content is unchanged apart from LICENSE/LIC_FILES_CHKSUM, so no rebuild is implied beyond the recipes' own signatures.

Closes #743