### PR TITLE
pubvendor: bring the docs back in line with the code

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -6,15 +6,22 @@
 #
 # Pairs with the SRC_URI fragment produced by tools/pubvendor/pubvendor.py:
 #   * points PUB_CACHE at the staged tree
-#   * asserts the in-tree pubspec.lock matches the lockfile the .inc was
-#     generated from (PUBSPEC_LOCK_SHA256)
+#   * installs PUBSPEC_LOCK_FILE, the lockfile the fragment was generated
+#     from, over the app's own -- they differ, because the roll re-resolves
+#     against the SDK this layer pins
+#   * asserts the result matches PUBSPEC_LOCK_SHA256, which now catches the
+#     layer's .inc and .lock drifting apart
 #   * synthesizes hosted-hashes/<host>/<pkg>-<ver>.sha256 files from the
 #     SRC_URI checksum flags, so newer Dart SDKs' content verification
 #     passes offline
-#   * runs `dart pub get --offline --enforce-lockfile`
+#   * runs `flutter pub get --offline --enforce-lockfile` -- flutter rather
+#     than dart, see the note above the task
+#   * marks do_archive_pub_cache and do_restore_pub_cache noexec, so the
+#     layer's own networked pub cache path stands down
 #
 # The recipe must set PUBSPEC_APP_DIR to the app source dir containing
-# pubspec.yaml/pubspec.lock (default ${S}).
+# pubspec.yaml/pubspec.lock (default ${S}), and PUBSPEC_LOCK_FILE to the
+# vendored lockfile it carries in SRC_URI.
 
 PUB_CACHE_LOCAL ?= "pub_cache"
 PUB_CACHE = "${WORKDIR}/${PUB_CACHE_LOCAL}"

--- a/tools/pubvendor/README.md
+++ b/tools/pubvendor/README.md
@@ -12,28 +12,82 @@ Options: `--style old` for pre-kirkstone `_append` syntax,
 (one-time fetch at generation, digest pinned into the .inc),
 `--download-prefix` for DL_DIR layout.
 
-Consume with `pub-cache.bbclass`:
+## From the roll
 
+Set `"pubvendor": true` on an entry in `meta-flutter-apps/conf/flutter-apps.json`
+and `roll_meta_flutter.py` does the rest: it re-resolves the app's lockfile
+against the SDK this layer pins, writes `<recipe>-pubcache.inc` and
+`<recipe>-pubspec.lock` beside the recipe, and emits the lines below into it.
+`--style` comes from `OVERRIDE_STYLE` in `tools/common.py`, which is
+branch-specific in the same way `LICENSE_OPERATOR` is.
+
+The re-resolve is deliberate. An app's committed lockfile was resolved
+against whatever SDK its authors used, which is why generated recipes have
+always carried `PUBSPEC_IGNORE_LOCKFILE = "1"` and deleted it at build time,
+leaving every builder to re-resolve independently. Resolving once at roll
+time and committing the result is that same concession made once, visibly,
+and identically for everyone.
+
+An app that cannot resolve against the pinned SDK is reported and skipped
+rather than failing the roll, and its recipe is written *without* the
+`require` line -- a recipe requiring a fragment that was never generated is
+a parse error for the whole layer.
+
+## Consuming a fragment by hand
+
+    FILESEXTRAPATHS:prepend := "${THISDIR}:"
+    SRC_URI += "file://app-pubspec.lock"
     require app-pubcache.inc
     inherit pub-cache
-    PUBSPEC_APP_DIR = "${S}"
+    PUBSPEC_APP_DIR = "${S}/${FLUTTER_APPLICATION_PATH}"
+    PUBSPEC_LOCK_FILE = "app-pubspec.lock"
+    PUBSPEC_IGNORE_LOCKFILE = "0"
 
