### PR TITLE
tools: declare MIT rather than Apache-2.0

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: (C) 2020-2024 Joel Winarske
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 
 import errno
 import os

--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: (C) 2020-2025 Joel Winarske
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 #
 # Script to create Yocto recipes from a given path.
 #

--- a/tools/pubspec.py
+++ b/tools/pubspec.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: (C) 2024 Joel Winarske
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 #
 # pubspec.py
 #   used to archive and/or restore pub cache packages

--- a/tools/roll_meta_flutter.py
+++ b/tools/roll_meta_flutter.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: (C) 2020-2024 Joel Winarske
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 #
 # Script to roll meta-flutter layer
 #

--- a/tools/update_version_files.py
+++ b/tools/update_version_files.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # SPDX-FileCopyrightText: (C) 2020-2024 Joel Winarske
-# SPDX-License-Identifier: Apache-2.0
+# SPDX-License-Identifier: MIT
 #
 # Script to build custom Flutter AOT artifacts for Release and Profile runtime
 #


### PR DESCRIPTION
Step 1 of the #283 cleanup, kept separate because it is the one genuine licensing ambiguity in the layer and does not need to wait on the 277-file header sweep.

## Problem

Five scripts under `tools/` declared `SPDX-License-Identifier: Apache-2.0`:

```
tools/common.py  tools/create_recipes.py  tools/pubspec.py
tools/roll_meta_flutter.py  tools/update_version_files.py
```

The layer's only `LICENSE` is MIT. There is no `LICENSES/` directory, no `REUSE.toml`, and nothing in `README.md` or `conf/layer.conf` scoping `tools/` differently — so the repository asserted MIT at the root and Apache-2.0 in five files with nothing reconciling them.

## Why MIT

- All five were added in 2024 with the Apache-2.0 header already present, and none derive from an Apache-2.0 upstream, so it reads as a carry-over rather than a deliberate choice.
- They are substantially single-author. The only other contributions are two small changes from @shr-project: a one-line regexp fix in `common.py` (39adf5d7) and a six-line `UNPACKDIR` adaptation in `create_recipes.py` (f7726203).
- MIT matches the layer, so no additional scoping file or README statement is needed.

If the Apache-2.0 was in fact deliberate, the alternative is to keep it and declare the scope explicitly instead — happy to switch this PR to that shape.

## Result

Every `SPDX-License-Identifier` in the layer now reads `MIT`, consistent with `LICENSE`.

Comment-only change; `py_compile` clean, no functional effect and no build required.

## Not in scope

Deliberately left for the follow-up so this stays reviewable:

- the `All rights reserved` sweep across 277 files
- the two header-emitting sites at `tools/create_recipes.py:294` and `:414`, which restamp the old form into generated recipes
- year-range normalisation, and `LICENSE` itself still reading `2018-2021`
