### PR TITLE
scarthgap: emit SPDX headers from the generators and sweep the tree

### DIFF
--- a/conf/include/app-utils.inc
+++ b/conf/include/app-utils.inc
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Joel Winarske. All rights reserved.
+# Copyright (c) 2023 Joel Winarske
 #
 # SPDX-License-Identifier: MIT
 #

--- a/conf/include/clang-utils.inc
+++ b/conf/include/clang-utils.inc
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 def clang_build_arch(d):

--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -1,4 +1,4 @@
-# Copyright (C) 2023 Joel Winarske. All rights reserved.
+# Copyright (c) 2023 Joel Winarske
 #
 # SPDX-License-Identifier: MIT
 #

--- a/conf/include/flutter-app.inc
+++ b/conf/include/flutter-app.inc
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 # Helper class for building Flutter Applications.
 # Assumes that:

--- a/conf/include/flutter-version.inc
+++ b/conf/include/flutter-version.inc
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 FLUTTER_SDK_TAG ??= "3.47.1"

--- a/conf/include/flutter-web.inc
+++ b/conf/include/flutter-web.inc
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 # Helper class for building Flutter Web Applications.
 # Assumes that:

--- a/conf/include/utils.inc
+++ b/conf/include/utils.inc
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 def get_binary_pkg_arch(d):

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 # We have a conf and classes directory, append to BBPATH

--- a/conf/machine/containerarm64.conf
+++ b/conf/machine/containerarm64.conf
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 require conf/machine/qemuarm64.conf

--- a/conf/machine/containerx86-64.conf
+++ b/conf/machine/containerx86-64.conf
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 require conf/machine/qemux86-64.conf

--- a/dynamic-layers/clang-layer/recipes-devtools/clang/clang_%.bbappend
+++ b/dynamic-layers/clang-layer/recipes-devtools/clang/clang_%.bbappend
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 # Declare clang-native as the provider of lld-native.
 #

--- a/dynamic-layers/clang-layer/recipes-graphics/flutter-engine/flutter-engine_%.bbappend
+++ b/dynamic-layers/clang-layer/recipes-graphics/flutter-engine/flutter-engine_%.bbappend
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 # The engine links with lld and builds against libc++. On master both come from

--- a/dynamic-layers/clang-layer/recipes-graphics/toyota/flutter-auto_3.0.bbappend
+++ b/dynamic-layers/clang-layer/recipes-graphics/toyota/flutter-auto_3.0.bbappend
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 # The v3 embedder builds against libc++/compiler-rt and links with lld. On

--- a/dynamic-layers/clang-layer/recipes-graphics/toyota/ivi-homescreen_3.0.bbappend
+++ b/dynamic-layers/clang-layer/recipes-graphics/toyota/ivi-homescreen_3.0.bbappend
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 # The v3 embedder builds against libc++/compiler-rt and links with lld. On

--- a/lib/gn.py
+++ b/lib/gn.py
@@ -5,7 +5,9 @@ This fetcher is created for gclient.
 The main target is flutter-engine, so for other gclient projects, this fetcher might not work.
 
 Copyright (c) 2020-2022 Woven Alpha, Inc
