### PR TITLE
scarthgap: record why buildpaths QA is not skipped for app packages

### DIFF
--- a/conf/include/flutter-app.inc
+++ b/conf/include/flutter-app.inc
@@ -101,6 +101,11 @@ do_install() {
     done
 }
 
+# buildpaths is deliberately not skipped. The AOT image used to embed the
+# absolute path of the plugin registrant, and suppressing the check here is
+# what let that ship unnoticed; with the registrant named through a
+# filesystem-root scheme (see common.inc) an app package has no build path
+# left in it, so the check is a regression guard rather than noise.
 INSANE_SKIP:${PN} += " ldflags libdir dev-so"
 
 FILES:${PN} = "\


### PR DESCRIPTION
Companion to #828 (wrynose) and the master port. **Comment only — no behavior change.**

scarthgap never carried the `buildpaths` entry in `flutter-app.inc`'s `INSANE_SKIP` that master and wrynose had:

| branch | app-package skip (before this series) |
|---|---|
| master | `… dev-so buildpaths` |
| wrynose | `… dev-so buildpaths` |
| scarthgap | `… dev-so` |

That is the whole reason scarthgap was the only branch reporting the app `buildpaths` warnings in #566 — it was the only one still looking. So there is nothing to change here except to record the intent, so it does not get "helpfully" aligned with the others later.

`dart-sdk` is deliberately untouched: it has no `buildpaths` skip on this branch, so the leak in `gen_kernel_aot.dart.snapshot` stays visible as the warning #827 tracks. master and wrynose suppress it and now carry a comment saying that is a known defect being hidden, not a check that does not apply.