### PR TITLE
scarthgap: run the frontend server snapshot that matches the host

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -527,8 +527,20 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
                 frontend_snapshot = f'{flutter_sdk}/bin/cache/artifacts/engine/linux-{clang_build_arch(d)}/frontend_server.dart.snapshot'
                 dep_path = glob.glob(f'{source_dir}/{flutter_application_path}/.dart_tool/flutter_build/*/kernel_snapshot.d')
             else:
-                dart_runtime = f'{flutter_sdk}/bin/cache/dart-sdk/bin/dartaotruntime'
-                frontend_snapshot = f'{flutter_sdk}/bin/cache/artifacts/engine/linux-{clang_build_arch(d)}/frontend_server_aot.dart.snapshot'
+                dart_runtime    = f'{flutter_sdk}/bin/cache/dart-sdk/bin/dartaotruntime'
+                # The frontend server runs on the build host, so its snapshot has to
+                # match the host, not the target. The copy under
+                # artifacts/engine/linux-<target>/ is built for x86-64 whatever the
+                # directory is named, so on an arm64 host dartaotruntime rejects it:
+                #
+                #   Loading failed: Architecture mismatch.
+                #   VM initialization failed: Invalid vm isolate snapshot seen
+                #
+                # The dart-sdk copy is host-native. Prefer it, and keep the engine one
+                # as the fallback for an SDK that does not ship it. See #575.
+                sdk_snapshot    = f'{flutter_sdk}/bin/cache/dart-sdk/bin/snapshots/frontend_server_aot.dart.snapshot'
+                engine_snapshot = f'{flutter_sdk}/bin/cache/artifacts/engine/linux-{clang_build_arch(d)}/frontend_server_aot.dart.snapshot'
+                frontend_snapshot = sdk_snapshot if os.path.exists(sdk_snapshot) else engine_snapshot
                 dep_path = glob.glob(f'{source_dir}/{flutter_application_path}/.dart_tool/flutter_build/*/kernel_snapshot_program.d')
 
             cmd = f'{dart_runtime} \


### PR DESCRIPTION
Fixes #575 for scarthgap.

Building on an arm64 host fails before compiling anything:

```
Loading failed: Architecture mismatch.
VM initialization failed: Invalid vm isolate snapshot seen
```

The frontend server runs on the **build host**, but the snapshot was taken unconditionally from `artifacts/engine/linux-<target>/`:

```python
frontend_snapshot = f'{flutter_sdk}/bin/cache/artifacts/engine/linux-{clang_build_arch(d)}/frontend_server_aot.dart.snapshot'
```

`clang_build_arch(d)` names the target, and those artifacts are host tools built for x86-64 whatever the directory is called — as the reporter showed:

```
artifacts/engine/linux-arm64/frontend_server_aot.dart.snapshot:
  ELF 64-bit LSB shared object, x86-64
```

So on an arm64 host `dartaotruntime` is handed an x86-64 snapshot and refuses it. On an x86-64 host both paths happen to be x86-64, which is why this only appears when the host is not x86-64 and why CI never caught it — every runner here is x86-64.

The `dart-sdk/bin/snapshots/` copy is host-native. Prefer it, keeping the engine one as the fallback for an SDK that does not ship it:

```python
sdk_snapshot      = f'{flutter_sdk}/bin/cache/dart-sdk/bin/snapshots/frontend_server_aot.dart.snapshot'
engine_snapshot   = f'{flutter_sdk}/bin/cache/artifacts/engine/linux-{clang_build_arch(d)}/frontend_server_aot.dart.snapshot'
frontend_snapshot = sdk_snapshot if os.path.exists(sdk_snapshot) else engine_snapshot
```

This is the change master and wrynose already carry (`7da4f2ac`), ported here — the surrounding code differs between branches, so it is the same transformation rather than a cherry-pick.

Only the new-build-scheme branch is touched, matching master; the legacy path uses `dart` rather than `dartaotruntime` and is left alone.

**Not verified on arm64 hardware** — there is no arm64 host here, and CI runs on x86-64 where both paths resolve identically. On x86-64 the change is a no-op in effect: the dart-sdk snapshot exists and is the same architecture as the engine copy.