### PR TITLE
README: note the kTouchSlop workaround for custom touch controllers

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,21 @@ Targets flutter-engine-* is known to work on
 * STM32MP157x - cortexa7t2hf
 * etc
 
+### Gesture responsiveness on custom touch controllers
+
+If drags and swipes feel unresponsive on a custom touch controller, the
+cause is usually Flutter's touch slop -- the distance a pointer must travel
+before a movement counts as a drag rather than a tap. The default suits a
+phone digitizer and is often too small for an industrial or resistive panel.
+
+Patch `kTouchSlop` in `flutter-sdk-native`:
+
+    packages/flutter/lib/src/gestures/constants.dart
+
+Raising it from 18 to 64 has made custom touch controllers markedly more
+responsive in the field. The right value is panel-specific, so treat 64 as a
+starting point rather than a recommendation.
+
 ## Include the Flutter SDK into Yocto SDK
 
 Add to local.conf file:


### PR DESCRIPTION
Closes #348. Documentation only — `**/*.md` is in `paths-ignore`, so no CI cost.

#348 has been open since 2023 labelled `documentation`, holding a field workaround that was never written anywhere a user would find it: if gestures feel unresponsive on a custom touch controller, raise `kTouchSlop` in `flutter-sdk-native`.

It is a tuning note, not a layer defect, so the issue was never going to close by being fixed. Moving it into the README is the actual resolution — same treatment as #834/#835.

Framed 64 as a starting point rather than a recommendation, since the right value is panel-specific.