### PR TITLE
scarthgap: build the integration tests and FFI apps, and stop rebuilding what sstate already has

### DIFF
--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -231,6 +231,7 @@ jobs:
           bitbake flutter-auto
 
       - name: Build flutter-pi
+        id: base
         shell: bash
         working-directory: ../scarthgap-linux-dummy
         run: |
@@ -238,46 +239,94 @@ jobs:
           bitbake flutter-pi -c do_cleansstate
           bitbake flutter-pi
 
-      - name: Build toyota-connected-tcna-packages-camera-linux-camera-example
+      # The ivi-homescreen v3 integration tests. All ten come from one upstream
+      # tree at HOMESCREEN_COMMIT through ivi-homescreen-test.inc, so they share
+      # a source revision and stand or fall together far more often than not.
+      #
+      # One workflow step, but bitbake is called once per recipe so they build
+      # one at a time. A single 'bitbake app1 app2 ...' call lets bitbake run
+      # all ten do_compile tasks at once, and they race: each drives the flutter
+      # tool against its own recipe-sysroot-native, whose SDK files are
+      # hardlinked from the shared native sysroot, so concurrent writes under
+      # bin/cache are visible to the others. A recipe reading that directory
+      # mid-write decides the tool snapshot is stale and re-resolves
+      # packages/flutter_tools -- which does not inherit our --offline, so in a
+      # network-isolated do_compile it can only fail.
+      - name: Build ivi-homescreen integration tests
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
+        if: ${{ !cancelled() && steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake toyota-connected-tcna-packages-camera-linux-camera-example -c do_cleansstate
-          bitbake toyota-connected-tcna-packages-camera-linux-camera-example
+          apps="ivi-homescreen-gesture-playground \
+            ivi-homescreen-hardware-keyboard-test \
+            ivi-homescreen-keyboard-test \
+            ivi-homescreen-mcp-drive-test \
+            ivi-homescreen-multi-touch-test \
+            ivi-homescreen-multi-view-test \
+            ivi-homescreen-osgi-activator-test \
+            ivi-homescreen-scroll-bench \
+            ivi-homescreen-stopwatch-stress-test \
+            ivi-homescreen-watchdog-test"
+          # Report every failing test, not just the first. A round costs
+          # over an hour, so learning about one broken recipe at a time
+          # turns a single bad commit into a week of rebuilds.
+          failed=""
+          for a in $apps; do
+            if bitbake $a -c do_cleansstate && bitbake $a; then
+              continue
+            fi
+            failed="$failed $a"
+          done
+          if [ -n "$failed" ]; then
+            echo "::error::integration tests failed:$failed"
+            exit 1
+          fi
 
-      - name: Build toyota-connected-tcna-packages-filament-scene-fluorite-examples-demo
+      # The FFI applications. All three inherit flutter-app-native, so their
+      # Dart packages carry hook/build.dart and compile native code during
+      # `flutter build bundle` -- the path the integration tests above never
+      # reach. They need the flutter_tools patch and the FLUTTER_HOOK_* wrappers
+      # to build for the target rather than the build host; without those the
+      # hook resolves a host compiler and emits a host-architecture library into
+      # a target package (meta-flutter#801).
+      #
+      # flatpak_dart: talks to the flatpak system libraries.
+      - name: Build flatpak-minimal-flatpak-dart-flutter-remote-manager
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
+        if: ${{ !cancelled() && steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake toyota-connected-tcna-packages-filament-scene-fluorite-examples-demo -c do_cleansstate
-          bitbake toyota-connected-tcna-packages-filament-scene-fluorite-examples-demo
+          bitbake flatpak-minimal-flatpak-dart-flutter-remote-manager -c do_cleansstate
+          bitbake flatpak-minimal-flatpak-dart-flutter-remote-manager
 
-      - name: Build toyota-connected-tcna-packages-video-player-video-player-linux-video-player-example
+      #
+      # appstream_dart: resolves a system sqlite3 through a hook user_define.
+      - name: Build flatpak-minimal-appstream-dart-flathub-catalog
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
+        if: ${{ !cancelled() && steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake toyota-connected-tcna-packages-video-player-video-player-linux-video-player-example -c do_cleansstate
-          bitbake toyota-connected-tcna-packages-video-player-video-player-linux-video-player-example
+          bitbake flatpak-minimal-appstream-dart-flathub-catalog -c do_cleansstate
+          bitbake flatpak-minimal-appstream-dart-flathub-catalog
 
-      - name: Build toyota-connected-tcna-packages-flatpak-flutter-example
+      #
+      # bluez_native: compiles a vendored sdbus-c++ from its own hook.
+      - name: Build jwinarske-bluez-native-flutter-ble-scanner
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine
-        if: matrix.machine != 'qemuarm'
+        if: ${{ !cancelled() && steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
         shell: bash
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake toyota-connected-tcna-packages-flatpak-flutter-example -c do_cleansstate
-          bitbake toyota-connected-tcna-packages-flatpak-flutter-example
+          bitbake jwinarske-bluez-native-flutter-ble-scanner -c do_cleansstate
+          bitbake jwinarske-bluez-native-flutter-ble-scanner

--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -69,17 +69,31 @@ jobs:
 
       - name: Free other release-branch trees
         run: |
-          # Only one release branch keeps a populated tmp at a time. master's
-          # tree is deliberately left alone so its per-pull-request builds stay
-          # fast.
-          for d in ../*-linux-dummy; do
-            case "$(basename "$d")" in
-              master-linux-dummy|scarthgap-linux-dummy) continue ;;
-            esac
-            [ -d "$d/build/tmp" ] || continue
-            echo "removing $(du -sh "$d/build/tmp" | cut -f1) from $d/build/tmp"
-            rm -rf "$d/build/tmp"
-          done
+          # Reclaim other release branches' build/tmp, but only when the disk
+          # is actually short.
+          #
+          # This used to run unconditionally, on the assumption that a tree
+          # measures around 106G and so only two would fit. Measured, the five
+          # trees come to 153G in total -- 19G to 34G each -- against terabytes
+          # free. Every job was destroying 30-50G that the next build of that
+          # branch then re-extracted from sstate, for space that was never
+          # scarce. master's tree is left alone regardless, so its
+          # per-pull-request builds stay fast.
+          MIN_FREE_GB=${CI_MIN_FREE_GB:-300}
+          free_gb=$(df -BG --output=avail . | tail -1 | tr -dc '0-9')
+          if [ "${free_gb:-0}" -ge "$MIN_FREE_GB" ]; then
+            echo "${free_gb}G free (>= ${MIN_FREE_GB}G), keeping the other release trees"
+          else
+            echo "${free_gb}G free (< ${MIN_FREE_GB}G), reclaiming other release trees"
+            for d in ../*-linux-dummy; do
+              case "$(basename "$d")" in
+                master-linux-dummy|scarthgap-linux-dummy) continue ;;
+              esac
+              [ -d "$d/build/tmp" ] || continue
+              echo "removing $(du -sh "$d/build/tmp" | cut -f1) from $d/build/tmp"
+              rm -rf "$d/build/tmp"
+            done
+          fi
 
       - name: Fetch poky
         run: |
@@ -117,6 +131,23 @@ jobs:
               fi
           done
           exit $rc
+
+      - name: Recover from an interrupted run
+        shell: bash
+        working-directory: ../scarthgap-linux-dummy
+        run: |
+          MARKER=.ci-build-incomplete
+          if [ -e "$MARKER" ]; then
+            echo "::warning::previous run did not finish; removing build/tmp"
+            if [ -d build/tmp ]; then
+              echo "removing $(du -sh build/tmp | cut -f1) from build/tmp"
+              rm -rf build/tmp
+            fi
+            rm -f "$MARKER"
+          else
+            echo "previous run finished cleanly; keeping build/tmp"
+          fi
+          : > "$MARKER"
 
       - name: Configure build
         shell: bash
@@ -163,7 +194,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake ca-certificates -c do_cleansstate
           bitbake ca-certificates
 
       - name: Build ca-certificates-native
@@ -171,7 +201,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake ca-certificates-native -c do_cleansstate
           bitbake ca-certificates-native
 
       - name: Build flutter-sdk-native
@@ -179,7 +208,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-sdk-native -c do_cleansstate
           bitbake flutter-sdk-native
 
       - name: Build dart-sdk
@@ -187,7 +215,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake dart-sdk -c do_cleansstate
           bitbake dart-sdk
 
       - name: Build sentry
@@ -195,7 +222,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake sentry -c do_cleansstate
           bitbake sentry
 
       - name: Build rive-text
@@ -203,7 +229,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake rive-text -c do_cleansstate
           bitbake rive-text
 
       - name: Build flutter-engine
@@ -211,7 +236,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-engine -c do_cleansstate
           bitbake flutter-engine
 
       - name: Build ivi-homescreen
@@ -219,7 +243,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake ivi-homescreen -c do_cleansstate
           bitbake ivi-homescreen
 
       - name: Build flutter-auto
@@ -227,7 +250,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-auto -c do_cleansstate
           bitbake flutter-auto
 
       - name: Build flutter-pi
@@ -236,7 +258,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-pi -c do_cleansstate
           bitbake flutter-pi
 
       # The ivi-homescreen v3 integration tests. All ten come from one upstream
@@ -275,7 +296,7 @@ jobs:
           # turns a single bad commit into a week of rebuilds.
           failed=""
           for a in $apps; do
-            if bitbake $a -c do_cleansstate && bitbake $a; then
+            if bitbake $a; then
               continue
             fi
             failed="$failed $a"
@@ -302,7 +323,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flatpak-minimal-flatpak-dart-flutter-remote-manager -c do_cleansstate
           bitbake flatpak-minimal-flatpak-dart-flutter-remote-manager
 
       #
@@ -315,7 +335,6 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flatpak-minimal-appstream-dart-flathub-catalog -c do_cleansstate
           bitbake flatpak-minimal-appstream-dart-flathub-catalog
 
       #
@@ -328,5 +347,11 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake jwinarske-bluez-native-flutter-ble-scanner -c do_cleansstate
           bitbake jwinarske-bluez-native-flutter-ble-scanner
+
+      # Only reached when every step above succeeded; a failed or cancelled run
+      # leaves the marker behind for the next one to act on.
+      - name: Mark the build complete
+        shell: bash
+        working-directory: ../scarthgap-linux-dummy
+        run: rm -f .ci-build-incomplete

--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -73,6 +73,22 @@ def run_command(d, cmd, cwd, env):
     bb.note(f'Output:{formatted_output}')
 
     if retval:
+        # bb.note() reaches only the task's log.do_* file on the builder. CI does
+        # not collect those, so a failure here has been arriving as a bare exit
+        # code with the diagnosis left behind on the machine -- 'flutter pub get
+        # --enforce-lockfile failed: 65' says nothing about which constraint pub
+        # objected to. Repeat the tail at error level so the reason travels with
+        # the failure. Tail rather than the whole capture because these commands
+        # are run with -v and the full output is thousands of lines; the failure
+        # is at the end, and the complete text is still in the task log for
+        # anyone on the builder. Raise FLUTTER_CMD_FAIL_LOG_LINES if the tail
+        # cuts something off.
+        limit = int(d.getVar('FLUTTER_CMD_FAIL_LOG_LINES') or 100)
+        tail = output.splitlines()[-limit:] if output else []
+        if tail:
+            elided = '' if len(tail) == len(output.splitlines()) else \
+                f' (last {len(tail)}; see log.do_* for the rest)'
+            bb.error(f'Output of failed command{elided}:\n  ' + '\n  '.join(tail))
         bb.fatal(f'{cmd} failed: {retval}')
 
 def md5_update_from_dir(directory, hash):

--- a/dynamic-layers/clang-layer/recipes-devtools/clang/clang_%.bbappend
+++ b/dynamic-layers/clang-layer/recipes-devtools/clang/clang_%.bbappend
@@ -1,0 +1,25 @@
+#
+# Copyright (c) 2026 Joel Winarske. All rights reserved.
+#
+# Declare clang-native as the provider of lld-native.
+#
+# flutter-app-native.bbclass carries `DEPENDS:append = " lld-native"`, which
+# dart needs for the native-assets hook. On master that is satisfied by
+# oe-core's standalone recipes-devtools/clang/lld_git.bb, which carries
+# BBCLASSEXTEND = "native". No meta-clang release branch has that recipe:
+# kirkstone-clang18 and scarthgap both build lld inside clang_git.bb, through
+#
+#   LLVM_PROJECTS ?= "clang;clang-tools-extra;lld${LLDB}"
+#
+# and install the binary, but never name it in PROVIDES. So any recipe
+# inheriting flutter-app-native fails at dependency resolution:
+#
+#   ERROR: Nothing PROVIDES 'lld-native' (but ...flathub-catalog_0.4.2.bb
+#     DEPENDS on or otherwise requires it). Close matches:
+#     db-native  gd-native  llvm-native
+#
+# clang-native builds and installs ld.lld, so pointing lld-native at it names
+# the recipe that already produces the linker rather than stubbing the
+# dependency out.
+#
+PROVIDES:append:class-native = " lld-native"

--- a/recipes-devtools/wayland-cxx-scanner/wayland-cxx-scanner_1.0.0.bb
+++ b/recipes-devtools/wayland-cxx-scanner/wayland-cxx-scanner_1.0.0.bb
@@ -20,7 +20,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8992d37861cd7e48b171be43673f1d7f"
 
 # Pinned to the commit ivi-homescreen v3.0 carries as third_party/wayland-cxx-scanner,
 # so the host code generator and the vendored wl/ framework stay in lock-step.
-SRCREV ??= "003dde1be1100ef300c52e11d71e1a2e52ec36bb"
+SRCREV ??= "75575fe3e78e95796f2b9abb51f8314cbf9c31b4"
 SRC_URI = "git://github.com/jwinarske/wayland-cxx-scanner.git;protocol=https;branch=main"
 
 DEPENDS = "pugixml"

--- a/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
@@ -35,7 +35,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=39ae29158ce710399736340c60147314"
 
 # Must stay in lock-step with the embedder recipes: the .so they link at build
 # time and the one this package installs have to be the same library.
-HOMESCREEN_COMMIT ??= "1f5a107f20e612b14d8bdfdc3177695a30ecade0"
+HOMESCREEN_COMMIT ??= "131cbc37a1248f394978b408d4c02f1ea7eee6c3"
 
 # gitsm: the MCP provider compiles against third_party/rapidjson, which is a
 # submodule. The other submodules are unused here but the fetch is shared with

--- a/recipes-graphics/toyota/ivi-homescreen-test.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-test.inc
@@ -25,7 +25,7 @@ SECTION = "graphics"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=39ae29158ce710399736340c60147314"
 
-HOMESCREEN_COMMIT ??= "1f5a107f20e612b14d8bdfdc3177695a30ecade0"
+HOMESCREEN_COMMIT ??= "131cbc37a1248f394978b408d4c02f1ea7eee6c3"
 SRCREV = "${HOMESCREEN_COMMIT}"
 
 # Plain git rather than the embedder's gitsm. The apps are pure Dart and none of

--- a/recipes-graphics/toyota/ivi-homescreen-v3.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-v3.inc
@@ -64,7 +64,7 @@ REQUIRED_DISTRO_FEATURES = "\
     ${@bb.utils.contains_any('PACKAGECONFIG', 'backend-wayland-egl backend-drm-kms-egl backend-headless-egl', 'opengl', '', d)} \
 "
 
-HOMESCREEN_COMMIT ??= "1f5a107f20e612b14d8bdfdc3177695a30ecade0"
+HOMESCREEN_COMMIT ??= "131cbc37a1248f394978b408d4c02f1ea7eee6c3"
 PLUGINS_COMMIT ??= "aa310172ac93efbfaf2beaaab7d99bb1f8fd586e"
 # v4l2-webrtc-codec supplies the V4L2 M2M encoder sources the embedder compiles
 # in directly (it installs nothing, so it is consumed as a source tree via


### PR DESCRIPTION
Brings scarthgap to parity with wrynose, kirkstone and dunfell. The same four changes those branches carry, in the same order.

## Roll ivi-homescreen v3 to 131cbc37

scarthgap pins `1f5a107f`, which carries a stale `pubspec.lock` in two of the ten integration tests and fails `do_archive_pub_cache`:

```
flutter pub get --enforce-lockfile failed: 65
```

ivi-homescreen `ac446a4e` untracked exactly those two files, so `common.inc`'s "if no pubspec.lock, create it" path generates a consistent one. Rolling also picks up the sysroot wayland.xml fix, the idle DrmSession waker fix and the missing standard includes. `wayland-cxx-scanner` moves to `75575fe` with it, that being the commit ivi-homescreen carries as its submodule at `131cbc37`.

## Report the output of a failed command

Cherry-picked from #800. `run_command` logged failures with `bb.note()`, which reaches only `log.do_*` on the builder — CI never collects those, so every flutter failure arrived as a bare exit code.

## Build the integration tests and FFI apps

The twelve deprecated `toyota-connected-tcna-packages-*` builds go, replaced by the ten `ivi-homescreen-*` integration tests and three applications carrying `hook/build.dart` — the code-asset path the integration tests never reach.

`bitbake` is called once per recipe rather than once with a list: the flutter tool bootstraps on first use and parallel recipes racing that bootstrap is what made these builds flaky.

The app steps are gated on the base build rather than on each other, and the test loop collects its failures instead of exiting at the first, so one broken recipe costs one round rather than one round per bug. `!cancelled()` is required for that gate to have any effect — GitHub prepends an implicit `success()` to any `if:` without a status check function.

## Clean after an interrupted run, not before every build

Every recipe was `cleansstate`'d before building, rebuilding the layer from source on each job. A per-recipe clean cannot fix the cross-recipe drift that actually bites a persistent runner — orphaned `build/tmp/sysroots-components` entries, or a partially written sstate manifest — which is why `runner-maintenance.yml` removes `build/tmp` instead.

A marker is written before the first build and removed only after the last succeeds, so it outlives exactly the runs that leave bad state. Finding it removes `build/tmp`. Tree reclamation is likewise conditional on free space now: measured on the runner, five trees total 153G against terabytes free.

On kirkstone this took the matrix from **62m to 19m wall clock**, all four machines green.