### PR TITLE
ci: stop cloning meta-drm and meta-vulkan on master

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -85,7 +85,9 @@ jobs:
           # existing directory fails. Those failures are swallowed by
           # the backgrounded clones and bare 'wait', so an omitted
           # layer silently freezes at whatever revision it was first
-          # cloned at. poky is kept to clear any legacy checkout.
+          # cloned at. poky, meta-drm and meta-vulkan are kept here, though no
+          # longer cloned, so a runner that has them from an earlier run does
+          # not keep a stale checkout around.
           rm -rf poky bitbake openembedded-core meta-yocto \
                  meta-openembedded meta-drm meta-vulkan
           # 'wait' with no operands always returns 0, so a failed clone used to
@@ -97,9 +99,7 @@ jobs:
               https://git.openembedded.org/bitbake.git \
               https://git.openembedded.org/openembedded-core.git \
               https://git.yoctoproject.org/meta-yocto.git \
-              https://github.com/openembedded/meta-openembedded.git \
-              https://github.com/jwinarske/meta-drm.git \
-              https://github.com/jwinarske/meta-vulkan.git ; do
+              https://github.com/openembedded/meta-openembedded.git ; do
               git clone -b ${{ env.YOCTO_BRANCH }} --single-branch "$repo" &
               pids="$pids $!:$repo"
           done
@@ -158,8 +158,6 @@ jobs:
               ../meta-openembedded/meta-multimedia \
               ../meta-openembedded/meta-networking \
               ../meta-openembedded/meta-python \
-              ../meta-drm \
-              ../meta-vulkan \
               ../../meta-flutter \
               ../../meta-flutter/meta-flutter-apps
           bitbake-layers show-layers


### PR DESCRIPTION
Neither contributes anything master CI builds, and parsing them is not free. meta-vulkan cost a full four-machine round on #855 when one of its recipes could not be parsed without the network — a failure with nothing to do with meta-flutter, in a layer nothing here depends on.

## What the references to them actually are

| reference | what it is |
|---|---|
| `filament-vk` in `flutter-auto_2.0`, `ivi-homescreen_2.0` | an **optional** `PACKAGECONFIG` dep, and only on the **2.0** recipes. CI builds v3, whose own comment records that *"filament-view was removed from the plugins tree"* |
| `swiftshader` in `flutter-engine_git.bb` | the copy **vendored inside the engine source** at `flutter/third_party/swiftshader`, not meta-vulkan's recipe. Zero `DEPENDS` on that recipe anywhere |
| `app-container-image-flutter-auto-vulkan` | genuinely needs meta-vulkan — and CI **never builds it** |
| meta-drm (`libdrmpp`, `libliftoff`, `kms-quads`, `drm-info`, `drm-howto`) | no meta-flutter recipe names any of them. ivi-homescreen v3 depends on `libdrm`, which is **oe-core**. `libliftoff` appears once, in a CHANGELOG |

## Why it is worth doing rather than just fixing the recipe

jwinarske/meta-vulkan#29 pinned those `SRCREV`s to shas and was worth landing on its own merits — a mutable tag as `SRCREV` can silently build different source. But it only fixed today's instance. Any recipe in either layer that cannot be parsed offline breaks the parse for the **whole build**, and we were paying that risk on every run for layers we do not use.

Same shape as the `meta-riscv` entry removed from this workflow earlier: a layer in the list without being needed.

## Kept deliberately

Both stay in the `rm -rf` so a persistent runner holding them from an earlier run does not keep a stale checkout — the same reason `poky` is still listed there. The comment now says so.

The other four branch workflows clone them too and can follow, once this is proven here.