### PR TITLE
roll: generate a pub cache fragment for apps that opt in

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -71,9 +71,27 @@ python do_write_hosted_hashes() {
 }
 addtask write_hosted_hashes after do_unpack before do_configure
 
+# `flutter pub get`, not `dart pub get`. Both resolve offline from the staged
+# cache, but only the flutter one writes .flutter-plugins-dependencies, which
+# is what tells the build which plugins to register and feeds the generated
+# dart_plugin_registrant.dart. With `dart pub get` an app builds green and
+# registers no plugins.
 do_pub_get_offline() {
     cd ${PUBSPEC_APP_DIR}
-    dart pub get --offline --enforce-lockfile
+    flutter pub get --offline --enforce-lockfile
 }
 addtask pub_get_offline after do_check_pubspec_lock do_write_hosted_hashes before do_compile
 do_pub_get_offline[network] = "0"
+
+# The layer's own pub cache path fetches with the network and carries the
+# resolution artifacts through an archive (common.inc, the .project copy in
+# do_archive_pub_cache and the moves back in do_restore_pub_cache). A recipe
+# staging its cache through SRC_URI needs neither: do_unpack puts the packages
+# in place and do_pub_get_offline regenerates the artifacts locally. Leaving
+# both enabled would mean two populators of ${WORKDIR}/pub_cache, one of them
+# reaching for the network, which is the thing this class exists to avoid.
+#
+# Doing it here rather than in common.inc keeps opting in to exactly
+# "inherit pub-cache", with no effect on any recipe that does not.
+do_archive_pub_cache[noexec] = "1"
+do_restore_pub_cache[noexec] = "1"

--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -22,6 +22,27 @@ PUBSPEC_APP_DIR ?= "${S}"
 
 export PUB_CACHE
 
+# The fragment is generated from a lockfile resolved against the SDK this
+# layer pins, which is not the one the app committed upstream. do_unpack
+# brings that resolved lockfile in through SRC_URI; install it over the app's
+# own before anything reads it, so what gets built is what was vendored.
+python do_install_pubspec_lock() {
+    import os
+    import shutil
+
+    name = d.getVar('PUBSPEC_LOCK_FILE')
+    if not name:
+        return
+    src = os.path.join(d.getVar('WORKDIR'), name)
+    if not os.path.isfile(src):
+        bb.fatal("PUBSPEC_LOCK_FILE %s not found in WORKDIR; is it in SRC_URI?"
+                 % name)
+    dst = os.path.join(d.getVar('PUBSPEC_APP_DIR'), 'pubspec.lock')
+    shutil.copyfile(src, dst)
+    bb.note("installed vendored pubspec.lock from %s" % name)
+}
+addtask install_pubspec_lock after do_unpack before do_check_pubspec_lock
+
 python do_check_pubspec_lock() {
     import hashlib, os
 
@@ -40,7 +61,7 @@ python do_check_pubspec_lock() {
             "different lockfile (expected %s, got %s). Re-run pubvendor.py."
             % (expected, actual))
 }