-Copyright (c) 2023-2025 Joel Winarske. All rights reserved.
+Copyright (c) 2023-2025 Joel Winarske
+
+SPDX-License-Identifier: MIT
 """
 
 import os

--- a/meta-flutter-apps/conf/layer.conf
+++ b/meta-flutter-apps/conf/layer.conf
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 # We have a conf and classes directory, append to BBPATH

--- a/meta-flutter-apps/dynamic-layers/gnome-layer/recipes-graphics/flutter-apps/first-party/flutter-packages-file-selector-file-selector-linux-file-selector-linux-example_1.0.0.bb
+++ b/meta-flutter-apps/dynamic-layers/gnome-layer/recipes-graphics/flutter-apps/first-party/flutter-packages-file-selector-file-selector-linux-file-selector-linux-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "file_selector_linux_example"

--- a/meta-flutter-apps/dynamic-layers/gnome-layer/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-flatpak-flutter-example_1.0.0.bb
+++ b/meta-flutter-apps/dynamic-layers/gnome-layer/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-flatpak-flutter-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flatpak_flutter_example"

--- a/meta-flutter-apps/dynamic-layers/meta-tensorflow/recipes-graphics/flutter-apps/first-party/meta-flutter-tflite-example-live-object-detection-ssd-mobilenet_1.0.0.bb
+++ b/meta-flutter-apps/dynamic-layers/meta-tensorflow/recipes-graphics/flutter-apps/first-party/meta-flutter-tflite-example-live-object-detection-ssd-mobilenet_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "live_object_detection_ssd_mobilenet"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-auth-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-auth-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_ui_auth_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-database-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-database-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_ui_database_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-firestore-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-firestore-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_ui_firestore_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-localizations-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-localizations-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_ui_localizations_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-oauth-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-oauth-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_ui_oauth_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-storage-example_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-packages-firebase-ui-storage-example_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_ui_storage_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-tests_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-firebaseui-flutter-tests_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "tests"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-cloud-firestore-cloud-firestore-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-cloud-firestore-cloud-firestore-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "cloud_firestore_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-cloud-functions-cloud-functions-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-cloud-functions-cloud-functions-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "cloud_functions_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-analytics-firebase-analytics-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-analytics-firebase-analytics-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_analytics_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-app-check-firebase-app-check-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-app-check-firebase-app-check-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_app_check_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-app-installations-firebase-app-installations-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-app-installations-firebase-app-installations-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_app_installations_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-auth-firebase-auth-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-auth-firebase-auth-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_auth_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-core-firebase-core-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-core-firebase-core-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_core_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-crashlytics-firebase-crashlytics-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-crashlytics-firebase-crashlytics-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_crashlytics_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-database-firebase-database-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-database-firebase-database-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_database_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-dynamic-links-firebase-dynamic-links-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-dynamic-links-firebase-dynamic-links-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_dynamic_links_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-in-app-messaging-firebase-in-app-messaging-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-in-app-messaging-firebase-in-app-messaging-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_in_app_messaging_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-messaging-firebase-messaging-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-messaging-firebase-messaging-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_messaging_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-ml-model-downloader-firebase-ml-model-downloader-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-ml-model-downloader-firebase-ml-model-downloader-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_ml_model_downloader_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-performance-firebase-performance-example_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-performance-firebase-performance-example_0.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_performance_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-remote-config-firebase-remote-config-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-remote-config-firebase-remote-config-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_remote_config_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-storage-firebase-storage-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-storage-firebase-storage-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "firebase_storage_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-vertexai-firebase-vertexai-example-vertex-ai-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/firebase-flutterfire-packages-firebase-vertexai-firebase-vertexai-example-vertex-ai-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "vertex_ai_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-ads_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-ads_0.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "ads"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-crossword_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-crossword_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "crossword"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-multiplayer_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-multiplayer_0.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "multiplayer"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-basic_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-basic_0.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "basic"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-card_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-card_0.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "card"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-endless-runner_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-endless-runner_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "endless_runner"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-animations-example_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-animations-example_0.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "animations_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-camera-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-camera-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "camera_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-cross-file-cross-file-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-cross-file-cross-file-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "cross_file_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-cupertino-ui-cupertino-ui-examples_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-cupertino-ui-cupertino-ui-examples_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "cupertino_ui_examples"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-espresso-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-espresso-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "espresso_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-extension-google-sign-in-as-googleapis-auth-extension-google-sign-in-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-extension-google-sign-in-as-googleapis-auth-extension-google-sign-in-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "extension_google_sign_in_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-flutter-adaptive-scaffold-flutter-adaptive-scaffold-example_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-flutter-adaptive-scaffold-flutter-adaptive-scaffold-example_0.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_adaptive_scaffold_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-flutter-image-flutter-image-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-flutter-image-flutter-image-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_image_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-flutter-lints-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-flutter-lints-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-flutter-markdown-flutter-markdown-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-flutter-markdown-flutter-markdown-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_markdown_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-go-router-builder-go-router-builder-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-go-router-builder-go-router-builder-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "go_router_builder_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-go-router-go-router-examples_3.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-go-router-go-router-examples_3.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "go_router_examples"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-adsense-google-adsense-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-adsense-google-adsense-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_adsense_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-fonts-google-fonts-tester_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-fonts-google-fonts-tester_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_fonts_tester"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-google-maps-flutter-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-google-maps-flutter-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_maps_flutter_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-ios-example-google-maps-flutter-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-ios-example-google-maps-flutter-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_maps_flutter_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-ios-google-maps-flutter-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-ios-google-maps-flutter-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_maps_flutter_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-ios-sdk10-google-maps-flutter-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-ios-sdk10-google-maps-flutter-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_maps_flutter_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-ios-sdk9-google-maps-flutter-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-ios-sdk9-google-maps-flutter-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_maps_flutter_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-web-example-3-google-maps-flutter-web-integration-tests_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-web-example-3-google-maps-flutter-web-integration-tests_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_maps_flutter_web_integration_tests"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-web-example-google-maps-flutter-web-integration-tests_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-maps-flutter-google-maps-flutter-web-example-google-maps-flutter-web-integration-tests_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_maps_flutter_web_integration_tests"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-sign-in-google-sign-in-google-sign-in-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-google-sign-in-google-sign-in-google-sign-in-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_sign_in_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-image-picker-image-picker-image-picker-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-image-picker-image-picker-image-picker-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "image_picker_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-image-picker-image-picker-linux-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-image-picker-image-picker-linux-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-in-app-purchase-in-app-purchase-in-app-purchase-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-in-app-purchase-in-app-purchase-in-app-purchase-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "in_app_purchase_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-interactive-media-ads-interactive-media-ads-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-interactive-media-ads-interactive-media-ads-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "interactive_media_ads_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-local-auth-local-auth-darwin-local-auth-darwin-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-local-auth-local-auth-darwin-local-auth-darwin-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "local_auth_darwin_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-local-auth-local-auth-local-auth-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-local-auth-local-auth-local-auth-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "local_auth_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-material-ui-material-ui-examples_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-material-ui-material-ui-examples_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "material_ui_examples"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-palette-generator-image-colors_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-palette-generator-image-colors_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "image_colors"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-path-provider-path-provider-linux-pathproviderexample_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-path-provider-path-provider-linux-pathproviderexample_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "pathproviderexample"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-pigeon-platform-tests-alternate-language-test-plugin-alternate-language-test-plugin-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-pigeon-platform-tests-alternate-language-test-plugin-alternate-language-test-plugin-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "alternate_language_test_plugin_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-pigeon-platform-tests-test-plugin-test-plugin-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-pigeon-platform-tests-test-plugin-test-plugin-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "test_plugin_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-pointer-interceptor-pointer-interceptor-pointer-interceptor-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-pointer-interceptor-pointer-interceptor-pointer-interceptor-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "pointer_interceptor_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-quick-actions-quick-actions-quick-actions-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-quick-actions-quick-actions-quick-actions-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "quick_actions_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-rfw-example-hello_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-rfw-example-hello_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "hello"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-rfw-example-local_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-rfw-example-local_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "local"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-rfw-example-remote_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-rfw-example-remote_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "remote"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-shared-preferences-shared-preferences-linux-shared-preferences-linux-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-shared-preferences-shared-preferences-linux-shared-preferences-linux-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "shared_preferences_linux_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-shared-preferences-shared-preferences-shared-preferences-tool_1.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-shared-preferences-shared-preferences-shared-preferences-tool_1.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "shared_preferences_tool"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-third-party-packages-flutter-svg-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-third-party-packages-flutter-svg-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_svg_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-two-dimensional-scrollables-two-dimensional-examples_2.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-two-dimensional-scrollables-two-dimensional-examples_2.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "two_dimensional_examples"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-url-launcher-url-launcher-linux-url-launcher-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-url-launcher-url-launcher-linux-url-launcher-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "url_launcher_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-vector-graphics-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-vector-graphics-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-webview-flutter-webview-flutter-android-webview-flutter-android-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-webview-flutter-webview-flutter-android-webview-flutter-android-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "webview_flutter_android_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-webview-flutter-webview-flutter-webview-flutter-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-webview-flutter-webview-flutter-webview-flutter-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "webview_flutter_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-xdg-directories-xdg-directories-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-packages-xdg-directories-xdg-directories-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "xdg_directories_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-android-view-flutter-module-using-plugin-android-view_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-android-view-flutter-module-using-plugin-android-view_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module_using_plugin_android_view"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-android-view-flutter-module-using-plugin-content-sizing-android-view_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-android-view-flutter-module-using-plugin-content-sizing-android-view_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module_using_plugin_content_sizing_android_view"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-android-view-flutter-module-using-plugin_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-android-view-flutter-module-using-plugin_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module_using_plugin"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-books-flutter-module-books_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-books-flutter-module-books_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module_books"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-fullscreen-flutter-module-fullscreen_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-fullscreen-flutter-module-fullscreen_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module_fullscreen"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-fullscreen-flutter-module_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-fullscreen-flutter-module_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-ios-content-resizing-flutter-module_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-ios-content-resizing-flutter-module_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-ios-content-resizing-ios-content-resizing-flutter-module_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-ios-content-resizing-ios-content-resizing-flutter-module_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-multiple-flutters-multiple-flutters-module_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-multiple-flutters-multiple-flutters-module_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "multiple_flutters_module"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-plugin-flutter-module-using-plugin_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-plugin-flutter-module-using-plugin_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module_using_plugin"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-prebuilt-module-flutter-module_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-add-to-app-prebuilt-module-flutter-module_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_module"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-ai-recipe-generation_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-ai-recipe-generation_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "ai_recipe_generation"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-android-splash-screen-splash-screen-sample_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-android-splash-screen-splash-screen-sample_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "splash_screen_sample"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-animations_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-animations_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "animations"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-asset-transformation_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-asset-transformation_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "asset_transformation"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-background-isolate-channels_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-background-isolate-channels_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "background_isolate_channels"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-code-sharing-client_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-code-sharing-client_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "client"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-compass-app_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-compass-app_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "compass_app"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-context-menus_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-context-menus_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "context_menus"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-cupertino-gallery_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-cupertino-gallery_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "cupertino_gallery"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-date-planner_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-date-planner_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "date_planner"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-deeplink-store-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-deeplink-store-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "deeplink_store_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-desktop-photo-search-fluent-ui_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-desktop-photo-search-fluent-ui_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "desktop_photo_search"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-desktop-photo-search-material_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-desktop-photo-search-material_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "desktop_photo_search_material"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-dynamic-theme_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-dynamic-theme_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "dynamic_theme"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-experimental-date-planner_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-experimental-date-planner_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "date_planner"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-experimental-federated-plugin-federated-plugin-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-experimental-federated-plugin-federated-plugin-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "federated_plugin_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-experimental-pedometer-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-experimental-pedometer-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "pedometer_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-experimental-varfont-shader-puzzle_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-experimental-varfont-shader-puzzle_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "varfont_shader_puzzle"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-flutter-maps-firestore_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-flutter-maps-firestore_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_maps_firestore"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-form-app_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-form-app_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "form_app"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-game-template_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-game-template_0.0.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "game_template"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-gemini-tasks_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-gemini-tasks_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gemini_tasks"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-google-maps-google-maps-in-flutter_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-google-maps-google-maps-in-flutter_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_maps_in_flutter"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-infinite-list-infinitelist_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-infinite-list-infinitelist_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "infinitelist"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-ios-app-clip_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-ios-app-clip_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "ios_app_clip"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-isolate-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-isolate-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "isolate_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-material-3-demo_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-material-3-demo_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "material_3_demo"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-navigation-and-routing-bookstore_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-navigation-and-routing-bookstore_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "bookstore"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-pedometer-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-pedometer-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "pedometer_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-place-tracker_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-place-tracker_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "place_tracker"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-platform-channels_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-platform-channels_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "platform_channels"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-platform-design_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-platform-design_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "platform_design"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-platform-view-swift_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-platform-view-swift_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "platform_view_swift"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-provider-counter_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-provider-counter_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "provider_counter"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-provider-shopper_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-provider-shopper_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "provider_shopper"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-rolodex_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-rolodex_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "rolodex"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-simple-sdf_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-simple-sdf_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "simple_sdf"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-simple-shader_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-simple-shader_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "simple_shader"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-simplistic-calculator_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-simplistic-calculator_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "simplistic_calculator"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-simplistic-editor_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-simplistic-editor_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "simplistic_editor"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-testing-app_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-testing-app_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "testing_app"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-veggieseasons_1.2.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-samples-veggieseasons_1.2.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "veggieseasons"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-super-dash-super-dash_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-super-dash-super-dash_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "super_dash"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/google-generative-ai-dart-samples-flutter-app-generative-ai-flutter_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/google-generative-ai-dart-samples-flutter-app-generative-ai-flutter_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "generative_ai_flutter"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-google-mobile-ads-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-google-mobile-ads-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_mobile_ads_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-google-mobile-ads-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-google-mobile-ads-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "google_mobile_ads_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-applovin-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-applovin-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_applovin_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-bidmachine-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-bidmachine-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_bidmachine_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-chartboost-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-chartboost-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_chartboost_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-dtexchange-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-dtexchange-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_dtexchange_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-imobile-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-imobile-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_imobile_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-inmobi-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-inmobi-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_inmobi_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-ironsource-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-ironsource-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_ironsource_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-liftoffmonetize-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-liftoffmonetize-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_liftoffmonetize_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-line-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-line-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_line_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-maio-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-maio-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_maio_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-meta-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-meta-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_meta_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-mintegral-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-mintegral-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_mintegral_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-moloco-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-moloco-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_moloco_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-mytarget-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-mytarget-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_mytarget_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-pangle-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-pangle-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_pangle_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-pubmatic-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-pubmatic-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_pubmatic_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-unity-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-packages-mediation-gma-mediation-unity-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gma_mediation_unity_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-api-demo_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-api-demo_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "api_demo"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-app-open-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-app-open-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "app_open_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-banner-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-banner-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "banner_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-interstitial-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-interstitial-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "interstitial_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-mediation-example-mediationexample_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-mediation-example-mediationexample_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "mediationexample"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-native-platform-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-native-platform-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "native_platform_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-native-template-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-native-template-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "native_template_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-rewarded-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-rewarded-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "rewarded_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-rewarded-interstitial-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/googleads-flutter-samples-admob-rewarded-interstitial-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "rewarded_interstitial_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/baseflow-flutter-geolocator-linux-geolocator-linux-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/baseflow-flutter-geolocator-linux-geolocator-linux-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "geolocator_linux_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/bernardpumped-ped-pumped-end-device_1.0.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/bernardpumped-ped-pumped-end-device_1.0.2.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "pumped_end_device"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/bluefireteam-audioplayers-packages-audioplayers-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/bluefireteam-audioplayers-packages-audioplayers-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "audioplayers_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/davbfr-dart-pdf-demo-printing-demo_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/davbfr-dart-pdf-demo-printing-demo_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "printing_demo"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/davbfr-dart-pdf-printing-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/davbfr-dart-pdf-printing-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "printing_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/flatpak-minimal-flatpak-dart-flutter-remote-manager_0.1.2.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/flatpak-minimal-flatpak-dart-flutter-remote-manager_0.1.2.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 SUMMARY = "flutter_remote_manager"
 DESCRIPTION = "Flutter Linux desktop app demonstrating the flatpak_dart package."

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-battery-plus-battery-plus-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-battery-plus-battery-plus-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "battery_plus_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-connectivity-plus-connectivity-plus-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-connectivity-plus-connectivity-plus-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "connectivity_plus_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-device-info-plus-device-info-plus-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-device-info-plus-device-info-plus-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "device_info_plus_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-network-info-plus-network-info-plus-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-network-info-plus-network-info-plus-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "network_info_plus_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-package-info-plus-package-info-plus-example_1.2.3.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-package-info-plus-package-info-plus-example_1.2.3.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "package_info_plus_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-sensors-plus-sensors-plus-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-sensors-plus-sensors-plus-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "sensors_plus_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-share-plus-share-plus-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/fluttercommunity-plus-plugins-packages-share-plus-share-plus-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "share_plus_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/gskinnerteam-flutter-wonderous-app-wonders_2.2.4.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/gskinnerteam-flutter-wonderous-app-wonders_2.2.4.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "wonders"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/gskinnerteam-flutter-wonderous-app-wonders_2.2.7.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/gskinnerteam-flutter-wonderous-app-wonders_2.2.7.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "wonders"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/jwinarske-bluez-native-flutter-ble-scanner_0.3.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/jwinarske-bluez-native-flutter-ble-scanner_0.3.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 SUMMARY = "flutter_ble_scanner"
 DESCRIPTION = "Flutter Linux desktop app demonstrating the bluez_native package."

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/jwinarske-packagekit-dart-packagekit-catalog_0.5.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/jwinarske-packagekit-dart-packagekit-catalog_0.5.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 SUMMARY = "packagekit_catalog"
 DESCRIPTION = "Flutter Linux desktop app demonstrating the packagekit_dart package."

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/knopp-layer-playground-layer-playground_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/knopp-layer-playground-layer-playground_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "layer_playground"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-tests-textures-test-egl_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-tests-textures-test-egl_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "test_egl"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-video-player-linux-example-video-player-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/meta-flutter-video-player-linux-example-video-player-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "video_player_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/mix1009-desktop-window-example-desktop-window-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/mix1009-desktop-window-example-desktop-window-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "desktop_window_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/mogol-flutter-secure-storage-flutter-secure-storage-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/mogol-flutter-secure-storage-flutter-secure-storage-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "flutter_secure_storage_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/rive-app-rive-flutter-example-rive-example_1.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/rive-app-rive-flutter-example-rive-example_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "rive_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/theyakka-qr-example_2.0.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/theyakka-qr-example_2.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-camera-linux-camera-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-camera-linux-camera-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "camera_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-filament-scene-fluorite-examples-demo_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-filament-scene-fluorite-examples-demo_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "fluorite_examples_demo"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-video-player-video-player-linux-example-video-player-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-video-player-video-player-linux-example-video-player-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "video_player_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-video-player-video-player-linux-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-video-player-video-player-linux-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "player"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-video-player-video-player-linux-video-player-example_git.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/toyota-connected-tcna-packages-video-player-video-player-linux-video-player-example_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "video_player_example"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/widgetbakery-pixel-snap-example_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/third-party/widgetbakery-pixel-snap-example_0.1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "example"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-baseflow-flutter-geolocator.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-baseflow-flutter-geolocator.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter baseflow flutter-geolocator apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-bernardpumped-ped.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-bernardpumped-ped.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter bernardpumped ped apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-bluefireteam-audioplayers.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-bluefireteam-audioplayers.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter bluefireteam audioplayers apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-davbfr-dart-pdf.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-davbfr-dart-pdf.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter davbfr dart_pdf apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-firebase-firebaseui-flutter.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-firebase-firebaseui-flutter.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter firebase firebaseui-flutter apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-firebase-flutterfire.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-firebase-flutterfire.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter firebase flutterfire apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-flutter-games.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-flutter-games.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter flutter games apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-flutter-packages.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-flutter-packages.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter flutter packages apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-flutter-samples.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-flutter-samples.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter flutter samples apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-flutter-super-dash.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-flutter-super-dash.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter flutter super_dash apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-fluttercommunity-plus-plugins.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-fluttercommunity-plus-plugins.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter fluttercommunity plus_plugins apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-google-generative-ai-dart.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-google-generative-ai-dart.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter google generative-ai-dart apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-googleads-flutter.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-googleads-flutter.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter googleads googleads-mobile-flutter apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-gskinnerteam-flutter-wonderous-app.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-gskinnerteam-flutter-wonderous-app.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter gskinnerteam flutter-wonderous-app apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-knopp-layer-playground.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-knopp-layer-playground.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter knopp layer_playground apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-meta-flutter-tests.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-meta-flutter-tests.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter meta-flutter tests apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-meta-flutter-tflite.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-meta-flutter-tflite.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter meta-flutter flutter-tflite apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-meta-flutter-video-player-linux.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-meta-flutter-video-player-linux.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter meta-flutter video_player_linux apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-mix1009-desktop-window.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-mix1009-desktop-window.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter mix1009 desktop_window apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-mogol-flutter-secure-storage.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-mogol-flutter-secure-storage.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter mogol flutter_secure_storage apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-rive-app-rive-flutter.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-rive-app-rive-flutter.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter rive-app rive-flutter apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-theyakka-qr.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-theyakka-qr.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter theyakka qr apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-toyota-connected-tcna-packages.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-toyota-connected-tcna-packages.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter toyota-connected tcna-packages apps"

--- a/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-widgetbakery-pixel-snap.bb
+++ b/meta-flutter-apps/recipes-platform/packagegroups/packagegroup-widgetbakery-pixel-snap.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Package of Flutter widgetbakery pixel_snap apps"

--- a/recipes-devtools/dart/dart-sdk_3.13.1.bb
+++ b/recipes-devtools/dart/dart-sdk_3.13.1.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2023 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2023 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Dart SDK"

--- a/recipes-devtools/depot-tools/depot-tools-native_git.bb
+++ b/recipes-devtools/depot-tools/depot-tools-native_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 LICENSE = "BSD-3-Clause"

--- a/recipes-devtools/sdbus-cpp-examples/sdbus-cpp-examples_git.bb
+++ b/recipes-devtools/sdbus-cpp-examples/sdbus-cpp-examples_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "sdbus-c++ examples"

--- a/recipes-devtools/sentry/sentry_0.9.0.bb
+++ b/recipes-devtools/sentry/sentry_0.9.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Sentry SDK for C, C++ and native applications."

--- a/recipes-devtools/wayland-cxx-scanner/wayland-cxx-scanner_1.0.0.bb
+++ b/recipes-devtools/wayland-cxx-scanner/wayland-cxx-scanner_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Wayland protocol scanner generating C++17 CRTP client/server headers"

--- a/recipes-graphics/flutter-engine/flutter-engine_git.bb
+++ b/recipes-graphics/flutter-engine/flutter-engine_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Flutter Engine"

--- a/recipes-graphics/flutter-pi/flutter-pi_git.bb
+++ b/recipes-graphics/flutter-pi/flutter-pi_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "A light-weight Flutter Engine Embedder for Raspberry Pi that runs without X."

--- a/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
+++ b/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Flutter makes it easy and fast to build beautiful apps for mobile and beyond."

--- a/recipes-graphics/libwebrtc/libwebrtc_125.6422.06.bb
+++ b/recipes-graphics/libwebrtc/libwebrtc_125.6422.06.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2024-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2024-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "libwebrtc"

--- a/recipes-graphics/pdfium/pdfium_139.0.7228.0.bb
+++ b/recipes-graphics/pdfium/pdfium_139.0.7228.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "PDFium"

--- a/recipes-graphics/rive/rive-text_0.4.11.bb
+++ b/recipes-graphics/rive/rive-text_0.4.11.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "rive_common"

--- a/recipes-graphics/sony/flutter-drm-eglstream-backend_git.bb
+++ b/recipes-graphics/sony/flutter-drm-eglstream-backend_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 DESCRIPTION = "Flutter Embedder with EGLStream Backend."

--- a/recipes-graphics/sony/flutter-drm-gbm-backend_git.bb
+++ b/recipes-graphics/sony/flutter-drm-gbm-backend_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 DESCRIPTION = "Flutter Embedder with DRM GBM Backend."

--- a/recipes-graphics/sony/flutter-external-texture-plugin_git.bb
+++ b/recipes-graphics/sony/flutter-external-texture-plugin_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 DESCRIPTION = "Flutter Embedder with external texture plugin."

--- a/recipes-graphics/sony/flutter-video-player-plugin_git.bb
+++ b/recipes-graphics/sony/flutter-video-player-plugin_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 DESCRIPTION = "Flutter Embedder with video player plugin."

--- a/recipes-graphics/sony/flutter-wayland-client_git.bb
+++ b/recipes-graphics/sony/flutter-wayland-client_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 DESCRIPTION = "Flutter Embedder with Wayland Client Backend."

--- a/recipes-graphics/sony/flutter-wayland-so.bb
+++ b/recipes-graphics/sony/flutter-wayland-so.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 DESCRIPTION = "Flutter Embedder with Wayland Client Backend as shared object (.so)."

--- a/recipes-graphics/sony/flutter-x11-client_git.bb
+++ b/recipes-graphics/sony/flutter-x11-client_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 DESCRIPTION = "Flutter Embedder with X11 Backend."

--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Embedded Linux embedding for Flutter"

--- a/recipes-graphics/toyota/flutter-auto_1.0.bb
+++ b/recipes-graphics/toyota/flutter-auto_1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Toyota IVI Homescreen (flutter-auto)"

--- a/recipes-graphics/toyota/flutter-auto_2.0.bb
+++ b/recipes-graphics/toyota/flutter-auto_2.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Toyota IVI Homescreen v2.0"

--- a/recipes-graphics/toyota/flutter-auto_3.0.bb
+++ b/recipes-graphics/toyota/flutter-auto_3.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Toyota IVI Homescreen v3.0 - AGL variant"

--- a/recipes-graphics/toyota/ivi-homescreen-gesture-playground_git.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-gesture-playground_git.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "gesture_playground"

--- a/recipes-graphics/toyota/ivi-homescreen-hardware-keyboard-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-hardware-keyboard-test_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "hardware_keyboard_test"

--- a/recipes-graphics/toyota/ivi-homescreen-keyboard-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-keyboard-test_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "keyboard_test"

--- a/recipes-graphics/toyota/ivi-homescreen-mcp-drive-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-mcp-drive-test_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "mcp_drive_test"

--- a/recipes-graphics/toyota/ivi-homescreen-multi-touch-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-multi-touch-test_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "multi_touch_test"

--- a/recipes-graphics/toyota/ivi-homescreen-multi-view-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-multi-view-test_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "multi_view_test"

--- a/recipes-graphics/toyota/ivi-homescreen-osgi-activator-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-osgi-activator-test_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "osgi_activator_test"

--- a/recipes-graphics/toyota/ivi-homescreen-scroll-bench_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-scroll-bench_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "scroll_bench"

--- a/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 # ihs_shared: the C-ABI shared library that fronts logging, tracing,
 # platform-view surface negotiation and config read-back for out-of-tree Dart

--- a/recipes-graphics/toyota/ivi-homescreen-stopwatch-stress-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-stopwatch-stress-test_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "stopwatch_stress_test"

--- a/recipes-graphics/toyota/ivi-homescreen-test.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-test.inc
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 # Shared body for the ivi-homescreen v3.0 integration test applications, which
 # live under test/integration in the embedder repository.

--- a/recipes-graphics/toyota/ivi-homescreen-v3.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-v3.inc
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 # Shared body for the ivi-homescreen v3.0 embedder recipes. The two consumers
 # (ivi-homescreen_3.0.bb, flutter-auto_3.0.bb) differ only in EXE_OUTPUT_NAME,

--- a/recipes-graphics/toyota/ivi-homescreen-watchdog-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-watchdog-test_1.0.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "watchdog_test"

--- a/recipes-graphics/toyota/ivi-homescreen_1.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_1.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Toyota IVI Homescreen"

--- a/recipes-graphics/toyota/ivi-homescreen_2.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_2.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2025 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Toyota IVI Homescreen v2.0"

--- a/recipes-graphics/toyota/ivi-homescreen_3.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen_3.0.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2026 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Toyota IVI Homescreen v3.0"

--- a/recipes-platform/images/app-container-image-flutter-auto-egl.bb
+++ b/recipes-platform/images/app-container-image-flutter-auto-egl.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "A flutter-auto container image"

--- a/recipes-platform/images/app-container-image-flutter-auto-vulkan.bb
+++ b/recipes-platform/images/app-container-image-flutter-auto-vulkan.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "A flutter-auto container image"

--- a/recipes-platform/images/app-container-image.bb
+++ b/recipes-platform/images/app-container-image.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Application container image"

--- a/recipes-platform/images/app-container-user.bb
+++ b/recipes-platform/images/app-container-user.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2020-2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2020-2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Setup dev user"

--- a/recipes-platform/packagegroups/packagegroup-flutter-sdk-deps.bb
+++ b/recipes-platform/packagegroups/packagegroup-flutter-sdk-deps.bb
@@ -1,5 +1,7 @@
 #
-# Copyright (c) 2024 Joel Winarske. All rights reserved.
+# Copyright (c) 2024 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
 #
 
 SUMMARY = "Packages required to run Flutter SDK + Linux GTK embedder on target"

--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -291,7 +291,9 @@ def create_recipe(directory,
     print(f'filename: {filename}')
     with open(filename, "w") as f:
         f.write('#\n')
-        f.write('# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.\n')
+        f.write('# Copyright (c) 2020-2025 Joel Winarske\n')
+        f.write('#\n')
+        f.write('# SPDX-License-Identifier: MIT\n')
         f.write('#\n')
         f.write('\n')
 
@@ -411,7 +413,9 @@ def create_package_group(org, unit, recipes,
 
     with open(filename, "w") as f:
         f.write('#\n')
-        f.write('# Copyright (c) 2020-2025 Joel Winarske. All rights reserved.\n')
+        f.write('# Copyright (c) 2020-2025 Joel Winarske\n')
+        f.write('#\n')
+        f.write('# SPDX-License-Identifier: MIT\n')
         f.write('#\n')
         f.write('\n')
         f.write(f'SUMMARY = "Package of Flutter {org} {unit} apps"\n')


### PR DESCRIPTION
Both halves of #283 for scarthgap, ported from wrynose (#810 and #811).

```
Copyright (c) 2020-2023 Joel Winarske. All rights reserved.
```

sits badly with the layer's own MIT licence, which grants the right to use, copy, modify, merge, publish, distribute, sublicense and sell. Read strictly, a file reserving all rights is not offered under it.

## 1. The generators, first

`tools/create_recipes.py` writes that header into every recipe it produces — at two sites — and `lib/gn.py` carries it in its own module docstring. Sweeping the tree without fixing these would regress the moment anyone regenerated a recipe. A generated header now reads:

```
#
# Copyright (c) 2020-2025 Joel Winarske
#
# SPDX-License-Identifier: MIT
#
```

`lib/gn.py`'s second copyright holder, Woven Alpha, is left alone — that line claims no reservation and is not ours to relicence.

## 2. The sweep

**275 files.** Three forms were in use — `(c)`, `(C)`, and no parenthesis at all — all normalised.

**Four files are deliberately untouched**, because they carry a copyright holder other than the one these commits speak for: The Flutter Authors (×2), The Chromium Authors, and Ahmed Wafdy. Declaring a file MIT while a second holder reserves all rights over it is a claim about their work, and wants their agreement rather than a search and replace. So four `All rights reserved` remain after this — the intended end state, not a miss.

Files that already carried an SPDX identifier keep the one they had; the reservation is dropped without a second being added.

## Validation

wrynose merged the identical change and went green on all four machines (`bitbake -p`: 3162 recipes, 0 errors; full build: 10 integration tests + 3 FFI apps across three architectures).