### PR TITLE
wrynose: drop the dead buildpaths skips on the v3 -dbg packages

### DIFF
--- a/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
@@ -85,5 +85,3 @@ python () {
 # it by the recipe name.
 DEBIAN_NOAUTONAME:${PN} = "1"
 DEBIAN_NOAUTONAME:${PN}-dev = "1"
-
-INSANE_SKIP:${PN}-dbg += " buildpaths"

--- a/recipes-graphics/toyota/ivi-homescreen-v3.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-v3.inc
@@ -542,6 +542,4 @@ RDEPENDS:${PN} += "\
     ivi-homescreen-shared \
     "
 
-INSANE_SKIP:${PN}-dbg += " buildpaths"
-
 BBCLASSEXTEND = "verbose-logs"


### PR DESCRIPTION
Part of #566. Continues the audit that #828/#829 started on app packages.

## These skip nothing

A `-dbg` package holds split debug info, and `DEBUG_PREFIX_MAP` is part of `TARGET_CFLAGS` by default — the build directory is rewritten out of DWARF before packaging. Checked against real packages from a master build tree rather than assumed:

| package | files | containing TMPDIR |
|---|---|---|
| `ivi-homescreen-dbg` | 1 | **0** |
| `ivi-homescreen-shared-dbg` | 1 | **0** |
| `flutter-auto-dbg` | 1 | **0** |

and the debug ELF itself:

```
DW_AT_comp_dir : /usr/src/debug/glibc/2.44+git/csu
```

A rewritten path, not one under `WORKDIR`. That is the prefix map working as designed.

The corroborating signal: **oe-core carries no `-dbg` buildpaths skip anywhere in its tree** — thousands of recipes produce `-dbg` packages without needing one. Only a `-staticdev` case in `openmp_git.bb`.

Neither recipe overrides `CFLAGS`, and ivi-homescreen's own CMake uses `string(APPEND ...)` and `add_compile_options` rather than assigning, so nothing was dropping the map. These look like they propagated by copy between the toyota recipes rather than answering an observed failure.

## Why remove rather than leave

`buildpaths` is in oe-core's `ERROR_QA`. With the skip gone, a build that *starts* leaking paths into debug info fails instead of shipping quietly — the same reason #828 was worth doing.

## Deliberately not touched

- `flutter-auto_2.0.bb` and `ivi-homescreen_2.0.bb` carry the same line, but they are a different source series and were not covered by the evidence above.
- `flutter-engine`'s `${PN}-test` and `flutter-sdk`'s `class-nativesdk` skips are different scopes again, and neither package was built in the tree I had, so there is nothing to check them against.

Worth a follow-up once those are built somewhere inspectable, rather than removed on inference.