### PR TITLE
wrynose: let buildpaths QA run on app packages again

### DIFF
--- a/conf/include/flutter-app.inc
+++ b/conf/include/flutter-app.inc
@@ -98,7 +98,12 @@ do_install() {
     done
 }
 
-INSANE_SKIP:${PN} += " ldflags libdir dev-so buildpaths"
+# buildpaths is deliberately not skipped. The AOT image used to embed the
+# absolute path of the plugin registrant, and suppressing the check here is
+# what let that ship unnoticed; with the registrant named through a
+# filesystem-root scheme (see common.inc) an app package has no build path
+# left in it, so the check is a regression guard rather than noise.
+INSANE_SKIP:${PN} += " ldflags libdir dev-so"
 
 FILES:${PN} = "\
     ${bindir} \

--- a/recipes-devtools/dart/dart-sdk_3.13.1.bb
+++ b/recipes-devtools/dart/dart-sdk_3.13.1.bb
@@ -145,6 +145,10 @@ do_install() {
     cp -R ${BUILD_DIR}/dart-sdk/* ${D}${datadir}/dart-sdk/
 }
 
+# buildpaths: gen_kernel_aot.dart.snapshot embeds a build path. It comes out
+# of the SDK's own `ninja create_sdk`, so it is not ours to construct and not
+# yet fixed -- see #827. The skip arrived here undocumented with the 3.47.1
+# roll; it is a known defect being hidden, not a check that does not apply.
 INSANE_SKIP:${PN} = "already-stripped ldflags buildpaths"
 
 FILES:${PN} += "${datadir}"


### PR DESCRIPTION
Follow-on to #820 / #819. Turns that fix from *done* into *enforced*.

## Why the leak survived so long

`conf/include/flutter-app.inc` skipped `buildpaths` for every Flutter app package:

```
INSANE_SKIP:${PN} += " ldflags libdir dev-so buildpaths"
```

master's own QA log shows the effect:

```
NOTE: Package flatpak-minimal-appstream-dart-flathub-catalog skipping QA tests:
      {'ldflags', 'dev-so', 'buildpaths', 'libdir'}
```

So the check that exists to catch exactly this was off. The branches diverged, too:

| branch | app-package skip |
|---|---|
| master | `… dev-so buildpaths` |
| wrynose | `… dev-so buildpaths` |
| scarthgap | `… dev-so` |

That is why scarthgap was the only branch ever reporting the app warnings in #566 — not because it was worse, but because it was the only one still looking.

## Why it is safe to remove now

Across **243 built recipes** in a master build tree, exactly two packages contained a build path — the two plugin apps, one file each (`libapp.so`), both fixed by #819. Of one app's twelve packaged files, only `libapp.so` ever carried one:

```
packaged files: 12
files containing TMPDIR:
  /usr/share/flutter/appstream-dart-example-flathub-catalog/3.47.1/release/lib/libapp.so
```

`buildpaths` is in oe-core's `ERROR_QA`, so with the skip gone a regression fails the build instead of shipping quietly.

## What this does not touch

The `dart-sdk` skip stays — `gen_kernel_aot.dart.snapshot` embeds a build path by a different route, out of the SDK's own `ninja create_sdk`, and is tracked in #827. Both skips now carry a comment saying why they exist; the `dart-sdk` one arrived undocumented with the 3.47.1 roll (8af2ba88), which is how a known defect came to look like a check that did not apply.

## Risk

My scan covers the apps present in that build tree. The ten `ivi-homescreen` integration tests and any app not built there are unverified — if one has another source of build paths, this will fail its build rather than warn. That is the point of landing it on wrynose first.

master and scarthgap follow if this is green. (scarthgap has no app-side skip to remove, so it only needs the `dart-sdk` comment.)