### PR TITLE
master: drop the dead buildpaths skips on the v3 -dbg packages

### DIFF
--- a/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
+++ b/recipes-graphics/toyota/ivi-homescreen-shared_3.0.bb
@@ -85,5 +85,3 @@ python () {
 # it by the recipe name.
 DEBIAN_NOAUTONAME:${PN} = "1"
 DEBIAN_NOAUTONAME:${PN}-dev = "1"
-
-INSANE_SKIP:${PN}-dbg += " buildpaths"

--- a/recipes-graphics/toyota/ivi-homescreen-v3.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-v3.inc
@@ -543,6 +543,4 @@ RDEPENDS:${PN} += "\
     ivi-homescreen-shared \
     "
 
-INSANE_SKIP:${PN}-dbg += " buildpaths"
-
 BBCLASSEXTEND = "verbose-logs"


### PR DESCRIPTION
Port of #841 (wrynose, merged, green on all four machines). The diff is byte-identical.

## These skip nothing

A `-dbg` package holds split debug info, and `DEBUG_PREFIX_MAP` is part of `TARGET_CFLAGS` by default — the build directory is rewritten out of DWARF before packaging. Checked against real packages from a master build tree:

| package | files | containing TMPDIR |
|---|---|---|
| `ivi-homescreen-dbg` | 1 | **0** |
| `ivi-homescreen-shared-dbg` | 1 | **0** |
| `flutter-auto-dbg` | 1 | **0** |

and the debug ELF carries

```
DW_AT_comp_dir : /usr/src/debug/glibc/2.44+git/csu
```

a rewritten path, not one under `WORKDIR`.

The corroborating signal: **oe-core carries no `-dbg` buildpaths skip anywhere** — thousands of recipes produce `-dbg` packages without one. Neither recipe overrides `CFLAGS`, and ivi-homescreen's CMake appends rather than assigns, so nothing was dropping the map. These propagated by copy between the toyota recipes rather than answering an observed failure.

wrynose CI then confirmed it with the check fatal: all four machines green with `buildpaths` in `ERROR_QA` and the skips gone.

## Why remove rather than leave

With the skip gone, a build that *starts* leaking paths into debug info fails instead of shipping quietly — the same reason #828/#829 were worth doing.

## Deliberately not touched

- `flutter-auto_2.0.bb` and `ivi-homescreen_2.0.bb` carry the same line but are a different source series, not covered by the evidence above.
- `flutter-engine`'s `${PN}-test` and `flutter-sdk`'s `class-nativesdk` skips are different scopes, and neither package was built in a tree I could inspect.

Part of #566.
