### PR TITLE
license: use "&" as the LICENSE operator, not "AND"

### DIFF
--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-ads_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-ads_0.0.1.bb
@@ -11,7 +11,7 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LICENSE = "Apache-2.0 & BSD-3-Clause & OFL-1.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-crossword_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-crossword_0.1.0.bb
@@ -11,7 +11,7 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LICENSE = "Apache-2.0 & BSD-3-Clause & OFL-1.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-multiplayer_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-samples-multiplayer_0.0.1.bb
@@ -11,7 +11,7 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LICENSE = "Apache-2.0 & BSD-3-Clause & OFL-1.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-basic_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-basic_0.0.1.bb
@@ -11,7 +11,7 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LICENSE = "Apache-2.0 & BSD-3-Clause & OFL-1.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-card_0.0.1.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-card_0.0.1.bb
@@ -11,7 +11,7 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LICENSE = "Apache-2.0 & BSD-3-Clause & OFL-1.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"

--- a/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-endless-runner_0.1.0.bb
+++ b/meta-flutter-apps/recipes-graphics/flutter-apps/first-party/flutter-games-templates-endless-runner_0.1.0.bb
@@ -11,7 +11,7 @@ HOMEPAGE = "None"
 BUGTRACKER = "None"
 SECTION = "graphics"
 
-LICENSE = "Apache-2.0 AND BSD-3-Clause AND OFL-1.1"
+LICENSE = "Apache-2.0 & BSD-3-Clause & OFL-1.1"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=b7eeb61b41ae366e94383bca5e113fce"
 
 SRCREV = "ae636d23deae83fd0e7fec9b862a7fcdf2bcfdd8"

--- a/recipes-graphics/libwebrtc/libwebrtc_144.7559.09.bb
+++ b/recipes-graphics/libwebrtc/libwebrtc_144.7559.09.bb
@@ -12,7 +12,7 @@ HOMEPAGE = "https://github.com/jwinarske/libwebrtc"
 BUGTRACKER = "https://github.com/jwinarske/libwebrtc/issues"
 SECTION = "graphics"
 
-LICENSE = "BSD-3-Clause AND MIT"
+LICENSE = "BSD-3-Clause & MIT"
 LIC_FILES_CHKSUM = "\
     file://LICENSE;md5=ad296492125bc71530d06234d9bfebe0 \
     file://libwebrtc/LICENSE;md5=166d54ea842ed1a582dabbd844fa4c80 \

--- a/recipes-graphics/rive/rive-text_0.4.11.bb
+++ b/recipes-graphics/rive/rive-text_0.4.11.bb
@@ -11,7 +11,7 @@ HOMEPAGE = "https://github.com/rive-app/rive-flutter"
 BUGTRACKER = "https://github.com/rive-app/rive-flutter"
 SECTION = "devtools"
 
-LICENSE = "Apache-2.0 AND MIT"
+LICENSE = "Apache-2.0 & MIT"
 LIC_FILES_CHKSUM = " \
     file://LICENSE;md5=c52243a14a066c83e50525d9ad046678 \
     file://macos/rive-cpp/LICENSE;md5=9a8a5e004196b5614e34130e5558fb6c \

--- a/recipes-graphics/toyota/ivi-homescreen-keyboard-test_1.0.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-keyboard-test_1.0.0.bb
@@ -33,7 +33,7 @@ SRC_URI[notolicense.sha256sum] = "500bb1ccf43df7bbb522112f9133a52b16e1c35e809632
 # Bundling the fonts puts their licenses in the image, so both join the
 # embedder's Apache-2.0: DejaVu is Bitstream-Vera plus public-domain additions,
 # and Noto Color Emoji is OFL-1.1.
-LICENSE = "Apache-2.0 AND Bitstream-Vera AND OFL-1.1"
+LICENSE = "Apache-2.0 & Bitstream-Vera & OFL-1.1"
 LIC_FILES_CHKSUM = "\
     file://LICENSE;md5=39ae29158ce710399736340c60147314 \
     file://${UNPACKDIR}/ihs-fonts/dejavu-fonts-ttf-2.37/LICENSE;md5=449b2c30bfe5fa897fe87b8b70b16cfa \


### PR DESCRIPTION
This PR fixes #823.
Convert the `LICENSE` value of nine recipes from the SPDX prose operator `AND` to BitBake's `&` operator. One line per recipe; the licence set of each recipe is unchanged.