### PR TITLE
wrynose: emit SPDX headers from the generators

### DIFF
--- a/lib/gn.py
+++ b/lib/gn.py
@@ -5,7 +5,9 @@ This fetcher is created for gclient.
 The main target is flutter-engine, so for other gclient projects, this fetcher might not work.
 
 Copyright (c) 2020-2022 Woven Alpha, Inc
-Copyright (c) 2023-2025 Joel Winarske. All rights reserved.
+Copyright (c) 2023-2025 Joel Winarske
+
+SPDX-License-Identifier: MIT
 """
 
 import os

--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -291,7 +291,9 @@ def create_recipe(directory,
     print(f'filename: {filename}')
     with open(filename, "w") as f:
         f.write('#\n')
-        f.write('# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.\n')
+        f.write('# Copyright (c) 2020-2025 Joel Winarske\n')
+        f.write('#\n')
+        f.write('# SPDX-License-Identifier: MIT\n')
         f.write('#\n')
         f.write('\n')
 
@@ -404,7 +406,9 @@ def create_package_group(org, unit, recipes,
 
     with open(filename, "w") as f:
         f.write('#\n')
-        f.write('# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.\n')
+        f.write('# Copyright (c) 2020-2025 Joel Winarske\n')
+        f.write('#\n')
+        f.write('# SPDX-License-Identifier: MIT\n')
         f.write('#\n')
         f.write('\n')
         f.write(f'SUMMARY = "Package of Flutter {org} {unit} apps"\n')


### PR DESCRIPTION
First half of #283.

The issue notes that

```
Copyright (c) 2020-2023 Joel Winarske. All rights reserved.
```

sits badly with the layer's own MIT licence, which grants the right to use, copy, modify, merge, publish, distribute, sublicense and sell. Read strictly, a file reserving all rights is not offered under it.

## Generators before files

`tools/create_recipes.py` writes that header into every recipe it produces — at two sites — and `lib/gn.py` carries it in its own module docstring. Sweeping the tree without fixing these first would regress the moment anyone regenerated a recipe. Three lines against 277 files, so this goes first.

A generated recipe header now reads:

```
#
# Copyright (c) 2020-2025 Joel Winarske
#
# SPDX-License-Identifier: MIT
#
```

which is the form the issue asks for.

## Not touched

`lib/gn.py` has a second copyright holder, Woven Alpha. That line claims no reservation and is not ours to relicence, so it stands as it is.

## Still to come

The sweep over the existing **277** files carrying `All rights reserved` (258 `.bb`, 11 `.inc`, 4 `.conf`, 2 `.py`, 2 `.in`). That lands separately, since it touches nearly every recipe and wants to rebase cleanly against anything in flight. Only 10 files in the layer currently carry an SPDX identifier.