### PR TITLE
wrynose: keep TMPDIR out of the AOT image

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -485,11 +485,27 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
             flutter_source_file = ''
             flutter_source_package = ''
             flutter_source_defines = ''
-            dart_plugin_registrant_file = f'{source_dir}/{flutter_application_path}/.dart_tool/flutter_build/dart_plugin_registrant.dart'
+            flutter_filesystem = ''
+            flutter_app_dir = os.path.normpath(f'{source_dir}/{flutter_application_path}')
+            dart_plugin_registrant_file = f'{flutter_app_dir}/.dart_tool/flutter_build/dart_plugin_registrant.dart'
             if os.path.isfile(dart_plugin_registrant_file):
-                flutter_source_file = f'--source file://{dart_plugin_registrant_file}'
+                # The registrant is the one library with no package: URI, so it
+                # is named to the frontend by path -- and that path becomes the
+                # generated library's import URI, which the AOT image keeps
+                # verbatim. Naming it absolutely puts WORKDIR, and so TMPDIR,
+                # inside every shipped libapp.so and trips the buildpaths QA
+                # check. A relative path does not help: the frontend
+                # canonicalizes it back to an absolute file URI. Only a scheme
+                # with no absolute form does, so declare the app as a filesystem
+                # root and name the registrant against it. See #819.
+                registrant_scheme = 'org-dartlang-root'
+                registrant_uri = f'{registrant_scheme}:///' \
+                    f'{os.path.relpath(dart_plugin_registrant_file, flutter_app_dir)}'
+                flutter_filesystem = f'--filesystem-root {flutter_app_dir}' \
+                    f' --filesystem-scheme {registrant_scheme}'
+                flutter_source_file = f'--source {registrant_uri}'
                 flutter_source_package = '--source package:flutter/src/dart_plugin_registrant.dart'
-                flutter_source_defines = f'-Dflutter.dart_plugin_registrant=file://{dart_plugin_registrant_file}'
+                flutter_source_defines = f'-Dflutter.dart_plugin_registrant={registrant_uri}'
 
             flutter_native_assets = ''
             yaml_path = glob.glob(f'{source_dir}/{flutter_application_path}/.dart_tool/flutter_build/*/native_assets.yaml')
@@ -529,6 +545,7 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
                 --aot \
                 --tfa \
                 --target-os linux \
+                {flutter_filesystem} \
                 --packages {package_config_json} \
                 --output-dill {flutter_app_output_dill} \
                 --depfile {dep_path[0]} \


### PR DESCRIPTION
First of three branches for #819. Resolves the **AOT generation** item of #566.

## The leak

```
QA Issue: File /usr/share/flutter/.../release/lib/libapp.so in package ...
contains reference to TMPDIR [buildpaths]
```

`common.inc` named the generated plugin registrant by absolute path, twice — as `--source` and as the `-Dflutter.dart_plugin_registrant` define. `source_dir` is under `WORKDIR`, hence under `TMPDIR`, and that path becomes the generated library's **import URI**, which the AOT image keeps verbatim.

The registrant is the *only* library an app compiles that has no `package:` URI — everything else is reached through `--packages`. So it is not the largest leak, it is the only one. Measured by building a plugin app with meta-flutter's exact gen_snapshot flag set (`--strip`, no `--obfuscate`):

| | absolute paths in `libapp.so` |
|---|---|
| before | **1** — the registrant |
| after | **0** |

Confirmed independently against a release build of `flutter_secure_storage/example` — the app in #566's warning — whose `libapp.so` contains exactly one absolute path, the registrant.

## Why not just make it relative

Tried that first; it does not work. The frontend canonicalizes a bare path back to an absolute `file:` URI, and the relative form then appears in the image *alongside* the absolute one rather than instead of it. The URI has to be in a scheme with no absolute form, so the app is declared as a filesystem root and the registrant named against it:

```
org-dartlang-root:///.dart_tool/flutter_build/dart_plugin_registrant.dart
```

Same shape `flutter build` produces via `toMultiRootPath()`, but only when given roots:

```dart
if (scheme == null || fileSystemRoots.isEmpty || fileUri.scheme != 'file') {
  return fileUri.toString();          // ← desktop AOT lands here
}
```

A desktop AOT build has none, so the leak survives into a plain `flutter build linux` too. It has to be set here.

## Registration still works

The risk is a build that goes green while quietly registering no plugins. Verified in [emb_cli#188](https://github.com/toyota-connected/emb_cli/pull/188), which builds the AOT through the same frontend/gen_snapshot sequence.

Statically, the string sets before and after are identical in count; the entire diff is the registrant's library hash, which is derived from its URI:

```
-  _PluginRegistrant@341152970     -  file:///.../dart_plugin_registrant.dart
+  _PluginRegistrant@341393342     +  org-dartlang-root:///.dart_tool/...
```

At runtime, on an app whose `main()` awaits `SharedPreferences.getInstance()` — `shared_preferences_linux` is Dart-only and reachable *only* through the registrant, so a registrant that did not run is a `MissingPluginException`, not something subtle:

```
before: flutter: REGTEST: registrant OK, readback=42
after:  flutter: REGTEST: registrant OK, readback=42
```

## Scope

Profile builds still carry source URIs — those come from `--track-widget-creation`, whose purpose is pointing the widget inspector at source. Release is what ships, and release is clean.

master and scarthgap follow once this is green.