### PR TITLE
pub-cache: find the lockfile in UNPACKDIR, and put the SDK on the task PATH

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -33,10 +33,13 @@ python do_install_pubspec_lock() {
     name = d.getVar('PUBSPEC_LOCK_FILE')
     if not name:
         return
-    src = os.path.join(d.getVar('WORKDIR'), name)
+    # file:// unpacks into UNPACKDIR from scarthgap on, and straight into
+    # WORKDIR before that. Take whichever this release provides.
+    base = d.getVar('UNPACKDIR') or d.getVar('WORKDIR')
+    src = os.path.join(base, name)
     if not os.path.isfile(src):
-        bb.fatal("PUBSPEC_LOCK_FILE %s not found in WORKDIR; is it in SRC_URI?"
-                 % name)
+        bb.fatal("PUBSPEC_LOCK_FILE %s not found in %s; is it in SRC_URI?"
+                 % (name, base))
     dst = os.path.join(d.getVar('PUBSPEC_APP_DIR'), 'pubspec.lock')
     shutil.copyfile(src, dst)
     bb.note("installed vendored pubspec.lock from %s" % name)
@@ -98,6 +101,14 @@ addtask write_hosted_hashes after do_unpack before do_configure
 # dart_plugin_registrant.dart. With `dart pub get` an app builds green and
 # registers no plugins.
 do_pub_get_offline() {
+    # The SDK is staged by flutter-sdk-native and is not on the task PATH by
+    # default. HOME and XDG_CONFIG_HOME are set for the same reasons
+    # common.inc sets them for its own pub invocations: dart and flutter both
+    # write into them and must not touch the builder's real home.
+    export PATH="${FLUTTER_SDK}/bin:${PUB_CACHE}/bin:$PATH"
+    export HOME="${WORKDIR}"
+    export XDG_CONFIG_HOME="${WORKDIR}"
+
     cd ${PUBSPEC_APP_DIR}
     flutter pub get --offline --enforce-lockfile
 }


### PR DESCRIPTION
Follow-on to #851/#852, which merged while the local build that found these was running. Both were caught by attempting a `BB_NO_NETWORK` build rather than by reading the code, and without them **no opted-in recipe can build at all**.

Nothing is broken on master today — the class is inert until an app sets `"pubvendor"` — but the series as merged would fail for the first person to try it.

## `file://` unpacks to `UNPACKDIR`

From scarthgap on, `file://` entries land in `UNPACKDIR` (`${WORKDIR}/sources`), not `WORKDIR`. The class looked only in `WORKDIR`, so the vendored lockfile was never found and `do_install_pubspec_lock` stopped on its own error message:

```
ERROR: PUBSPEC_LOCK_FILE …-pubspec.lock not found in WORKDIR; is it in SRC_URI?
```

Takes whichever the release provides, since dunfell and kirkstone have no `UNPACKDIR` — the same branch-portability shape as `OECMAKE_ARGS` and `CMAKE_SYSROOT` before it.

## `flutter` was not on the task PATH

`do_pub_get_offline` then failed with no output, because `flutter` could not be found. The SDK is staged by `flutter-sdk-native`, but nothing puts it on a task's PATH — `common.inc` builds an env for its own pub invocations (`:172-179`) and this class was not getting the benefit.

Now sets the same three things it does: SDK and pub cache `bin` on PATH, and `HOME` / `XDG_CONFIG_HOME` at `WORKDIR` so dart and flutter write there rather than into the builder's real home.

## What the build got to

- opted-in recipe **parses**, 43 tasks
- `bitbake --runall=fetch` pulled **156 pub tarballs** into `DL_DIR` through `SRC_URI`, checksums verified
- under `BB_NO_NETWORK=1`, `do_install_pubspec_lock` and `do_check_pubspec_lock` both **pass**

It stopped after that on a missing `bin/flutter` in the recipe's sysroot, which is an artifact of how I made the build affordable — pinning oe-core back to pre-build revisions while meta-flutter sat at current master. Sibling recipes staged before that surgery all have it. Not claimed as a defect, and not fixed here.

`pub get` itself and the plugin-registration assertion remain unproven; that needs a consistent tree or the CI job in #843.