### PR TITLE
kirkstone: keep TMPDIR out of the AOT image

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -501,11 +501,27 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
             flutter_source_file = ''
             flutter_source_package = ''
             flutter_source_defines = ''
-            dart_plugin_registrant_file = f'{source_dir}/{flutter_application_path}/.dart_tool/flutter_build/dart_plugin_registrant.dart'
+            flutter_filesystem = ''
+            flutter_app_dir = os.path.normpath(f'{source_dir}/{flutter_application_path}')
+            dart_plugin_registrant_file = f'{flutter_app_dir}/.dart_tool/flutter_build/dart_plugin_registrant.dart'
             if os.path.isfile(dart_plugin_registrant_file):
-                flutter_source_file = f'--source file://{dart_plugin_registrant_file}'
+                # The registrant is the one library with no package: URI, so it
+                # is named to the frontend by path -- and that path becomes the
+                # generated library's import URI, which the AOT image keeps
+                # verbatim. Naming it absolutely puts WORKDIR, and so TMPDIR,
+                # inside every shipped libapp.so and trips the buildpaths QA
+                # check. A relative path does not help: the frontend
+                # canonicalizes it back to an absolute file URI. Only a scheme
+                # with no absolute form does, so declare the app as a filesystem
+                # root and name the registrant against it. See #819.
+                registrant_scheme = 'org-dartlang-root'
+                registrant_uri = f'{registrant_scheme}:///' \
+                    f'{os.path.relpath(dart_plugin_registrant_file, flutter_app_dir)}'
+                flutter_filesystem = f'--filesystem-root {flutter_app_dir}' \
+                    f' --filesystem-scheme {registrant_scheme}'
+                flutter_source_file = f'--source {registrant_uri}'
                 flutter_source_package = '--source package:flutter/src/dart_plugin_registrant.dart'
-                flutter_source_defines = f'-Dflutter.dart_plugin_registrant=file://{dart_plugin_registrant_file}'
+                flutter_source_defines = f'-Dflutter.dart_plugin_registrant={registrant_uri}'
 
             flutter_native_assets = ''
             yaml_path = glob.glob(f'{source_dir}/{flutter_application_path}/.dart_tool/flutter_build/*/native_assets.yaml')
@@ -556,6 +572,7 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
                 --aot \
                 --tfa \
                 --target-os linux \
+                {flutter_filesystem} \
                 --packages {package_config_json} \
                 --output-dill {flutter_app_output_dill} \
                 --depfile {dep_path[0]} \


### PR DESCRIPTION
Closes #832. Completes #819 across all five branches — the diff is byte-identical to the merged master commit (`52b6c351`).

## The leak

`common.inc` named the generated plugin registrant to the frontend by absolute path, twice — as `--source` and as the `-Dflutter.dart_plugin_registrant` define. `source_dir` is under `WORKDIR`, hence `TMPDIR`, and that path becomes the generated library's import URI, which the AOT image retains verbatim. So every release `libapp.so` this branch builds for an app **with plugins** carries the path of the machine it was built on.

The registrant is the only library an app compiles that has no `package:` URI — everything else is reached through `--packages` — so it is not the largest leak, it is the only one.

Fixed by declaring the app as a filesystem root and naming the registrant against it:

```
org-dartlang-root:///.dart_tool/flutter_build/dart_plugin_registrant.dart
```

All five branches pin `FLUTTER_SDK_TAG = "3.47.1"`, so the frontend server is identical and `--filesystem-root` behaves the same here as on master. The changed block is plain Python inside `do_compile`, so dunfell's `_append` override syntax does not come into it.

## What CI here does and does not prove

Worth being explicit. This branch's CI builds `jwinarske-bluez-native-flutter-ble-scanner` and `jwinarske-packagekit-dart-packagekit-catalog` — and both of those have **no plugin registrant**, so neither enters the `if os.path.isfile(dart_plugin_registrant_file)` branch this change touches. A `strings` sweep of a master rootfs found 0 TMPDIR references in both, against 1 each in the two apps that do have registrants.

So CI here is a **smoke test**: it proves `do_compile` still runs for every app, which is the real risk in a Python change of this shape, but it cannot exercise the fix. That is also why `buildpaths` never appeared in this branch's logs.

The fix itself was verified on master, where the replay of the recipe's own `do_compile` commands reproduced the shipped `libapp.so` **byte for byte** and went from 1 TMPDIR reference to 0, with `_PluginRegistrant` still linked under a hash derived from the new URI. Since the code here is byte-identical and the SDK is the same, that result carries.

`do_compile` compiles cleanly as Python on this branch.
