### PR TITLE
pub-cache: resolve with flutter pub get, and stand down the archive path

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -71,9 +71,27 @@ python do_write_hosted_hashes() {
 }
 addtask write_hosted_hashes after do_unpack before do_configure
 
+# `flutter pub get`, not `dart pub get`. Both resolve offline from the staged
+# cache, but only the flutter one writes .flutter-plugins-dependencies, which
+# is what tells the build which plugins to register and feeds the generated
+# dart_plugin_registrant.dart. With `dart pub get` an app builds green and
+# registers no plugins.
 do_pub_get_offline() {
     cd ${PUBSPEC_APP_DIR}
-    dart pub get --offline --enforce-lockfile
+    flutter pub get --offline --enforce-lockfile
 }
 addtask pub_get_offline after do_check_pubspec_lock do_write_hosted_hashes before do_compile
 do_pub_get_offline[network] = "0"
+
+# The layer's own pub cache path fetches with the network and carries the
+# resolution artifacts through an archive (common.inc, the .project copy in
+# do_archive_pub_cache and the moves back in do_restore_pub_cache). A recipe
+# staging its cache through SRC_URI needs neither: do_unpack puts the packages
+# in place and do_pub_get_offline regenerates the artifacts locally. Leaving
+# both enabled would mean two populators of ${WORKDIR}/pub_cache, one of them
+# reaching for the network, which is the thing this class exists to avoid.
+#
+# Doing it here rather than in common.inc keeps opting in to exactly
+# "inherit pub-cache", with no effect on any recipe that does not.
+do_archive_pub_cache[noexec] = "1"
+do_restore_pub_cache[noexec] = "1"


### PR DESCRIPTION
Step 1 of the #843 sequence. Two fixes the class needed before any recipe could safely inherit it.

## `dart pub get` was the wrong command

It writes `.dart_tool` and nothing else. A Flutter app also needs **`.flutter-plugins-dependencies`** — that is what tells the build which plugins to register, and what the generated `dart_plugin_registrant.dart` is built from. Checked on a clean tree, both offline against a staged cache:

| command | produces |
|---|---|
| `dart pub get --offline --enforce-lockfile` | `.dart_tool` |
| `flutter pub get --offline --enforce-lockfile` | `.dart_tool`, **`.flutter-plugins-dependencies`** |

and the file carries real content rather than merely existing:

```
linux plugins listed: ['path_provider_linux', 'shared_preferences_linux']
```

An app resolved with `dart pub get` would have built **green and registered no plugins** — the worst shape for a defect, and the same class of silent failure as #819 itself.

Worth recording how it hid: the offline check I ran on #842 appeared to produce the file, because that test deleted only `.dart_tool` and the file was left over from an earlier `flutter pub get`. Deleting both is what shows it. Neither that check nor the unit tests would have caught this.

## The archive path had to stand down

`common.inc` already populates the pub cache its own way: `do_archive_pub_cache` fetches **with the network** and copies the resolution artifacts into the archive as `.project` (`:293`), which `do_restore_pub_cache` moves back afterwards (`:354-361`).

A recipe staging its cache through `SRC_URI` needs neither half — `do_unpack` puts the packages in place and `do_pub_get_offline` regenerates the artifacts locally. Leaving both enabled would give `${WORKDIR}/pub_cache` two populators, one of them reaching for the network, which is the thing this class exists to avoid.

Marking that pair `noexec` **in the class** rather than editing `common.inc` means opting in is exactly `inherit pub-cache`, with no change to shared code and no effect on any recipe that does not. That is cheaper than the "make `do_archive_pub_cache` yield" I originally proposed in #843.

## Still to come

This makes the class correct; it does not yet wire anything up. Remaining in #843: the roll regenerating the lockfile against the pinned SDK and committing the `.inc`, then proving one opted-in app with a real `BB_NO_NETWORK` build before widening. No recipe inherits this class yet, so nothing changes for any existing build.

`dart test` on the tools suite: 14 passed.