### PR TITLE
tools: reject a license_type using the wrong operator for the branch

### DIFF
--- a/tools/common.py
+++ b/tools/common.py
@@ -381,9 +381,43 @@ def detect_licenses(license_path: str) -> list:
     return found
 
 
+# Multiple licenses are joined with "AND" on master and with "&" on the release
+# branches: oe-core 51c7930220 made AND the native SPDX operator, and before it
+# a bare AND parsed as a license *name*. Both spellings are correct on their own
+# branch and each is a regression on the other, so the value is declared here
+# and checked, rather than left to a sweep to notice after the fact. Change it
+# in the same commit that branches for a new release. See README.
+LICENSE_OPERATOR = 'AND'
+_LICENSE_OPERATOR_OTHER = '&'
+
+
 def detect_license(license_path: str) -> str:
     """detect_licenses() as an SPDX expression, e.g. "BSD-3-Clause AND MIT"."""
-    return ' AND '.join(sorted(detect_licenses(license_path)))
+    return f' {LICENSE_OPERATOR} '.join(sorted(detect_licenses(license_path)))
+
+
+def wrong_license_operator(declared: str) -> str:
+    """The operator in [declared] that this branch does not use, else ''.
+
+    Does not require an operator to be present -- a single-license value has
+    none. "&" cannot occur inside an SPDX id, so a substring test is enough for
+    it; "AND" can, so that one is matched on token boundaries.
+    """
+    if not declared:
+        return ''
+    if LICENSE_OPERATOR == 'AND':
+        return '&' if '&' in declared else ''
+    return 'AND' if 'AND' in re.split(r'[\s()]+', declared) else ''
+    # Match on token boundaries: "&" cannot appear inside an SPDX id, but "AND"
+    # would otherwise match inside a name that contains it.
+    tokens = re.split(r'[\s()]+', declared)
+    if _LICENSE_OPERATOR_OTHER in tokens:
+        return _LICENSE_OPERATOR_OTHER
+    if LICENSE_OPERATOR == 'AND' and '&' in declared:
+        return '&'
+    if LICENSE_OPERATOR == '&' and 'AND' in tokens:
+        return 'AND'
+    return ''
 
 
 def license_agrees_with_source(declared: str, detected_list: list) -> bool:

--- a/tools/roll_meta_flutter.py
+++ b/tools/roll_meta_flutter.py
@@ -14,6 +14,8 @@ import sys
 
 from common import detect_licenses
 from common import license_agrees_with_source
+from common import LICENSE_OPERATOR
+from common import wrong_license_operator
 from common import make_sure_path_exists
 from common import print_banner
 
@@ -126,6 +128,21 @@ def get_repo(repo_path: str, output_path: str,
         # LICENSE = "GPLv3" over BSD-3-Clause text. Upstreams also relicense and
         # add licenses between rolls -- flutter/games grew an Apache-2.0 section
         # and a bundled font's OFL-1.1 -- and a roll is when that surfaces.
+        # The operator is branch-specific and each spelling is a regression on
+        # the other branch, so a manifest entry carrying the wrong one has to
+        # fail here -- it generates recipes in the wrong dialect for the
+        # oe-core this branch builds against, and nothing downstream looks.
+        # A cherry-picked entry is the likely way in.
+        wrong = wrong_license_operator(license_type)
+        if wrong:
+            print_banner(
+                f'ERROR: {repo_name}: license_type joins licenses with '
+                f'"{wrong}", but this branch uses "{LICENSE_OPERATOR}"\n'
+                f'  declared: {license_type}\n'
+                f'Fix license_type in flutter-apps.json. See the LICENSE '
+                f'operator note in README.')
+            exit(1)
+
         if validate_license:
             detected = detect_licenses(license_path)
             if not detected:


### PR DESCRIPTION
Closes #831. Tooling only — `tools/**` is in `paths-ignore`, so this costs no CI.

## The gap

`roll_meta_flutter.py` validated the licence *set* a manifest entry declares against the licence text — a real check, and the one that caught `depot-tools` carrying `LICENSE = "GPLv3"` over BSD-3-Clause text. But it never looked at the **operator**, so `Apache-2.0 AND MIT` and `Apache-2.0 & MIT` both passed, on every branch.

That matters because the operator is branch-specific and each spelling is a regression on the other (see #835 / #834): master needs `AND`, the release branches need `&`. An entry with the wrong one generates recipes in the wrong dialect for the oe-core that branch builds against — a `license-format` "old syntax" warning per recipe on master, an outright failure on a release branch — and nothing downstream looks.

Not hypothetical: the flutter/games entry alone generates six recipes, and a cherry-picked manifest entry carries its operator with it.

## The check

`LICENSE_OPERATOR` is declared once in `common.py`, with the reason and a note to change it when branching for a release. `wrong_license_operator()` reports only the spelling this branch rejects, and the roll fails before the existing set validation, naming the branch and the expected operator.

It does not require an operator to be present — a single-licence value has none. `&` cannot occur inside an SPDX id, so a substring test suffices; `AND` can, so it is matched on token boundaries.

Tested both directions, master and a release-branch simulation:

| value | master (`AND`) | release (`&`) |
|---|---|---|
| `Apache-2.0 AND MIT` | ok | rejected: `AND` |
| `Apache-2.0 & MIT` | rejected: `&` | ok |
| `Apache-2.0&MIT` | rejected: `&` | ok |
| `MIT`, `CLOSED`, `""` | ok | ok |
| `(MIT OR Apache-2.0) AND BSD-3-Clause` | ok | rejected: `AND` |
| `LicenseRef-ANDroid-thing` | ok | ok — no false positive |

Against the real manifest: **25 entries, 0 rejected**. Substituting scarthgap's value for the same entry is rejected with `&`, which is precisely the cherry-pick failure mode.

`detect_license()` now derives its joiner from the same constant rather than hard-coding one. It is still uncalled on every branch, but it can no longer be wired up in the wrong dialect — I left it in place rather than delete it, happy to drop it instead if you would rather.