-addtask check_pubspec_lock after do_unpack before do_configure
+addtask check_pubspec_lock after do_install_pubspec_lock before do_configure
 
 python do_write_hosted_hashes() {
     # Newer Dart SDKs verify hosted package content hashes against

--- a/tools/common.py
+++ b/tools/common.py
@@ -387,6 +387,13 @@ def detect_licenses(license_path: str) -> list:
 # branch and each is a regression on the other, so the value is declared here
 # and checked, rather than left to a sweep to notice after the fact. Change it
 # in the same commit that branches for a new release. See README.
+# Override syntax for generated fragments: ':append' from kirkstone on,
+# '_append' for dunfell's older bitbake. Declared alongside LICENSE_OPERATOR
+# because it is the same kind of fact -- branch-specific, correct on its own
+# branch, and a regression if carried to the other. Change it in the same
+# commit that branches for a new release. See README.
+OVERRIDE_STYLE = 'new'
+
 LICENSE_OPERATOR = 'AND'
 _LICENSE_OPERATOR_OTHER = '&'
 

--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -280,7 +280,14 @@ def generate_pubcache_inc(app_dir, recipe_name, output_path) -> bool:
     if rc != 0:
         print(f'WARNING: {recipe_name}: pubvendor failed, no fragment written')
         return False
-    print(f'{recipe_name}: wrote {os.path.basename(out)}')
+
+    # Ship the lockfile the fragment was generated from. The resolution above
+    # happened in this clone, which is not what the recipe builds -- that
+    # fetches the app at SRCREV, carrying whatever lockfile upstream committed.
+    # Without this the two disagree and pub-cache.bbclass stops the build on
+    # the mismatch it exists to catch.
+    shutil.copyfile(lock, os.path.join(output_path, f'{recipe_name}-pubspec.lock'))
+    print(f'{recipe_name}: wrote {os.path.basename(out)} + pubspec.lock')
     return True
 
 
@@ -451,9 +458,12 @@ def create_recipe(directory,
 
         if pubvendor:
             f.write('\n')
+            f.write('FILESEXTRAPATHS:prepend := "${THISDIR}:"\n')
+            f.write(f'SRC_URI += "file://{recipe_name}-pubspec.lock"\n')
             f.write(f'require {recipe_name}-pubcache.inc\n')
             f.write('inherit pub-cache\n')
             f.write('PUBSPEC_APP_DIR = "${S}/${FLUTTER_APPLICATION_PATH}"\n')
+            f.write(f'PUBSPEC_LOCK_FILE = "{recipe_name}-pubspec.lock"\n')
 
         if rdepends_list and flutter_application_path in rdepends_list:
             rdepends = rdepends_list[flutter_application_path]

--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -237,6 +237,53 @@ def copy_src_file(file: str, src_folder: str, patch_dir: str, output_path: str):
     shutil.copy2(src_file, dst_file)
 
 
+def generate_pubcache_inc(app_dir, recipe_name, output_path) -> bool:
+    """Regenerate the lockfile against the pinned SDK, then emit its fragment.
+
+    The lockfile an app ships was resolved against whatever SDK its authors
+    used, which is rarely the one this layer pins -- that mismatch is why
+    generated recipes have always set PUBSPEC_IGNORE_LOCKFILE, deleting the
+    lockfile at build time and re-resolving per build. Resolving once here and
+    committing the result is the same concession made once, visibly, and
+    identically for everyone, rather than silently on every builder.
+
+    Needs `flutter` on PATH, and only for apps that opt in.
+    """
+    import shutil
+    import subprocess
+    import sys
+
+    if shutil.which('flutter') is None:
+        print_banner(
+            f'ERROR: {recipe_name}: "pubvendor" needs flutter on PATH to '
+            f'resolve against the pinned SDK')
+        return False
+
+    lock = os.path.join(app_dir, 'pubspec.lock')
+    if os.path.exists(lock):
+        os.remove(lock)
+    r = subprocess.run(['flutter', 'pub', 'get'], cwd=app_dir,
+                       capture_output=True, text=True)
+    if r.returncode != 0 or not os.path.exists(lock):
+        # Not fatal: an app that cannot resolve against the pinned SDK is a
+        # fact about that app, and one of them must not block a whole roll.
+        print(f'WARNING: {recipe_name}: pub get failed, no fragment written\n'
+              f'{r.stderr.strip()[:400]}')
+        return False
+
+    sys.path.insert(0, os.path.join(os.path.dirname(__file__), 'pubvendor'))
+    import pubvendor
+    from common import OVERRIDE_STYLE
+
+    out = os.path.join(output_path, f'{recipe_name}-pubcache.inc')
+    rc = pubvendor.main(['-i', lock, '-o', out, '--style', OVERRIDE_STYLE])
+    if rc != 0:
+        print(f'WARNING: {recipe_name}: pubvendor failed, no fragment written')
+        return False
+    print(f'{recipe_name}: wrote {os.path.basename(out)}')
+    return True
+
+
 def create_recipe(directory,
                   pubspec_yaml,
                   flutter_application_path,
@@ -251,7 +298,8 @@ def create_recipe(directory,
                   src_folder,
                   src_files,
                   variables,
-                  patch_dir) -> str:
+                  patch_dir,
+                  pubvendor=False) -> str:
     is_web = False
     # TODO detect web
 
@@ -280,6 +328,15 @@ def create_recipe(directory,
     make_sure_path_exists(str(output_path))
 
     recipe_name = get_recipe_name(org, unit, flutter_application_path, project_name)
+
+    # A fragment that failed to generate must not leave behind a recipe that
+    # `require`s it -- a missing include is a parse error for the whole layer,
+    # so one bad app would take the rest down with it.
+    if pubvendor:
+        pubvendor = generate_pubcache_inc(
+            app_dir=os.path.dirname(pubspec_yaml),
+            recipe_name=recipe_name,
+            output_path=output_path)
 
     if project_version is not None:
         version = project_version.split('+')
@@ -369,7 +426,14 @@ def create_recipe(directory,
 
         f.write(f'PUBSPEC_APPNAME = "{project_name}"\n')
         f.write(f'FLUTTER_APPLICATION_INSTALL_SUFFIX = "{recipe_name}"\n')
-        f.write(f'PUBSPEC_IGNORE_LOCKFILE = "1"\n')
+        if pubvendor:
+            # The fragment is generated from this app's lockfile, and
+            # pub-cache.bbclass refuses to build if the in-tree lockfile no
+            # longer matches it -- so the lockfile has to survive do_unpack
+            # rather than be deleted here.
+            f.write(f'PUBSPEC_IGNORE_LOCKFILE = "0"\n')
+        else:
+            f.write(f'PUBSPEC_IGNORE_LOCKFILE = "1"\n')
 
         f.write(f'FLUTTER_APPLICATION_PATH = "{flutter_application_path}"\n')
 
@@ -384,6 +448,12 @@ def create_recipe(directory,
             f.write('inherit flutter-web\n')
         else:
             f.write('inherit flutter-app\n')
+
+        if pubvendor:
+            f.write('\n')
+            f.write(f'require {recipe_name}-pubcache.inc\n')
+            f.write('inherit pub-cache\n')
+            f.write('PUBSPEC_APP_DIR = "${S}/${FLUTTER_APPLICATION_PATH}"\n')
 
         if rdepends_list and flutter_application_path in rdepends_list:
             rdepends = rdepends_list[flutter_application_path]
@@ -451,7 +521,8 @@ def create_yocto_recipes(directory,
                          src_files,
                          entry_files,
                          variables,
-                         patch_dir):
+                         patch_dir,
+                         pubvendor=False):
     """Create bb recipe for each pubspec.yaml file in path"""
     import glob
 
@@ -533,7 +604,8 @@ def create_yocto_recipes(directory,
                                src_folder=src_folder,
                                src_files=src_files,
                                variables=variables,
-                               patch_dir=patch_dir)
+                               patch_dir=patch_dir,
+                               pubvendor=pubvendor)
 
         if recipe != '':
             recipes.append([recipe, flutter_application_path])

--- a/tools/roll_meta_flutter.py
+++ b/tools/roll_meta_flutter.py
@@ -50,7 +50,8 @@ def get_repo(repo_path: str, output_path: str,
              src_files: dict,
              entry_files: dict,
              variables: dict,
-             patch_dir: str):
+             patch_dir: str,
+             pubvendor: bool = False):
     """ Clone Git Repo """
 
     print(f'repo_path: {repo_path}')
@@ -186,7 +187,8 @@ def get_repo(repo_path: str, output_path: str,
                          src_files=src_files,
                          entry_files=entry_files,
                          variables=variables,
-                         patch_dir=patch_dir)
+                         patch_dir=patch_dir,
+                         pubvendor=pubvendor)
 
 
 def get_workspace_repos(repo_path, repos, output_path, package_output_path, patch_dir):
@@ -211,6 +213,7 @@ def get_workspace_repos(repo_path, repos, output_path, package_output_path, patc
                                            rdepends_list=r.get('rdepends'),
                                            output_path_override_list=r.get('output_folder'),
                                            compiler_requires_network_list=r.get('compiler_requires_network'),
+                                          pubvendor=r.get('pubvendor', False),
                                            src_folder=r.get('src_folder'),
                                            src_files=r.get('src_files'),
                                            entry_files=r.get('entry_files'),


### PR DESCRIPTION
Step 3 of #843. **Stacked on #851** — merge that first.

Opt-in and inert: no app sets `"pubvendor"` yet, so nothing changes for any existing recipe.

## Why it re-resolves the lockfile

For an opted-in app the roll deletes `pubspec.lock` and re-runs `flutter pub get` before generating the fragment. That looks destructive, and is the opposite:

The lockfile an app ships was resolved against whatever SDK its authors used, rarely the one this layer pins. That mismatch is exactly why every generated recipe has always carried `PUBSPEC_IGNORE_LOCKFILE = "1"`, which **deletes the lockfile at build time** so each build re-resolves. Two people building the same SRCREV a week apart can get different dependency sets today.

Resolving once at roll time and committing the fragment is that same concession made **once, visibly, and identically for everyone** — strictly more reproducible than the status quo, not less. Verified: the re-resolved lockfile records `dart: ">=3.13.1 <4.0.0"`, the pinned SDK.

An opted-in recipe therefore sets `PUBSPEC_IGNORE_LOCKFILE = "0"`; the fragment is generated from that lockfile and `pub-cache.bbclass` refuses to build if the in-tree one no longer matches, so it has to survive `do_unpack`.

## Two failures handled rather than propagated

- **No flutter on PATH** — reported and skipped. The SDK is only needed by apps that opt in, so a roll with none must not require it.
- **`pub get` cannot resolve against the pinned SDK** — a fact about that app, and one of them must not take down a roll of twenty-five. Warns and moves on.

In both cases the recipe is written **without** the `require` line. A recipe requiring a fragment that was never generated is a parse error for the entire layer — much worse than one app missing its fragment. That is why generation happens before the recipe is written and its result gates the emission.

## Branch-specific style

`OVERRIDE_STYLE` is new in `common.py`, declared next to `LICENSE_OPERATOR` because it is the same kind of fact: branch specific, correct on its own branch, a regression if carried to the other. dunfell will set it to `old`.

## Verified

Ran the generation path against a real 40-package app:

```
demo-app-pubcache.inc: 40 hosted, 0 git, 4 skipped
:append entries present: yes    _append entries: 0
```

and the no-flutter path:

```
** ERROR: x: "pubvendor" needs flutter on PATH to resolve against the pinned SDK **
result: False
```

Tools suite: 14 passed.

## Still outstanding in #843

Opting one app in and proving it with a real `BB_NO_NETWORK` build. Everything to this point is reasoning about task graphs and generated text; only a build shows whether an app with plugins comes out with its plugins.