### PR TITLE
kirkstone: roll ivi-homescreen v3 to 131cbc37

### DIFF
--- a/recipes-devtools/wayland-cxx-scanner/wayland-cxx-scanner_1.0.0.bb
+++ b/recipes-devtools/wayland-cxx-scanner/wayland-cxx-scanner_1.0.0.bb
@@ -20,7 +20,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=8992d37861cd7e48b171be43673f1d7f"
 
 # Pinned to the commit ivi-homescreen v3.0 carries as third_party/wayland-cxx-scanner,
 # so the host code generator and the vendored wl/ framework stay in lock-step.
-SRCREV ??= "003dde1be1100ef300c52e11d71e1a2e52ec36bb"
+SRCREV ??= "75575fe3e78e95796f2b9abb51f8314cbf9c31b4"
 SRC_URI = "git://github.com/jwinarske/wayland-cxx-scanner.git;protocol=https;branch=main"
 
 DEPENDS = "pugixml"

--- a/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
@@ -35,7 +35,7 @@ LIC_FILES_CHKSUM = "file://LICENSE;md5=39ae29158ce710399736340c60147314"
 
 # Must stay in lock-step with the embedder recipes: the .so they link at build
 # time and the one this package installs have to be the same library.
-HOMESCREEN_COMMIT ??= "87bc27235990d6843716671ac17b97e829e9a9c4"
+HOMESCREEN_COMMIT ??= "131cbc37a1248f394978b408d4c02f1ea7eee6c3"
 
 # gitsm: the MCP provider compiles against third_party/rapidjson, which is a
 # submodule. The other submodules are unused here but the fetch is shared with

--- a/recipes-graphics/toyota/ivi-homescreen-test.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-test.inc
@@ -25,7 +25,7 @@ SECTION = "graphics"
 LICENSE = "Apache-2.0"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=39ae29158ce710399736340c60147314"
 
-HOMESCREEN_COMMIT ??= "87bc27235990d6843716671ac17b97e829e9a9c4"
+HOMESCREEN_COMMIT ??= "131cbc37a1248f394978b408d4c02f1ea7eee6c3"
 SRCREV = "${HOMESCREEN_COMMIT}"
 
 # Plain git rather than the embedder's gitsm. The apps are pure Dart and none of

--- a/recipes-graphics/toyota/ivi-homescreen-v3.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-v3.inc
@@ -64,7 +64,7 @@ REQUIRED_DISTRO_FEATURES = "\
     ${@bb.utils.contains_any('PACKAGECONFIG', 'backend-wayland-egl backend-drm-kms-egl backend-headless-egl', 'opengl', '', d)} \
 "
 
-HOMESCREEN_COMMIT ??= "87bc27235990d6843716671ac17b97e829e9a9c4"
+HOMESCREEN_COMMIT ??= "131cbc37a1248f394978b408d4c02f1ea7eee6c3"
 PLUGINS_COMMIT ??= "aa310172ac93efbfaf2beaaab7d99bb1f8fd586e"
 # v4l2-webrtc-codec supplies the V4L2 M2M encoder sources the embedder compiles
 # in directly (it installs nothing, so it is consumed as a source tree via


### PR DESCRIPTION
The last branch still on `87bc2723`. master, wrynose, scarthgap and dunfell all carry `131cbc37`, so kirkstone was missing four merged fixes:

- the core `wayland.xml` taken from the sysroot rather than the build host
- the idle `DrmSession` waker fix
- the missing standard includes
- the `wayland-cxx-scanner` roll itself

Nothing here was failing. `87bc2723` is the commit that untracked the two stale integration-test `pubspec.lock` files, which is exactly why the tests pass on this branch — but it left the layer describing one revision and building another.

## The scanner moves with it

The recipe pins the commit ivi-homescreen carries as `third_party/wayland-cxx-scanner`, so the host code generator and the vendored `wl/` framework stay in lock-step. At `131cbc37` that submodule is `75575fe`, verified against the repository:

```
recipe:    75575fe3e78e95796f2b9abb51f8314cbf9c31b4
submodule: 75575fe3e78e95796f2b9abb51f8314cbf9c31b4
```

At `003dde1` the recipe no longer matched the submodule at the revision being built, so the lock-step its own comment describes was already broken.

Closes the last parity gap across the five branches.