### PR TITLE
wrynose: clean after an interrupted run, and stop evicting trees that fit

### DIFF
--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -145,6 +145,40 @@ jobs:
           done
           exit $rc
 
+      # Recover from a run that did not finish.
+      #
+      # Every recipe used to be cleansstate'd before building, which rebuilt the
+      # whole layer from source on every job to guard against state left by an
+      # interrupted build. That is an hour a round spent on something that only
+      # happens after an abnormal exit, and it guarded narrowly: a per-recipe
+      # clean cannot fix the cross-recipe drift that actually bites here --
+      # orphaned entries in build/tmp/sysroots-components, or a partially
+      # written sstate manifest -- which is why runner-maintenance.yml wipes
+      # build/tmp instead.
+      #
+      # So clean when it is warranted and not otherwise. The marker is written
+      # before the first build and removed only after the last one succeeds, so
+      # it survives exactly the cases that leave bad state: a cancelled run, an
+      # OOM kill, a crashed worker. Finding it means the previous run died
+      # mid-build, and build/tmp goes -- strictly more than the old per-recipe
+      # clean did, and regenerable from the shared sstate mount.
+      - name: Recover from an interrupted run
+        shell: bash
+        working-directory: ../wrynose-linux-dummy
+        run: |
+          MARKER=.ci-build-incomplete
+          if [ -e "$MARKER" ]; then
+            echo "::warning::previous run did not finish; removing build/tmp"
+            if [ -d build/tmp ]; then
+              echo "removing $(du -sh build/tmp | cut -f1) from build/tmp"
+              rm -rf build/tmp
+            fi
+            rm -f "$MARKER"
+          else
+            echo "previous run finished cleanly; keeping build/tmp"
+          fi
+          : > "$MARKER"
+
       - name: Configure build
         shell: bash
         working-directory: ../wrynose-linux-dummy
@@ -189,7 +223,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake ca-certificates -c do_cleansstate
           bitbake ca-certificates
 
       - name: Build ca-certificates-native
@@ -197,7 +230,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake ca-certificates-native -c do_cleansstate
           bitbake ca-certificates-native
 
       - name: Build flutter-sdk-native
@@ -205,7 +237,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-sdk-native -c do_cleansstate
           bitbake flutter-sdk-native
 
       - name: Build dart-sdk
@@ -213,7 +244,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake dart-sdk -c do_cleansstate
           bitbake dart-sdk
 
       - name: Build sentry
@@ -221,7 +251,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake sentry -c do_cleansstate
           bitbake sentry
 
       - name: Build rive-text
@@ -229,7 +258,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake rive-text -c do_cleansstate
           bitbake rive-text
 
       - name: Build flutter-engine
@@ -237,7 +265,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-engine -c do_cleansstate
           bitbake flutter-engine
 
       - name: Build ivi-homescreen
@@ -245,7 +272,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake ivi-homescreen -c do_cleansstate
           bitbake ivi-homescreen
 
       - name: Build flutter-auto
@@ -253,7 +279,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-auto -c do_cleansstate
           bitbake flutter-auto
 
       - name: Build flutter-pi
@@ -262,7 +287,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-pi -c do_cleansstate
           bitbake flutter-pi
 
       # The ivi-homescreen v3 integration tests. All ten come from one upstream
@@ -301,7 +325,7 @@ jobs:
           # turns a single bad commit into a week of rebuilds.
           failed=""
           for a in $apps; do
-            if bitbake $a -c do_cleansstate && bitbake $a; then
+            if bitbake $a; then
               continue
             fi
             failed="$failed $a"
@@ -328,7 +352,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flatpak-minimal-flatpak-dart-flutter-remote-manager -c do_cleansstate
           bitbake flatpak-minimal-flatpak-dart-flutter-remote-manager
 
       #
@@ -341,7 +364,6 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flatpak-minimal-appstream-dart-flathub-catalog -c do_cleansstate
           bitbake flatpak-minimal-appstream-dart-flathub-catalog
 
       #
@@ -354,5 +376,11 @@ jobs:
         working-directory: ../wrynose-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake jwinarske-bluez-native-flutter-ble-scanner -c do_cleansstate
           bitbake jwinarske-bluez-native-flutter-ble-scanner
+
+      # Only reached when every step above succeeded; a failed or cancelled run
+      # leaves the marker behind for the next one to act on.
+      - name: Mark the build complete
+        shell: bash
+        working-directory: ../wrynose-linux-dummy
+        run: rm -f .ci-build-incomplete

