### PR TITLE
ci: stop demoting license-format for the whole build

### DIFF
--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -18,20 +18,18 @@ DISTRO_FEATURES:append = " systemd x11 wayland opengl pam polkit pipewire pulsea
 
 DISTRO_FEATURES_OPTED_OUT = ""
 
-# ***************************************
-# CI clones every layer at master. oe-core master's license-format QA resolves
-# every LicenseRef- in a LICENSE expression, either to a file in
-# COMMON_LICENSE_DIR or through NO_GENERIC_LICENSE, and errors when it cannot.
-# meta-openembedded master has not caught up: coremark and coremark-pro declare
-# LicenseRef-EEMBC-AUA, glmark2 LicenseRef-SGI-1 and lmbench
-# LicenseRef-GPL-2.0-with-lmbench-restriction, none of which oe-core ships and
-# none of which those recipes map with NO_GENERIC_LICENSE. That is a fatal QA
-# error at parse time, so bitbake halts before reaching any meta-flutter recipe.
-# None of those recipes are built here, so demote the check to a warning rather
-# than let third-party layer skew block CI entirely. This file is CI-only and
-# does not affect QA for meta-flutter's own recipes in a real build.
-ERROR_QA:remove = "license-format"
-WARN_QA:append = " license-format"
+# license-format is deliberately left at its oe-core default, which is fatal.
+# It used to be demoted here, because meta-openembedded master declares
+# LicenseRef- values oe-core cannot resolve and that halts parsing before any
+# meta-flutter recipe is reached. But every recipe that does so -- coremark,
+# coremark-pro, glmark2, lmbench -- lives under recipes-benchmark, which the
+# BBMASK below already removes from the parse entirely, so the demotion was
+# redundant with a narrower fix already in place.
+#
+# It was not harmless, either: ERROR_QA:remove applies to the whole build, so a
+# genuine license-format error in one of meta-flutter's own recipes surfaced as
+# a warning in a green CI run. That is the check that would have answered the
+# question in #823 directly. Keep the mask narrow and the check fatal.
 
 # meta-openembedded master is currently out of step with oe-core master in ways
 # that halt parsing before any meta-flutter recipe is reached, and meta-oe has no


### PR DESCRIPTION
Closes #833.

## The demotion was redundant

`ci-build.inc` demoted `license-format` from `ERROR_QA` to `WARN_QA` because meta-openembedded master declares `LicenseRef-` values oe-core cannot resolve, which is fatal at parse time and halts bitbake before any meta-flutter recipe is reached. The four recipes named as the reason are `coremark`, `coremark-pro`, `glmark2` and `lmbench`.

All four live under `recipes-benchmark`, and twelve lines below the demotion:

```
BBMASK += "meta-openembedded/meta-oe/recipes-benchmark/"
```

A masked recipe is never parsed, so its `license-format` error cannot fire. The demotion had nothing left to protect against — a narrower fix was already in place.

## And it was not harmless

`ERROR_QA:remove` applies to the whole build, not to the layer that needed it. So a genuine `license-format` error in one of meta-flutter's own recipes came out as a warning inside a green CI run. That is the check that would have answered #823 directly from CI, instead of from reading oe-core's parser by hand.

The comment claimed this file "does not affect QA for meta-flutter's own recipes in a real build" — true of a real build, and beside the point for CI, which is where anyone actually looks.

Same shape as the `buildpaths` skip removed in #828/#829: a check that exists to catch a specific defect, switched off for an unrelated reason, so the defect it guards ships unnoticed.

## Risk

If any recipe outside the masked directories still trips `license-format`, this fails the build rather than warning — that is the point, and this run is the test. master's nine `AND` recipes parse cleanly on oe-core master (verified against `02e3265178`), so the expected result is green.