### PR TITLE
ci: run the tools test suites

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -16,6 +16,8 @@ on:
       - 'docs/**'
       - 'tools/**'
       - '.github/workflows/runner-maintenance.yml'
+      # Runs on a GitHub-hosted runner and never touches a build.
+      - '.github/workflows/tools-tests.yml'
       # Release-branch builds are registered here so they can be
       # dispatched, but they never affect a master build.
       - '.github/workflows/scarthgap-build.yml'

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -1,0 +1,46 @@
+name: tools-tests
+
+# The Python under tools/ has no coverage in the build workflows: 'tools/**'
+# is in their paths-ignore, correctly, because a script change should not
+# trigger four hour-long Yocto builds. This runs the test suites instead.
+#
+# GitHub-hosted on purpose. The build workflows use the self-hosted runner and
+# run one at a time; a five-second test run must not queue behind an hour-long
+# build, and it needs nothing the self-hosted runner provides.
+
+on:
+  pull_request:
+    paths:
+      - 'tools/**'
+      - '.github/workflows/tools-tests.yml'
+  workflow_dispatch:
+
+jobs:
+
+  pytest:
+    name: pytest (${{ matrix.python }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # 3.10 is the floor: pubvendor.py annotates dataclass fields with
+        # 'str | None', which is evaluated at class creation. Newest is
+        # tested too so a deprecation surfaces here rather than on a
+        # maintainer's machine.
+        python: ['3.10', '3.13']
+    steps:
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v4
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python }}
+
+      - name: 📦 Install Dependencies
+        run: python -m pip install --disable-pip-version-check pytest pyyaml
+
+      - name: 🧪 Run tools test suites
+        # Discovers every tests/ dir under tools/, so a new tool with tests
+        # is picked up without touching this workflow.
+        run: python -m pytest tools -q


### PR DESCRIPTION
Closes #844. First of the three #842 follow-ups — #843 and #845 both depend on this existing.

## The gap

#842 added 14 tests guarding invariants that break quietly: checksums taken from the lockfile rather than fetched, git SRCREV pinned to `resolved-ref` rather than a branch head, the pub cache directory contract, scp URL normalization, BitBake-safe identifier uniqueness.

Nothing ran them. `tools/**` is in the build workflows' `paths-ignore` — correctly, since a Python change should not cost four hour-long Yocto builds — so the side effect was that `tools/` had no automated coverage at all.

## Where it runs, and why that matters

`ubuntu-latest`, not `[self-hosted, linux]` like every other workflow here. The build workflows share one self-hosted runner and run one at a time; a five-second test run must not sit behind an hour-long build, and it needs nothing that runner provides. It can also run concurrently with a Yocto build rather than displacing one.

## Details

- **Collects from `tools/`**, not `tools/pubvendor`, so a second tool with a `tests/` dir is picked up without editing this workflow.
- **Two Python versions.** 3.10 is the floor — `pubvendor.py` annotates dataclass fields with `str | None`, which is evaluated at class creation — and the newest is covered so a deprecation surfaces here rather than on a maintainer's machine.
- **`master-build.yml` gains the new workflow in `paths-ignore`**, matching how `runner-maintenance.yml` and the release-branch workflows are registered: it runs elsewhere and can never affect a build.

## Verification

Ran the exact command CI will run, from the repo root:

```
$ python -m pytest tools -q
..............                                                    [100%]
14 passed in 0.06s
```

Both workflow files parse as YAML.

One honest caveat: only Python 3.14 is installed here, so the 3.10 leg is reasoned from the syntax used rather than executed. If the floor is wrong the matrix says so in seconds on a hosted runner — which is much of the point of putting it there.

Note this PR does trigger a master Yocto build, because it edits `master-build.yml` and that file is deliberately not self-ignored. One build to add the entry, none thereafter.