--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -83,17 +83,31 @@ jobs:
 
       - name: Free other release-branch trees
         run: |
-          # Only one release branch keeps a populated tmp at a time. master's
-          # tree is deliberately left alone so its per-pull-request builds stay
-          # fast.
-          for d in ../*-linux-dummy; do
-            case "$(basename "$d")" in
-              master-linux-dummy|wrynose-linux-dummy) continue ;;
-            esac
-            [ -d "$d/build/tmp" ] || continue
-            echo "removing $(du -sh "$d/build/tmp" | cut -f1) from $d/build/tmp"
-            rm -rf "$d/build/tmp"
-          done
+          # Reclaim other release branches' build/tmp, but only when the disk
+          # is actually short.
+          #
+          # This used to run unconditionally, on the assumption that a tree
+          # measures around 106G and so only two would fit. Measured, the five
+          # trees come to 153G in total -- 19G to 34G each -- against terabytes
+          # free. Every job was destroying 30-50G that the next build of that
+          # branch then re-extracted from sstate, for space that was never
+          # scarce. master's tree is left alone regardless, so its
+          # per-pull-request builds stay fast.
+          MIN_FREE_GB=${CI_MIN_FREE_GB:-300}
+          free_gb=$(df -BG --output=avail . | tail -1 | tr -dc '0-9')
+          if [ "${free_gb:-0}" -ge "$MIN_FREE_GB" ]; then
+            echo "${free_gb}G free (>= ${MIN_FREE_GB}G), keeping the other release trees"
+          else
+            echo "${free_gb}G free (< ${MIN_FREE_GB}G), reclaiming other release trees"
+            for d in ../*-linux-dummy; do
+              case "$(basename "$d")" in
+                master-linux-dummy|wrynose-linux-dummy) continue ;;
+              esac
+              [ -d "$d/build/tmp" ] || continue
+              echo "removing $(du -sh "$d/build/tmp" | cut -f1) from $d/build/tmp"
+              rm -rf "$d/build/tmp"
+            done
+          fi
 
       - name: Fetch poky
         run: |


### PR DESCRIPTION
Two CI changes, measured against the last green kirkstone run (x86-64 job 30m01s with warm sstate, 62m wall clock for the matrix).

## Reclaim other branches' trees only when the disk is short

The step ran unconditionally, justified in its own comment by a tree measuring "around 106G", so only two would fit. Measured on the runner:

| tree | total | build/tmp |
|---|---|---|
| kirkstone | 34G | absent |
| master | 31G | 31G |
| scarthgap | 25G | absent |
| dunfell | 21G | absent |
| wrynose | 19G | 18G |

153G for all five, against terabytes free. So every job destroyed 30–50G that the next build of that branch re-extracted from sstate — the kirkstone jobs logged `removing 31G from ../wrynose-linux-dummy/build/tmp` while the volume sat at 5% used.

Now it checks free space first and reclaims only below a threshold (`CI_MIN_FREE_GB`, default 300). master's tree is still exempt.

## Clean after an interrupted run, not before every build

Every recipe was `cleansstate`'d before building — 13 named plus the integration-test loop — so the whole layer rebuilt from source on each of the four jobs. `flutter-engine` (8m53s) and `dart-sdk` (5m46s) alone come to roughly an hour per round across the matrix, while sstate sat at `92% match, 99% complete` for everything else. The misses were precisely the recipes CI had just cleaned.

The point of that clean is recovering from state left by an interrupted build. But a *per-recipe* clean can't fix what actually bites a persistent runner — orphaned `build/tmp/sysroots-components` entries, or a partially written sstate manifest. Neither belongs to the recipe being cleaned, which is why `runner-maintenance.yml` removes `build/tmp` instead.

So clean when it's warranted:

- a marker is written before the first build
- it is removed only after the last build succeeds
- finding it at the start of a run means the previous one died mid-build — cancelled, OOM-killed, crashed — and `build/tmp` goes

That is strictly more than the old per-recipe clean removed, regenerable from the shared sstate mount, and free on the normal path.

### The trade

A recipe whose signature hasn't changed is no longer rebuilt from source every run. It was last built from source when it last changed, which is what sstate signatures are for. A from-scratch build of the whole layer remains available on demand through `runner-maintenance.yml`.

The marker is per-tree and the four matrix jobs share one tree per runner. That holds because a self-hosted runner takes one job at a time.

## What to look for in this run

Job times against the 30m01s baseline, and `previous run finished cleanly; keeping build/tmp` plus a free-space line in the recover and reclaim steps.