-The class asserts the in-tree lockfile matches PUBSPEC_LOCK_SHA256,
-synthesizes hosted-hashes/*.sha256 for newer Dart content verification,
-and runs `dart pub get --offline --enforce-lockfile` before do_compile.
+`PUBSPEC_IGNORE_LOCKFILE` must be `"0"`: the fragment is generated from that
+lockfile, and the class refuses to build when the two disagree.
 
-Invariants guarded by tests (tests/test_pubvendor.py):
+`pub-cache.bbclass` then installs the vendored lockfile over the app's own,
+checks it against `PUBSPEC_LOCK_SHA256`, synthesizes the
+`hosted-hashes/*.sha256` files newer Dart SDKs verify against, and runs
+`flutter pub get --offline --enforce-lockfile` before do_compile. It also
+marks `do_archive_pub_cache` and `do_restore_pub_cache` noexec, so the
+layer's own networked pub cache path stands down rather than fighting it.
+
+`flutter pub get` rather than `dart pub get`: both resolve offline from the
+staged cache, but only the flutter one writes
+`.flutter-plugins-dependencies`, which is what tells the build which plugins
+to register. With `dart pub get` an app builds green and registers nothing.
+
+## Invariants guarded by tests
+
+`tests/test_pubvendor.py`:
+
 - zero network on the default path; archive URLs constructed from the
   pub API layout, checksums from the lockfile
 - git SRCREV == lockfile resolved-ref, never a branch head
-- git cache destsuffix == <repo>-sha1(raw lockfile URL), matching pub's
-  cache keying (validate per-SDK with an offline `pub get` CI job)
-- scp-style URLs (git@host:org/repo.git) normalized for the git fetcher
-- BitBake-safe unique name= idents, collisions suffixed with url-hash
+- git cache destsuffix == `<repo>-sha1(raw lockfile URL)`, matching pub's
+  cache keying
+- scp-style URLs (`git@host:org/repo.git`) normalized for the git fetcher
+- BitBake-safe unique `name=` idents, collisions suffixed with url-hash
 
-## Running the tests
+`offline_check.py` covers what those cannot: that the staged layout is one
+pub accepts. It generates a fragment, fetches and stages exactly what its
+SRC_URI entries name, runs `pub get --offline`, and fails if anything
+resolved from outside the staged cache. Its fixture carries both a hosted
+and a git dependency on purpose, and it rejects one that does not.
 
-    python3 -m pytest tools/pubvendor/tests -q
+## CI
 
-Requires `pyyaml` and `pytest`. Not yet wired into CI -- `tools/**` is in
-the build workflow's `paths-ignore`, so a separate job is needed.
+`.github/workflows/tools-tests.yml`, on a GitHub-hosted runner so it never
+queues behind the Yocto builds:
+
+- `pytest` on Python 3.10 (the floor -- `str | None` in a dataclass field)
+  and current
+- `offline_check.py` against two Dart SDKs, since the cache layout is a pub
+  internal rather than a documented contract and can change under us
+
+Run the unit tests locally with:
+
+    python3 -m pytest tools -q
+
+Requires `pyyaml` and `pytest`.


### PR DESCRIPTION
Four claims had gone stale as this series landed. One of them documented the exact defect #851 fixed.

| claim | reality |
|---|---|
| class runs `dart pub get` | runs **`flutter pub get`** — only that writes `.flutter-plugins-dependencies`; with dart an app builds green and registers no plugins |
| consume snippet is 3 lines | needs **7** — `FILESEXTRAPATHS`, the vendored lockfile in `SRC_URI`, `PUBSPEC_LOCK_FILE`, and `PUBSPEC_IGNORE_LOCKFILE = "0"` |
| class "asserts the in-tree lockfile matches" | it **installs** the vendored one first, then checks — the app's own can never match, since the roll re-resolves against the pinned SDK |
| "Not yet wired into CI" | `tools-tests.yml` runs pytest on two Pythons and `offline_check.py` on two Dart SDKs |

The class's **own header comment** said `dart pub get` too — #851 changed the code and missed the comment four lines above it. Fixed here.

Also documents the roll-side opt-in, which had no user-facing description at all: what `"pubvendor": true` does, why the lockfile is re-resolved rather than trusted, and what happens to an app that cannot resolve against the pinned SDK (reported and skipped, recipe written *without* the `require` line, since a recipe requiring a missing fragment is a parse error for the whole layer).

Every claim in the new text was checked against the code rather than written from memory — the `flutter pub get` call, the `noexec` pair, `PUBSPEC_LOCK_FILE`, `OVERRIDE_STYLE`, the manifest flag, `offline_check.py`, and both CI matrices.

`UNPACKDIR` and the task PATH from #853 are deliberately not mentioned: they are internal to how the class locates and runs things, not part of the contract a recipe author needs.

Tools suite: 14 passed.