### PR TITLE
common: report the output of a failed command

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -73,6 +73,22 @@ def run_command(d, cmd, cwd, env):
     bb.note(f'Output:{formatted_output}')
 
     if retval:
+        # bb.note() reaches only the task's log.do_* file on the builder. CI does
+        # not collect those, so a failure here has been arriving as a bare exit
+        # code with the diagnosis left behind on the machine -- 'flutter pub get
+        # --enforce-lockfile failed: 65' says nothing about which constraint pub
+        # objected to. Repeat the tail at error level so the reason travels with
+        # the failure. Tail rather than the whole capture because these commands
+        # are run with -v and the full output is thousands of lines; the failure
+        # is at the end, and the complete text is still in the task log for
+        # anyone on the builder. Raise FLUTTER_CMD_FAIL_LOG_LINES if the tail
+        # cuts something off.
+        limit = int(d.getVar('FLUTTER_CMD_FAIL_LOG_LINES') or 100)
+        tail = output.splitlines()[-limit:] if output else []
+        if tail:
+            elided = '' if len(tail) == len(output.splitlines()) else \
+                f' (last {len(tail)}; see log.do_* for the rest)'
+            bb.error(f'Output of failed command{elided}:\n  ' + '\n  '.join(tail))
         bb.fatal(f'{cmd} failed: {retval}')
 
 def md5_update_from_dir(directory, hash):


### PR DESCRIPTION
## Problem

`run_command()` in `conf/include/common.inc` captures a command's output and logs it with `bb.note()`. That reaches only the task's `log.do_*` file on the builder, which CI does not collect — so a failure arrives as a bare exit code:

```
ERROR: ivi-homescreen-osgi-activator-test-1.0.0-r0 do_archive_pub_cache:
  flutter pub get --enforce-lockfile failed: 65
```

Exit 65 says nothing about which constraint pub objected to, and the text that would say sits on a machine the reader may not have.

This came up twice today in one CI run, and neither was diagnosable from the log:

- `flutter pub get --enforce-lockfile failed: 65` on two integration tests
- `flutter build bundle --no-pub -v failed: 1` on the camera example

Both had to be worked out by inference from what else in the run passed.

## Change

On failure, repeat the tail of the captured output at error level so the reason travels with the failure.

Tail rather than the whole capture, because these commands run with `-v` and produce thousands of lines, the failure is at the end, and the complete text is still in the task log for anyone on the builder. `FLUTTER_CMD_FAIL_LOG_LINES` raises the limit; the default is 100.

## Behavior

Exercised against the real function body with stubbed `bb`/`d`:

| case | result |
|---|---|
| short output | shown whole, no elision marker |
| 500 lines, default limit | last 100, header reads `(last 100; see log.do_* for the rest)` |
| empty output | no error line added; `bb.fatal` still raised, so a silent failure reports exactly as before |
| `FLUTTER_CMD_FAIL_LOG_LINES=5` | 5 lines kept |

The success path is untouched — no duplicated output on builds that pass.