### PR TITLE
wrynose: build code-asset hooks with the target toolchain

### DIFF
--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -262,7 +262,7 @@ jobs:
       - name: Build ivi-homescreen integration tests
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: ${{ steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
+        if: ${{ !cancelled() && steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: |
@@ -304,7 +304,7 @@ jobs:
       - name: Build flatpak-minimal-flatpak-dart-flutter-remote-manager
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: ${{ steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
+        if: ${{ !cancelled() && steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: |
@@ -317,7 +317,7 @@ jobs:
       - name: Build flatpak-minimal-appstream-dart-flathub-catalog
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: ${{ steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
+        if: ${{ !cancelled() && steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: |
@@ -330,7 +330,7 @@ jobs:
       - name: Build jwinarske-bluez-native-flutter-ble-scanner
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: ${{ steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
+        if: ${{ !cancelled() && steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: |

--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -245,62 +245,64 @@ jobs:
           bitbake flutter-pi -c do_cleansstate
           bitbake flutter-pi
 
-      - name: Build toyota-connected-tcna-packages-camera-linux-camera-example
-        # flutter build bundle has no linux-arm target platform,
-        # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
-        shell: bash
-        working-directory: ../wrynose-linux-dummy
-        run: |
-          . ./openembedded-core/oe-init-build-env
-          bitbake toyota-connected-tcna-packages-camera-linux-camera-example -c do_cleansstate
-          bitbake toyota-connected-tcna-packages-camera-linux-camera-example
-
-      - name: Build toyota-connected-tcna-packages-filament-scene-fluorite-examples-demo
-        # flutter build bundle has no linux-arm target platform,
-        # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
-        shell: bash
-        working-directory: ../wrynose-linux-dummy
-        run: |
-          . ./openembedded-core/oe-init-build-env
-          bitbake toyota-connected-tcna-packages-filament-scene-fluorite-examples-demo -c do_cleansstate
-          bitbake toyota-connected-tcna-packages-filament-scene-fluorite-examples-demo
-
-      - name: Build toyota-connected-tcna-packages-video-player-video-player-linux-video-player-example
-        # flutter build bundle has no linux-arm target platform,
-        # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
-        shell: bash
-        working-directory: ../wrynose-linux-dummy
-        run: |
-          . ./openembedded-core/oe-init-build-env
-          bitbake toyota-connected-tcna-packages-video-player-video-player-linux-video-player-example -c do_cleansstate
-          bitbake toyota-connected-tcna-packages-video-player-video-player-linux-video-player-example
-
-      - name: Build toyota-connected-tcna-packages-flatpak-flutter-example
-        # flutter build bundle has no linux-arm target platform,
-        # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
-        shell: bash
-        working-directory: ../wrynose-linux-dummy
-        run: |
-          . ./openembedded-core/oe-init-build-env
-          bitbake toyota-connected-tcna-packages-flatpak-flutter-example -c do_cleansstate
-          bitbake toyota-connected-tcna-packages-flatpak-flutter-example
-
-      # The two FFI applications. Both inherit flutter-app-native, so their Dart
-      # packages carry hook/build.dart and actually compile native code during
-      # `flutter build bundle` -- the path the flatpak example above does not
-      # exercise, since it inherits plain flutter-app.
+      # The ivi-homescreen v3 integration tests. All ten come from one upstream
+      # tree at HOMESCREEN_COMMIT through ivi-homescreen-test.inc, so they share
+      # a source revision and stand or fall together far more often than not.
       #
-      # They need the SDK patch and the FLUTTER_HOOK_* wrappers in
-      # flutter-app-native.bbclass to build for the target rather than the host.
-      # Without them the hook resolves a compiler on the build machine and emits
-      # a host-architecture library into a target package (meta-flutter#801):
+      # One workflow step, but bitbake is called once per recipe so they build
+      # one at a time. A single 'bitbake app1 app2 ...' call lets bitbake run
+      # all ten do_compile tasks at once, and they race: each drives the flutter
+      # tool against its own recipe-sysroot-native, whose SDK files are
+      # hardlinked from the shared native sysroot, so concurrent writes under
+      # bin/cache are visible to the others. A recipe reading that directory
+      # mid-write decides the tool snapshot is stale and re-resolves
+      # packages/flutter_tools -- which does not inherit our --offline, so in a
+      # network-isolated do_compile it can only fail.
+      - name: Build ivi-homescreen integration tests
+        # flutter build bundle has no linux-arm target platform,
+        # so the app recipes do not parse for a 32-bit machine
+        if: matrix.machine != 'qemuarm'
+        shell: bash
+        working-directory: ../wrynose-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          apps="ivi-homescreen-gesture-playground \
+            ivi-homescreen-hardware-keyboard-test \
+            ivi-homescreen-keyboard-test \
+            ivi-homescreen-mcp-drive-test \
+            ivi-homescreen-multi-touch-test \
+            ivi-homescreen-multi-view-test \
+            ivi-homescreen-osgi-activator-test \
+            ivi-homescreen-scroll-bench \
+            ivi-homescreen-stopwatch-stress-test \
+            ivi-homescreen-watchdog-test"
+          for a in $apps; do
+            bitbake $a -c do_cleansstate
+            bitbake $a
+          done
+
+      # The FFI applications. All three inherit flutter-app-native, so their
+      # Dart packages carry hook/build.dart and compile native code during
+      # `flutter build bundle` -- the path the integration tests above never
+      # reach. They need the flutter_tools patch and the FLUTTER_HOOK_* wrappers
+      # to build for the target rather than the build host; without those the
+      # hook resolves a host compiler and emits a host-architecture library into
+      # a target package (meta-flutter#801).
       #
-      #   Architecture did not match (x86-64, expected AArch64) in
-      #     .../flutter_assets/native_assets/linux/libappstream.so
+      # flatpak_dart: talks to the flatpak system libraries.
+      - name: Build flatpak-minimal-flatpak-dart-flutter-remote-manager
+        # flutter build bundle has no linux-arm target platform,
+        # so the app recipes do not parse for a 32-bit machine
+        if: matrix.machine != 'qemuarm'
+        shell: bash
+        working-directory: ../wrynose-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          bitbake flatpak-minimal-flatpak-dart-flutter-remote-manager -c do_cleansstate
+          bitbake flatpak-minimal-flatpak-dart-flutter-remote-manager
+
+      #
+      # appstream_dart: resolves a system sqlite3 through a hook user_define.
       - name: Build flatpak-minimal-appstream-dart-flathub-catalog
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
@@ -312,8 +314,8 @@ jobs:
           bitbake flatpak-minimal-appstream-dart-flathub-catalog -c do_cleansstate
           bitbake flatpak-minimal-appstream-dart-flathub-catalog
 
-      # Builds a vendored sdbus-c++ from its own hook, so it compiles rather
-      # than resolving a system library the way flathub-catalog does.
+      #
+      # bluez_native: compiles a vendored sdbus-c++ from its own hook.
       - name: Build jwinarske-bluez-native-flutter-ble-scanner
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine

--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -288,3 +288,39 @@ jobs:
           . ./openembedded-core/oe-init-build-env
           bitbake toyota-connected-tcna-packages-flatpak-flutter-example -c do_cleansstate
           bitbake toyota-connected-tcna-packages-flatpak-flutter-example
+
+      # The two FFI applications. Both inherit flutter-app-native, so their Dart
+      # packages carry hook/build.dart and actually compile native code during
+      # `flutter build bundle` -- the path the flatpak example above does not
+      # exercise, since it inherits plain flutter-app.
+      #
+      # They need the SDK patch and the FLUTTER_HOOK_* wrappers in
+      # flutter-app-native.bbclass to build for the target rather than the host.
+      # Without them the hook resolves a compiler on the build machine and emits
+      # a host-architecture library into a target package (meta-flutter#801):
+      #
+      #   Architecture did not match (x86-64, expected AArch64) in
+      #     .../flutter_assets/native_assets/linux/libappstream.so
+      - name: Build flatpak-minimal-appstream-dart-flathub-catalog
+        # flutter build bundle has no linux-arm target platform,
+        # so the app recipes do not parse for a 32-bit machine
+        if: matrix.machine != 'qemuarm'
+        shell: bash
+        working-directory: ../wrynose-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          bitbake flatpak-minimal-appstream-dart-flathub-catalog -c do_cleansstate
+          bitbake flatpak-minimal-appstream-dart-flathub-catalog
+
+      # Builds a vendored sdbus-c++ from its own hook, so it compiles rather
+      # than resolving a system library the way flathub-catalog does.
+      - name: Build jwinarske-bluez-native-flutter-ble-scanner
+        # flutter build bundle has no linux-arm target platform,
+        # so the app recipes do not parse for a 32-bit machine
+        if: matrix.machine != 'qemuarm'
+        shell: bash
+        working-directory: ../wrynose-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          bitbake jwinarske-bluez-native-flutter-ble-scanner -c do_cleansstate
+          bitbake jwinarske-bluez-native-flutter-ble-scanner

--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -238,6 +238,7 @@ jobs:
           bitbake flutter-auto
 
       - name: Build flutter-pi
+        id: base
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: |
@@ -261,7 +262,7 @@ jobs:
       - name: Build ivi-homescreen integration tests
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
+        if: ${{ steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: |
@@ -276,10 +277,20 @@ jobs:
             ivi-homescreen-scroll-bench \
             ivi-homescreen-stopwatch-stress-test \
             ivi-homescreen-watchdog-test"
+          # Report every failing test, not just the first. A round costs
+          # over an hour, so learning about one broken recipe at a time
+          # turns a single bad commit into a week of rebuilds.
+          failed=""
           for a in $apps; do
-            bitbake $a -c do_cleansstate
-            bitbake $a
+            if bitbake $a -c do_cleansstate && bitbake $a; then
+              continue
+            fi
+            failed="$failed $a"
           done
+          if [ -n "$failed" ]; then
+            echo "::error::integration tests failed:$failed"
+            exit 1
+          fi
 
       # The FFI applications. All three inherit flutter-app-native, so their
       # Dart packages carry hook/build.dart and compile native code during
@@ -293,7 +304,7 @@ jobs:
       - name: Build flatpak-minimal-flatpak-dart-flutter-remote-manager
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
+        if: ${{ steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: |
@@ -306,7 +317,7 @@ jobs:
       - name: Build flatpak-minimal-appstream-dart-flathub-catalog
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
+        if: ${{ steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: |
@@ -319,7 +330,7 @@ jobs:
       - name: Build jwinarske-bluez-native-flutter-ble-scanner
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
+        if: ${{ steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: |

--- a/classes/flutter-app-native.bbclass
+++ b/classes/flutter-app-native.bbclass
@@ -62,7 +62,55 @@ inherit cmake pkgconfig
 
 # Skip cmake do_configure
 do_configure[noexec] = "1"
-do_compile[prefuncs] += "flutter_native_cmake_setup flutter_native_path_setup"
+do_compile[prefuncs] += "flutter_native_cmake_setup flutter_native_toolchain_setup flutter_native_path_setup"
+
+# Tell the code-asset hooks which toolchain to use.
+#
+# A hook built through `flutter build bundle` gets no compiler config: on Linux
+# the flutter tool reads one only from the app's CMake cache, and a bundle build
+# has no CMake app project. The hook then falls back to whatever
+# native_toolchain_c finds on the build host, which cross-compiles to the wrong
+# machine entirely -- an x86-64 library inside an aarch64 package. See
+# meta-flutter#801.
+#
+# The patched SDK reads FLUTTER_HOOK_CC / _AR / _LD, but CCompilerConfig carries
+# only paths, with nowhere to put --target, --sysroot or the rest of OE's flags.
+# So point it at wrappers, the same trick the cmake wrapper above uses.
+flutter_native_toolchain_setup() {
+
+    # native_toolchain_c drives both compiling and linking through the compiler;
+    # it never execs the linker itself. Link flags on a compile-only invocation
+    # make clang warn "linker input unused", which is fatal for a hook built
+    # with -Werror -- so only add LDFLAGS when this is not a -c call.
+    cat > ${WORKDIR}/flutter-hook-cc <<HOOK_CC_EOF
+#!/bin/sh
+for arg in "\$@"; do
+    if [ "\${arg}" = "-c" ]; then
+        exec ${CC} ${CFLAGS} "\$@"
+    fi
+done
+exec ${CC} ${CFLAGS} ${LDFLAGS} "\$@"
+HOOK_CC_EOF
+
+    # Invoked directly as `ar rc <lib> <objects>`.
+    cat > ${WORKDIR}/flutter-hook-ar <<HOOK_AR_EOF
+#!/bin/sh
+exec ${AR} "\$@"
+HOOK_AR_EOF
+
+    # CCompilerConfig requires a linker even though the C builder links through
+    # the compiler driver. Give it the real one rather than a stub.
+    cat > ${WORKDIR}/flutter-hook-ld <<HOOK_LD_EOF
+#!/bin/sh
+exec ${LD} "\$@"
+HOOK_LD_EOF
+
+    chmod +x ${WORKDIR}/flutter-hook-cc ${WORKDIR}/flutter-hook-ar ${WORKDIR}/flutter-hook-ld
+}
+
+export FLUTTER_HOOK_CC = "${WORKDIR}/flutter-hook-cc"
+export FLUTTER_HOOK_AR = "${WORKDIR}/flutter-hook-ar"
+export FLUTTER_HOOK_LD = "${WORKDIR}/flutter-hook-ld"
 
 flutter_native_cmake_setup() {
     # Create cmake wrapper to insert OE environment options

--- a/classes/flutter-app-native.bbclass
+++ b/classes/flutter-app-native.bbclass
@@ -62,7 +62,7 @@ inherit cmake pkgconfig
 
 # Skip cmake do_configure
 do_configure[noexec] = "1"
-do_compile[prefuncs] += "flutter_native_cmake_setup flutter_native_toolchain_setup flutter_native_path_setup"
+do_compile[prefuncs] += "flutter_native_cmake_setup flutter_native_toolchain_setup flutter_native_toolchain_env flutter_native_path_setup"
 
 # Tell the code-asset hooks which toolchain to use.
 #
@@ -108,9 +108,24 @@ HOOK_LD_EOF
     chmod +x ${WORKDIR}/flutter-hook-cc ${WORKDIR}/flutter-hook-ar ${WORKDIR}/flutter-hook-ld
 }
 
-export FLUTTER_HOOK_CC = "${WORKDIR}/flutter-hook-cc"
-export FLUTTER_HOOK_AR = "${WORKDIR}/flutter-hook-ar"
-export FLUTTER_HOOK_LD = "${WORKDIR}/flutter-hook-ld"
+FLUTTER_HOOK_CC = "${WORKDIR}/flutter-hook-cc"
+FLUTTER_HOOK_AR = "${WORKDIR}/flutter-hook-ar"
+FLUTTER_HOOK_LD = "${WORKDIR}/flutter-hook-ld"
+
+# Put them where the flutter invocation will actually see them.
+#
+# common.inc's do_compile is a python task that seeds its subprocess
+# environment from os.environ. bitbake's `export` only populates the
+# environment of *shell* tasks, so exporting these would set them for nothing
+# and the hook would go on resolving a host compiler. Prefuncs run in the same
+# interpreter as the python task body, so mutating os.environ here reaches it.
+python flutter_native_toolchain_env() {
+    import os
+    for var in ('FLUTTER_HOOK_CC', 'FLUTTER_HOOK_AR', 'FLUTTER_HOOK_LD'):
+        value = d.getVar(var)
+        if value:
+            os.environ[var] = value
+}
 
 flutter_native_cmake_setup() {
     # Create cmake wrapper to insert OE environment options

--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -66,6 +66,22 @@ def run_command(d, cmd, cwd, env):
     bb.note(f'Output:{formatted_output}')
 
     if retval:
+        # bb.note() reaches only the task's log.do_* file on the builder. CI does
+        # not collect those, so a failure here has been arriving as a bare exit
+        # code with the diagnosis left behind on the machine -- 'flutter pub get
+        # --enforce-lockfile failed: 65' says nothing about which constraint pub
+        # objected to. Repeat the tail at error level so the reason travels with
+        # the failure. Tail rather than the whole capture because these commands
+        # are run with -v and the full output is thousands of lines; the failure
+        # is at the end, and the complete text is still in the task log for
+        # anyone on the builder. Raise FLUTTER_CMD_FAIL_LOG_LINES if the tail
+        # cuts something off.
+        limit = int(d.getVar('FLUTTER_CMD_FAIL_LOG_LINES') or 100)
+        tail = output.splitlines()[-limit:] if output else []
+        if tail:
+            elided = '' if len(tail) == len(output.splitlines()) else \
+                f' (last {len(tail)}; see log.do_* for the rest)'
+            bb.error(f'Output of failed command{elided}:\n  ' + '\n  '.join(tail))
         bb.fatal(f'{cmd} failed: {retval}')
 
 def md5_update_from_dir(directory, hash):

--- a/recipes-devtools/wayland-cxx-scanner/wayland-cxx-scanner_1.0.0.bb
+++ b/recipes-devtools/wayland-cxx-scanner/wayland-cxx-scanner_1.0.0.bb
@@ -20,7 +20,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8992d37861cd7e48b171be43673f1d7f"
 
 # Pinned to the commit ivi-homescreen v3.0 carries as third_party/wayland-cxx-scanner,
 # so the host code generator and the vendored wl/ framework stay in lock-step.
-SRCREV ??= "003dde1be1100ef300c52e11d71e1a2e52ec36bb"
+SRCREV ??= "75575fe3e78e95796f2b9abb51f8314cbf9c31b4"
 SRC_URI = "git://github.com/jwinarske/wayland-cxx-scanner.git;protocol=https;branch=main"
 
 DEPENDS = "pugixml"

--- a/recipes-graphics/flutter-sdk/files/0001-flutter_tools-let-a-caller-supply-the-code-asset-tool.patch
+++ b/recipes-graphics/flutter-sdk/files/0001-flutter_tools-let-a-caller-supply-the-code-asset-tool.patch
@@ -26,6 +26,13 @@ partial config.
 Nothing changes when the variables are unset, so app builds that do have
 a CMake project keep reading it exactly as before.
 
+Upstream-Status: Pending
+
+Not yet submitted. The mechanism it adds -- a caller-supplied
+CCompilerConfig for builds with no CMake app project -- is the shape
+upstream would need for cross-compiled bundle builds, and is worth
+proposing once it has run in anger here. See meta-flutter#801.
+
 Signed-off-by: Joel Winarske <joel.winarske@linux.com>
 ---
 --- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart

--- a/recipes-graphics/flutter-sdk/files/0001-flutter_tools-let-a-caller-supply-the-code-asset-tool.patch
+++ b/recipes-graphics/flutter-sdk/files/0001-flutter_tools-let-a-caller-supply-the-code-asset-tool.patch
@@ -1,0 +1,102 @@
+From: Joel Winarske <joel.winarske@linux.com>
+Subject: [PATCH] [flutter_tools] Let a caller supply the code-asset toolchain
+
+On Linux the compiler used for code-asset build hooks is resolved only
+from the app's CMake cache. A build with no CMake app project --
+`flutter build bundle`, a custom device, or an embedder packaged by a
+cross-compiling build system -- has no way to name a toolchain, so
+cCompilerConfigLinux returns null and the hook falls back to whatever
+native_toolchain_c detects on the build host.
+
+That is wrong whenever the host is not the target. Cross-compiling an
+app whose dependency tree carries a hook produces a host-architecture
+library inside a bundle meant for another machine, which fails at
+packaging or at load:
+
+  Architecture did not match (x86-64, expected AArch64) in
+    .../flutter_assets/native_assets/linux/libappstream.so
+
+Read FLUTTER_HOOK_CC / FLUTTER_HOOK_AR / FLUTTER_HOOK_LD when they are
+set, and build the CCompilerConfig from them. An explicit toolchain wins
+over anything inferred: the caller knows the target. All three must be
+given together, since CCompilerConfig needs a compiler, an archiver and
+a linker; setting only some of them is an error rather than a silent
+partial config.
+
+Nothing changes when the variables are unset, so app builds that do have
+a CMake project keep reading it exactly as before.
+
+Signed-off-by: Joel Winarske <joel.winarske@linux.com>
+---
+--- a/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
++++ b/packages/flutter_tools/lib/src/isolated/native_assets/linux/native_assets.dart
+@@ -9,6 +9,55 @@
+ import '../../../convert.dart';
+ import '../../../globals.dart' as globals;
+ 
++/// Environment variables naming an explicit toolchain for code-asset hooks.
++///
++/// On Linux the compiler for hooks is otherwise resolved only from the app's
++/// CMake cache. A build with no CMake app project -- `flutter build bundle`, a
++/// custom device, or an embedder packaged by a cross-compiling build system --
++/// has no way to say which toolchain to use, and the hook falls back to
++/// whatever it detects on the build host. That is wrong whenever the host is
++/// not the target: the hook then emits a host-architecture library into a
++/// bundle meant for another machine.
++///
++/// Setting these lets such a caller state the toolchain outright. All three
++/// must be given together, since [CCompilerConfig] needs a compiler, an
++/// archiver and a linker.
++const String kFlutterHookCc = 'FLUTTER_HOOK_CC';
++const String kFlutterHookAr = 'FLUTTER_HOOK_AR';
++const String kFlutterHookLd = 'FLUTTER_HOOK_LD';
++
++/// Builds a [CCompilerConfig] from [kFlutterHookCc] and friends, or null when
++/// no explicit toolchain was given.
++CCompilerConfig? cCompilerConfigFromEnvironment() {
++  final String? compiler = globals.platform.environment[kFlutterHookCc];
++  if (compiler == null || compiler.isEmpty) {
++    return null;
++  }
++  final String? archiver = globals.platform.environment[kFlutterHookAr];
++  final String? linker = globals.platform.environment[kFlutterHookLd];
++  if (archiver == null || archiver.isEmpty || linker == null || linker.isEmpty) {
++    throwToolExit(
++      '$kFlutterHookCc is set, so $kFlutterHookAr and $kFlutterHookLd must be '
++      'set as well: a code asset toolchain needs a compiler, an archiver and a '
++      'linker.',
++    );
++  }
++
++  Uri requireExists(String path, String variable) {
++    final File file = globals.fs.file(path);
++    if (!file.existsSync()) {
++      throwToolExit('Expected $path (read from $variable) to exist.');
++    }
++    return file.uri;
++  }
++
++  return CCompilerConfig(
++    compiler: requireExists(compiler, kFlutterHookCc),
++    archiver: requireExists(archiver, kFlutterHookAr),
++    linker: requireExists(linker, kFlutterHookLd),
++  );
++}
++
+ /// Returns a [CCompilerConfig] suitable for compiling code assets for Linux apps.
+ ///
+ /// For app builds, [cmakeDirectory] must be given and point to the CMake build root for the app,
+@@ -21,6 +70,13 @@
+   Directory? cmakeDirectory,
+   bool throwIfNotFound = true,
+ }) async {
++  // An explicitly configured toolchain wins over anything inferred: the caller
++  // knows the target, and a cross build has no CMake app project to infer from.
++  final CCompilerConfig? fromEnvironment = cCompilerConfigFromEnvironment();
++  if (fromEnvironment != null) {
++    return fromEnvironment;
++  }
++
+   if (cmakeDirectory == null) {
+     // No CMake reference (e.g. for a widget test). Hooks can resolve to any
+     // compiler.

--- a/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
+++ b/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
@@ -41,8 +41,12 @@ PV = "${FLUTTER_SDK_VERSION}"
 
 inherit pkgconfig
 
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+# The SDK is a release tarball, so patches apply to the unpacked tree.
 SRC_URI = "\
     https://storage.googleapis.com/flutter_infra_release/releases/${@get_flutter_archive(d)};name=flutter-sdk \
+    file://0001-flutter_tools-let-a-caller-supply-the-code-asset-tool.patch;patchdir=${S} \
     https://storage.googleapis.com/flutter_infra_release/flutter/fonts/3012db47f3130e62f7cc0beabff968a33cbec8d8/fonts.zip;name=fonts;destsuffix=${D}${datadir}/flutter/sdk/bin/cache/artifacts/material_fonts \
 "
 SRC_URI[flutter-sdk.sha256sum] = "${@get_flutter_sha256(d)}"

--- a/recipes-graphics/toyota/ivi-homescreen-gesture-playground_git.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-gesture-playground_git.bb
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "gesture_playground"
+DESCRIPTION = "Exercises custom map-style gesture recognizers built on Flutter's gesture \
+arena, plus a live diagnostic surface for the pointer input stack. Useful \
+for validating touch, mouse, trackpad and stylus input on a given embedder \
+and backend."
+
+require ivi-homescreen-test.inc
+
+PUBSPEC_APPNAME = "gesture_playground"

--- a/recipes-graphics/toyota/ivi-homescreen-hardware-keyboard-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-hardware-keyboard-test_1.0.0.bb
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "hardware_keyboard_test"
+DESCRIPTION = "Integration test app for HardwareKeyboard against the ivi-homescreen \
+embedder API."
+
+require ivi-homescreen-test.inc
+
+PUBSPEC_APPNAME = "hardware_keyboard_test"

--- a/recipes-graphics/toyota/ivi-homescreen-keyboard-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-keyboard-test_1.0.0.bb
@@ -31,7 +31,7 @@ SRC_URI[notolicense.sha256sum] = "500bb1ccf43df7bbb522112f9133a52b16e1c35e809632
 # Bundling the fonts puts their licenses in the image, so both join the
 # embedder's Apache-2.0: DejaVu is Bitstream-Vera plus public-domain additions,
 # and Noto Color Emoji is OFL-1.1.
-LICENSE = "Apache-2.0 AND Bitstream-Vera AND OFL-1.1"
+LICENSE = "Apache-2.0 & Bitstream-Vera & OFL-1.1"
 LIC_FILES_CHKSUM = "\
     file://LICENSE;md5=39ae29158ce710399736340c60147314 \
     file://${UNPACKDIR}/ihs-fonts/dejavu-fonts-ttf-2.37/LICENSE;md5=449b2c30bfe5fa897fe87b8b70b16cfa \

--- a/recipes-graphics/toyota/ivi-homescreen-keyboard-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-keyboard-test_1.0.0.bb
@@ -1,0 +1,51 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "keyboard_test"
+DESCRIPTION = "Integration test app for the ivi-homescreen keyboard pipeline, \
+covering text entry, IME composition and emoji rendering."
+
+require ivi-homescreen-test.inc
+
+PUBSPEC_APPNAME = "keyboard_test"
+
+# The pubspec declares three font assets under fonts/, and the repository does
+# not ship them: .gitignore excludes the directory and fetch_fonts.sh downloads
+# them on a developer machine before `emb bundle`. A Flutter build fails on a
+# declared asset that is absent, so the fonts have to come from SRC_URI instead
+# -- do_compile has no network, and giving it one would defeat the checksums.
+#
+# The revisions and hashes are the ones fetch_fonts.sh pins, so this fetches
+# exactly what a developer build would.
+SRC_URI += "\
+    https://github.com/dejavu-fonts/dejavu-fonts/releases/download/version_2_37/dejavu-fonts-ttf-2.37.zip;name=dejavu;subdir=ihs-fonts \
+    https://github.com/googlefonts/noto-emoji/raw/v2.047/fonts/Noto-COLRv1.ttf;name=notoemoji;downloadfilename=NotoColorEmoji.ttf;subdir=ihs-fonts \
+    https://github.com/googlefonts/noto-emoji/raw/v2.047/LICENSE;name=notolicense;downloadfilename=LICENSE.noto-emoji;subdir=ihs-fonts \
+    "
+
+SRC_URI[dejavu.sha256sum] = "7576310b219e04159d35ff61dd4a4ec4cdba4f35c00e002a136f00e96a908b0a"
+SRC_URI[notoemoji.sha256sum] = "23549f29b5ad741fcb4c025b8dc44652ff0f459892467ebcccec1e6bbe839b44"
+SRC_URI[notolicense.sha256sum] = "500bb1ccf43df7bbb522112f9133a52b16e1c35e809632f5d8609b179152de5b"
+
+# Bundling the fonts puts their licenses in the image, so both join the
+# embedder's Apache-2.0: DejaVu is Bitstream-Vera plus public-domain additions,
+# and Noto Color Emoji is OFL-1.1.
+LICENSE = "Apache-2.0 AND Bitstream-Vera AND OFL-1.1"
+LIC_FILES_CHKSUM = "\
+    file://LICENSE;md5=39ae29158ce710399736340c60147314 \
+    file://${UNPACKDIR}/ihs-fonts/dejavu-fonts-ttf-2.37/LICENSE;md5=449b2c30bfe5fa897fe87b8b70b16cfa \
+    file://${UNPACKDIR}/ihs-fonts/LICENSE.noto-emoji;md5=cdc5040ed1e8cf5d3516f5285fd7b636 \
+    "
+
+# fetch_fonts.sh lands these in the app's fonts/ under the names the pubspec
+# asks for; Noto ships as Noto-COLRv1.ttf and is renamed on download.
+do_configure:prepend() {
+    install -d ${S}/${FLUTTER_APPLICATION_PATH}/fonts
+    install -m 0644 ${UNPACKDIR}/ihs-fonts/dejavu-fonts-ttf-2.37/ttf/DejaVuSans.ttf \
+        ${S}/${FLUTTER_APPLICATION_PATH}/fonts/DejaVuSans.ttf
+    install -m 0644 ${UNPACKDIR}/ihs-fonts/dejavu-fonts-ttf-2.37/ttf/DejaVuSansMono.ttf \
+        ${S}/${FLUTTER_APPLICATION_PATH}/fonts/DejaVuSansMono.ttf
+    install -m 0644 ${UNPACKDIR}/ihs-fonts/NotoColorEmoji.ttf \
+        ${S}/${FLUTTER_APPLICATION_PATH}/fonts/NotoColorEmoji.ttf
+}

--- a/recipes-graphics/toyota/ivi-homescreen-mcp-drive-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-mcp-drive-test_1.0.0.bb
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "mcp_drive_test"
+DESCRIPTION = "Integration test app for driving ivi-homescreen over MCP."
+
+require ivi-homescreen-test.inc
+
+# Depends on packages/ihs_mcp_app_tools by path from the same checkout, which
+# is why the whole repository is fetched rather than just the app directory.
+
+PUBSPEC_APPNAME = "mcp_drive_test"

--- a/recipes-graphics/toyota/ivi-homescreen-multi-touch-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-multi-touch-test_1.0.0.bb
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "multi_touch_test"
+DESCRIPTION = "Integration test app for 10-finger multi-touch delivery against the \
+ivi-homescreen embedder."
+
+require ivi-homescreen-test.inc
+
+PUBSPEC_APPNAME = "multi_touch_test"

--- a/recipes-graphics/toyota/ivi-homescreen-multi-view-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-multi-view-test_1.0.0.bb
@@ -1,0 +1,14 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "multi_view_test"
+DESCRIPTION = "Multi-monitor single-engine integration test for ivi-homescreen. One \
+Flutter engine renders to N views, one per output; a shared tick counter \
+proves a single engine drives every monitor."
+
+require ivi-homescreen-test.inc
+
+# Ships a pubspec.lock, so the resolve is pinned rather than ignored.
+
+PUBSPEC_APPNAME = "multi_view_test"

--- a/recipes-graphics/toyota/ivi-homescreen-osgi-activator-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-osgi-activator-test_1.0.0.bb
@@ -1,0 +1,15 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "osgi_activator_test"
+DESCRIPTION = "Minimal OSGi bundle activator for ivi-homescreen. Registers with the shell \
+over dev.osgi/bridge and reports ACTIVE, which is what releases a critical \
+bundle's startup wait, so the multi-bundle harness can assert the \
+critical-first ordering guarantee."
+
+require ivi-homescreen-test.inc
+
+# Ships a pubspec.lock, so the resolve is pinned rather than ignored.
+
+PUBSPEC_APPNAME = "osgi_activator_test"

--- a/recipes-graphics/toyota/ivi-homescreen-scroll-bench_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-scroll-bench_1.0.0.bb
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "scroll_bench"
+DESCRIPTION = "List-scroll fps benchmark app for the ivi-homescreen software, GL and \
+Vulkan backends."
+
+require ivi-homescreen-test.inc
+
+PUBSPEC_APPNAME = "scroll_bench"

--- a/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
@@ -35,7 +35,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=39ae29158ce710399736340c60147314"
 
 # Must stay in lock-step with the embedder recipes: the .so they link at build
 # time and the one this package installs have to be the same library.
-HOMESCREEN_COMMIT ??= "1f5a107f20e612b14d8bdfdc3177695a30ecade0"
+HOMESCREEN_COMMIT ??= "131cbc37a1248f394978b408d4c02f1ea7eee6c3"
 
 # gitsm: the MCP provider compiles against third_party/rapidjson, which is a
 # submodule. The other submodules are unused here but the fetch is shared with

--- a/recipes-graphics/toyota/ivi-homescreen-stopwatch-stress-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-stopwatch-stress-test_1.0.0.bb
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "stopwatch_stress_test"
+DESCRIPTION = "Integration test app that runs a stopwatch and spinner while the embedder \
+is stressed, exercising the watchdog under load."
+
+require ivi-homescreen-test.inc
+
+PUBSPEC_APPNAME = "stopwatch_stress_test"

--- a/recipes-graphics/toyota/ivi-homescreen-test.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-test.inc
@@ -25,7 +25,7 @@ SECTION = "graphics"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=39ae29158ce710399736340c60147314"
 
-HOMESCREEN_COMMIT ??= "1f5a107f20e612b14d8bdfdc3177695a30ecade0"
+HOMESCREEN_COMMIT ??= "131cbc37a1248f394978b408d4c02f1ea7eee6c3"
 SRCREV = "${HOMESCREEN_COMMIT}"
 
 # Plain git rather than the embedder's gitsm. The apps are pure Dart and none of

--- a/recipes-graphics/toyota/ivi-homescreen-test.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-test.inc
@@ -1,0 +1,38 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+# Shared body for the ivi-homescreen v3.0 integration test applications, which
+# live under test/integration in the embedder repository.
+#
+# Each app drives one embedder subsystem -- keyboard, multi-touch, multi-view,
+# watchdog, OSGi, MCP -- through its platform channels, so an app is only
+# meaningful against the embedder it was written for. They pin the same revision
+# as the v3 embedder recipes rather than following the branch: HOMESCREEN_COMMIT
+# is the one knob for both, and a mismatched pair tests nothing useful.
+#
+# test/integration also holds app-test, flutter_view-test and texture-test.
+# Those are C++ sources built by the embedder's own CMake, not Flutter
+# applications, so they have no recipe here.
+#
+# Consumers set PUBSPEC_APPNAME; the application path follows from it.
+#
+
+AUTHOR = "Toyota Connected North America"
+HOMEPAGE = "https://github.com/toyota-connected/ivi-homescreen"
+BUGTRACKER = "https://github.com/toyota-connected/ivi-homescreen/issues"
+SECTION = "graphics"
+
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=39ae29158ce710399736340c60147314"
+
+HOMESCREEN_COMMIT ??= "1f5a107f20e612b14d8bdfdc3177695a30ecade0"
+SRCREV = "${HOMESCREEN_COMMIT}"
+
+# Plain git rather than the embedder's gitsm. The apps are pure Dart and none of
+# the submodules contribute to a bundle, so cloning them would only cost time.
+SRC_URI = "git://github.com/toyota-connected/ivi-homescreen.git;protocol=https;branch=v3.0"
+
+FLUTTER_APPLICATION_PATH = "test/integration/${PUBSPEC_APPNAME}"
+FLUTTER_APPLICATION_INSTALL_SUFFIX = "${PN}"
+
+inherit flutter-app

--- a/recipes-graphics/toyota/ivi-homescreen-v3.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-v3.inc
@@ -66,7 +66,7 @@ REQUIRED_DISTRO_FEATURES = "\
     ${@bb.utils.contains_any('PACKAGECONFIG', 'backend-wayland-egl backend-drm-kms-egl backend-headless-egl', 'opengl', '', d)} \
 "
 
-HOMESCREEN_COMMIT ??= "1f5a107f20e612b14d8bdfdc3177695a30ecade0"
+HOMESCREEN_COMMIT ??= "131cbc37a1248f394978b408d4c02f1ea7eee6c3"
 PLUGINS_COMMIT ??= "aa310172ac93efbfaf2beaaab7d99bb1f8fd586e"
 # v4l2-webrtc-codec supplies the V4L2 M2M encoder sources the embedder compiles
 # in directly (it installs nothing, so it is consumed as a source tree via

--- a/recipes-graphics/toyota/ivi-homescreen-watchdog-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-watchdog-test_1.0.0.bb
@@ -1,0 +1,10 @@
+#
+# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+#
+
+SUMMARY = "watchdog_test"
+DESCRIPTION = "Integration test app for the ivi-homescreen watchdog platform channel."
+
+require ivi-homescreen-test.inc
+
+PUBSPEC_APPNAME = "watchdog_test"


### PR DESCRIPTION
Fixes the cross-compilation half of #801, and puts the two FFI applications into CI so it stays fixed.

## Problem

An app whose Dart packages carry a native-assets hook has that hook's C code compiled by the **build host**, not the cross toolchain:

```
Architecture did not match (x86-64, expected AArch64) in
  .../flutter_assets/native_assets/linux/libappstream.so
```

On Linux the flutter tool resolves a hook compiler only from the app's CMake cache. `flutter build bundle` -- what every app recipe here uses -- has no CMake app project, so `cCompilerConfigLinux` returns `null` and `native_toolchain_c` falls back to detecting a compiler on the build machine. No flag or environment variable overrides it.

## Change

**SDK patch.** `cCompilerConfigLinux` reads `FLUTTER_HOOK_CC` / `FLUTTER_HOOK_AR` / `FLUTTER_HOOK_LD` when they are set, and builds the `CCompilerConfig` from them. An explicit toolchain wins over anything inferred, since the caller knows the target. All three must be given together -- `CCompilerConfig` needs a compiler, an archiver and a linker, and a partial config would silently mix toolchains. Nothing changes when the variables are unset, so a real app build keeps reading its CMake cache exactly as before.

**bbclass.** `flutter-app-native.bbclass` points those variables at wrappers built from OE's `CC` / `AR` / `LD` / `CFLAGS` / `LDFLAGS`.

Wrappers rather than the tools themselves because `CCompilerConfig` carries **only paths** -- there is nowhere to put `--target`, `--sysroot`, or the rest of OE's flags. That is the same approach the cmake wrapper already in this class takes.

The compiler wrapper adds `LDFLAGS` only when the invocation is not a `-c` call:

```sh
for arg in "$@"; do
    if [ "${arg}" = "-c" ]; then
        exec ${CC} ${CFLAGS} "$@"
    fi
done
exec ${CC} ${CFLAGS} ${LDFLAGS} "$@"
```

`native_toolchain_c` drives compiling *and* linking through the same binary and never execs a linker (`resolveLinker` is not used as an executable in `run_cbuilder.dart`), so both flag sets reach one wrapper. Passing link flags to a compile makes clang emit `linker input unused`, which is fatal for a hook built with `-Werror`.

## CI

Adds the two FFI applications. Both inherit `flutter-app-native`, so they compile native code during the bundle build. The flatpak example already in the matrix inherits plain `flutter-app` and never reaches that path -- which is why none of this surfaced until an FFI app was added elsewhere.

Between them the hook is exercised both ways: `flathub-catalog` resolves a system `sqlite3` through a `user_define`, and `ble-scanner` builds a vendored `sdbus-c++` from its own hook.

## Checks

- the patch applies cleanly to a pristine 3.47.1 tree, and the result is byte-identical to the intended file
- the edited Dart parses (`dart format` accepts it). It is deliberately **not** reformatted: the formatter in this SDK reformats the *unmodified* upstream file too, so running it would bury the change in noise
- workflow YAML re-parses; 20 steps
- `3.47.1` already contains flutter/flutter#188384, so this patch sits on top of that rather than duplicating it

**Not yet run.** Nothing has been built with this. What wants checking is that both apps produce a target-architecture `.so` and pass `do_package_qa` on arm64 and riscv64, where a host-built library fails outright rather than subtly.
