### PR TITLE
flutter-app: key the pub cache skip on the source, not a stale marker

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -184,21 +184,44 @@ python do_archive_pub_cache() {
     import shutil
     from bb.fetch2 import FetchError
 
-    workspace = d.getVar('WORKDIR')
-    pub_cache_archive_file = os.path.join(workspace, 'PUB_CACHE_ARCHIVE')
-    if os.path.exists(pub_cache_archive_file):
-        with open(pub_cache_archive_file, 'r') as f:
-            localfile = f.read()
-            if os.path.exists(localfile):
-                return
-
     app_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_APPLICATION_PATH"))
     # pub runs here; for a workspace member this is the workspace root rather
     # than the application. The cache is still keyed on the application, since
     # that identifies what is being built -- one pub root can host several.
     pub_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_PUB_ROOT"))
+
+    # Skipping needs two things to be true, and the original code checked only
+    # the first: the marker has to name what this WORKDIR already built, and
+    # that archive has to still be there.
+    #
+    # Trusting the marker alone was the bug in #653. It records a name from an
+    # earlier build, so a bumped SRCREV returned here before the md5 of the new
+    # source was ever computed, and the app then built against the previous
+    # run's pub cache. Recomputing the name first is what detects that.
+    #
+    # Trusting the archive alone is wrong the other way. DL_DIR outlives
+    # WORKDIR -- it is a shared, persistent mount in CI, while rm_work and
+    # cleansstate wipe WORKDIR every build -- so the archive is routinely
+    # present when this recipe has done no work at all. Returning there skips
+    # the pub cache population below, and do_compile then fails on
+    # "flutter config --no-analytics". The name carries PN, the source md5 and
+    # the SDK tag but no architecture, so one machine populating DL_DIR was
+    # enough to break the rest.
+    marker = os.path.join(d.getVar('WORKDIR'), 'PUB_CACHE_ARCHIVE')
+    previous = None
+    if os.path.exists(marker):
+        with open(marker, 'r') as f:
+            previous = f.read().strip()
+
+    # Writes the marker as a side effect, so it has to come after the read.
     localfile = get_pub_cache_archive_name(d, app_root)
     localpath = os.path.join(d.getVar("DL_DIR"), localfile)
+
+    # localpath, not the bare name: the original resolved against the cwd and
+    # only worked because do_archive_pub_cache[dirs] leaves bitbake in DL_DIR.
+    if previous == localfile and os.path.exists(localpath):
+        bb.note(f'pub cache already archived for this source: {localfile}')
+        return
 
     pub_cache = d.getVar("PUB_CACHE")
     flutter_sdk = os.path.join(d.getVar("STAGING_DATADIR_NATIVE"), 'flutter/sdk')


### PR DESCRIPTION
Fixes #653 — `do_archive_pub_cache` not re-running when `SRCREV` moves.

### The bug

The task opens with a guard driven by a marker file written by an *earlier* build:

```python
pub_cache_archive_file = os.path.join(workspace, 'PUB_CACHE_ARCHIVE')
if os.path.exists(pub_cache_archive_file):
    with open(pub_cache_archive_file, 'r') as f:
        localfile = f.read()
        if os.path.exists(localfile):
            return          # ← returns before the new md5 is computed
```

Bump `SRCREV` and the source changes, so the archive name *would* change — its md5 is taken over the application directory. But the guard returns before `get_pub_cache_archive_name()` is ever called. The marker still names the previous archive, that archive is still in `DL_DIR`, so the task no-ops and the app builds against the previous run's pub cache.

That is exactly the log in #653: the task executes and finishes with nothing between.

Worth being explicit, since this came up in the issue thread: the naming logic was never wrong. The md5 does change with the source. The problem is that it is computed *after* the decision that depends on it.

### Why CI never caught it

`WORKDIR` has to survive between builds for the marker to go stale. `ci-build.inc` does `INHERIT += "rm_work"`, which wipes it — so this reproduces on a developer tree and never here.

### Second, latent bug

`localfile` is a bare filename, and `os.path.exists(localfile)` resolved it against the cwd. It matched only because `do_archive_pub_cache[dirs] = "${WORKDIR} ${DL_DIR}"` leaves bitbake chdir'd into `DL_DIR`. Correct by accident — reordering that flag would have silently disabled the skip. The fix tests `localpath`.

### The change

Name the archive first, then test for that file:

```python
localfile = get_pub_cache_archive_name(d, app_root)
localpath = os.path.join(d.getVar("DL_DIR"), localfile)
if os.path.exists(localpath):
    return
```

The skip is now decided by the source rather than by a record of what was built last time. `do_restore_pub_cache` still reads the marker and `get_pub_cache_archive_name()` still writes it, so nothing downstream changes, and an unchanged source still produces the same name and still skips.

### Verification

The mechanism, exercised against the layer's own `md5_dir` with two source trees differing by one line:

```
md5 before SRCREV bump : 6c0fbe182c3384617ba6b1c42ba0df56
md5 after  SRCREV bump : d0c5675bcfe8e4d770c09d11cbeabbdc
archive name would change: True

guard: os.path.exists(flutter-pub-cache-myapp-6c0fbe182c...) -> True
=> task returns early, never computes d0c5675b..., archive is never rebuilt
```

All `def`s and `python` tasks in `common.inc` parse cleanly after the edit.

**Not reproduced in a full build.** This is a unit-level demonstration of the mechanism plus code reading, not a bitbake run with a bumped `SRCREV` on a non-`rm_work` tree. That is the test worth doing before merge if you want belt and braces — the reporter's own workaround (putting `SRCREV` back into `PV`) also suggests it, since that changes `WORKDIR` and so sidesteps the stale marker.