### PR TITLE
master: let buildpaths QA run on app packages again

### DIFF
--- a/conf/include/flutter-app.inc
+++ b/conf/include/flutter-app.inc
@@ -98,7 +98,12 @@ do_install() {
     done
 }
 
-INSANE_SKIP:${PN} += " ldflags libdir dev-so buildpaths"
+# buildpaths is deliberately not skipped. The AOT image used to embed the
+# absolute path of the plugin registrant, and suppressing the check here is
+# what let that ship unnoticed; with the registrant named through a
+# filesystem-root scheme (see common.inc) an app package has no build path
+# left in it, so the check is a regression guard rather than noise.
+INSANE_SKIP:${PN} += " ldflags libdir dev-so"
 
 FILES:${PN} = "\
     ${bindir} \

--- a/recipes-devtools/dart/dart-sdk_3.13.1.bb
+++ b/recipes-devtools/dart/dart-sdk_3.13.1.bb
@@ -145,6 +145,10 @@ do_install() {
     cp -R ${BUILD_DIR}/dart-sdk/* ${D}${datadir}/dart-sdk/
 }
 
+# buildpaths: gen_kernel_aot.dart.snapshot embeds a build path. It comes out
+# of the SDK's own `ninja create_sdk`, so it is not ours to construct and not
+# yet fixed -- see #827. The skip arrived here undocumented with the 3.47.1
+# roll; it is a known defect being hidden, not a check that does not apply.
 INSANE_SKIP:${PN} = "already-stripped ldflags buildpaths"
 
 FILES:${PN} += "${datadir}"


### PR DESCRIPTION
Port of #828 (wrynose, merged) — the diff is byte-identical.

## Why the leak survived so long

`conf/include/flutter-app.inc` skipped `buildpaths` for every Flutter app package, so the check that exists to catch exactly this was off. master's own QA log:

```
NOTE: Package flatpak-minimal-appstream-dart-flathub-catalog skipping QA tests:
      {'ldflags', 'dev-so', 'buildpaths', 'libdir'}
```

scarthgap was the only branch ever reporting the app warnings in #566 — not because it was worse, but because it was the only one without this entry.

## Why it is safe now

Across **243 built recipes** in a master build tree, exactly two packages contained a build path — the two plugin apps, one file each (`libapp.so`), both fixed by #821. Of one app's twelve packaged files, only `libapp.so` ever carried one.

wrynose CI then confirmed it on the apps I could not scan locally, including the ten `ivi-homescreen` integration tests: zero `buildpaths` issues, with `do_package_qa` shown **Started/Succeeded** rather than stamp-skipped. `do_compile` correctly did not re-run — changing `INSANE_SKIP` alters the QA task's signature, not the compile's — so QA ran with the check enabled against post-fix artifacts.

`buildpaths` is in oe-core's `ERROR_QA`, so this turns #819 from a repair into an invariant: a regression fails the build rather than shipping quietly.

## What this does not touch

The `dart-sdk` skip stays — `gen_kernel_aot.dart.snapshot` embeds a build path by a different route, out of the SDK's own `ninja create_sdk`, tracked in #827. Both skips now carry a comment saying why they exist; the `dart-sdk` one arrived undocumented with the 3.47.1 roll (8af2ba88), which is how a known defect came to look like a check that did not apply.
