### PR TITLE
Fix flutter elinux

### DIFF
--- a/recipes-graphics/flutter-elinux/flutter-elinux.inc
+++ b/recipes-graphics/flutter-elinux/flutter-elinux.inc
@@ -46,24 +46,13 @@ do_configure:prepend() {
 
     mkdir -p ${S}/build || true
 
-    # determine build type based on what flutter-engine installed
-    FLUTTER_RUNTIME_MODES="$(ls ${STAGING_DIR_TARGET}${datadir}/flutter/${FLUTTER_SDK_VERSION}/)"
-
-    for FLUTTER_RUNTIME_MODE in $FLUTTER_RUNTIME_MODES; do
-        if [ "${FLUTTER_RUNTIME_MODE}" = "release" ]; then
-            break
-        elif [ "${FLUTTER_RUNTIME_MODE}" = "jit_release" ]; then
-            break
-        elif [ "${FLUTTER_RUNTIME_MODE}" = "profile" ]; then
-            break
-        elif [ "${FLUTTER_RUNTIME_MODE}" = "debug" ]; then
-            break
-        fi
+    for FLUTTER_ENGINE in ${STAGING_DIR_TARGET}${datadir}/flutter/${FLUTTER_SDK_VERSION}/*/lib/libflutter_engine.so; do
+        [ -e "$FLUTTER_ENGINE" ] || continue
+        ln -sf "$FLUTTER_ENGINE" ${S}/build/libflutter_engine.so
+        break
     done
 
-    FLUTTER_ENGINE_PATH=${STAGING_DIR_TARGET}${datadir}/flutter/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}
-
-    ln -sf ${FLUTTER_ENGINE_PATH}/lib/libflutter_engine.so ${S}/build/libflutter_engine.so
+    [ -e ${S}/build/libflutter_engine.so ] || bbfatal "No libflutter_engine.so found in the target sysroot"
 }
 
 PRIVATE_LIBS:${PN} = "libflutter_engine.so"

--- a/recipes-graphics/flutter-elinux/flutter-wayland-so.bb
+++ b/recipes-graphics/flutter-elinux/flutter-wayland-so.bb
@@ -21,4 +21,6 @@ do_install() {
     install -m 0755 ${B}/libflutter_elinux_wayland.so ${D}${libdir}
 }
 
+SOLIBS = ".so"
+FILES_SOLIBSDEV = ""
 FILES:${PN} = "${libdir}"

--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -598,6 +598,8 @@ FILES:${PN} = "\
 
 ALLOW_EMPTY:${PN} = "1"
 RDEPENDS:${PN} += "${@' '.join('${PN}-' + m.replace('_', '-') for m in bb.utils.filter('PACKAGECONFIG', 'debug profile release jit_release', d).split())}"
+# file-rdeps checks direct dependencies, so expose the library guaranteed by the mode packages.
+RPROVIDES:${PN} += "libflutter_engine.so()(64bit) libflutter_engine.so"
 
 FILES:${PN}-dbg = "\
     ${FLUTTER_ENGINE_INSTALL_PREFIX}/*/lib/.debug \


### PR DESCRIPTION
Disclaimer: Mostly codex findings, but I've verified the work myself.

#765 wasn't tested on top of all of the new changes that @jwinarske made, before it was merged. This series fixes three failures exposed by splitting Flutter engine runtime modes into separate packages.

Existing embedders depend on the flutter-engine metapackage. That package pulls in the configured runtime-mode packages, but Yocto’s file-rdeps QA check only examines direct dependencies. It does not follow the metapackage dependency chain when looking for the ELF provider. That means binaries requiring libflutter_engine.so()(64bit) failed QA even though installing flutter-engine would install the library.

The metapackage now advertises:

`RPROVIDES:${PN} += "libflutter_engine.so()(64bit) libflutter_engine.so"`

Both 64-bit and 32-bit targets are included in the meta data and the correct version will be chosen by bitbake.

Next patch addresses flutter-wayland-so installing an unversioned library:

`/usr/lib/libflutter_elinux_wayland.so`

By default, Yocto treats unversioned lib*.so files as development symlinks. The default ${PN}-dev file rules therefore claimed this
library before ${PN}, producing:

-dev package flutter-wayland-so-dev contains non-symlink .so

The recipe now declares that .so is the runtime library suffix and prevents the development package from claiming it:

```
SOLIBS = ".so"
FILES_SOLIBSDEV = ""
```

The library is packaged in flutter-wayland-so, while debug symbols remain in the normal debug package.

Lastly, the flutter-elinux configure hook previously enumerated runtime-mode directories under the target sysroot and selected one without
verifying that it contained an engine library.

After changing flutter-engine configuration eg., from debug/profile/release to release-only the recipe sysroot could retain empty directories for disabled modes. The configure hook would select an empty debug directory and create a dangling symlink:

build/libflutter_engine.so -> .../debug/lib/libflutter_engine.so

Ninja then failed with:

libflutter_engine.so, needed by flutter-drm-gbm-backend,
missing and no known rule to make it

The hook now enumerates engine files directly:

```
for FLUTTER_ENGINE in \
    ${STAGING_DIR_TARGET}${datadir}/flutter/${FLUTTER_SDK_VERSION}/*/lib/libflutter_engine.so
do
    [ -e "$FLUTTER_ENGINE" ] || continue
    ln -sf "$FLUTTER_ENGINE" ${S}/build/libflutter_engine.so
    break
done
```

It also fails during configuration with a clear error if no usable engine exists, rather than creating a dangling link and failing later during compilation.

The affected Flutter Linux recipes pass do_package_qa, including configurations with multiple engine runtime packages. flutter-drm-gbm-backend was also rebuilt from configuration through compilation and packaging its engine symlink resolves to a real sysroot library, and both compilation and package QA succeed.