### PR TITLE
pub-cache: order after do_archive_pub_cache, and quiet flutter's first run

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -156,10 +156,23 @@ do_pub_get_offline() {
     export HOME="${WORKDIR}"
     export XDG_CONFIG_HOME="${WORKDIR}"
 
+    # Opt out of analytics before resolving, while the config write is the
+    # only thing happening. It is a local settings file, so it needs no
+    # network itself, but leaving it unset makes the first flutter run in a
+    # fresh XDG_CONFIG_HOME do its first-run work -- which does.
+    flutter config --no-analytics --no-cli-animations >/dev/null 2>&1 || true
+
     cd ${PUBSPEC_APP_DIR}
-    flutter pub get --offline --enforce-lockfile
+    flutter --suppress-analytics pub get --offline --enforce-lockfile
 }
-addtask pub_get_offline after do_check_pubspec_lock do_write_hosted_hashes do_seed_pub_cache do_patch before do_compile
+# Ordered after do_archive_pub_cache as well, even though this class makes
+# that task noexec. It is the layer's convention for "before pub runs": a
+# recipe that must touch the source first orders itself before it, as the
+# appstream_dart app does to inject its hooks section. Ordering only against
+# do_patch left both siblings of it with no relative order, so the edit could
+# land after resolution -- and pub then re-resolves, fetching security
+# advisories from pub.dev and failing with no network.
+addtask pub_get_offline after do_check_pubspec_lock do_write_hosted_hashes do_seed_pub_cache do_patch do_archive_pub_cache before do_compile
 do_pub_get_offline[network] = "0"
 
 # The layer's own pub cache path fetches with the network and carries the


### PR DESCRIPTION
Class-only. Two fixes for what #855's latest run hit — the seeding from #857 worked (`test` now resolves), and the next thing surfaced.

## Ordering against do_patch was not enough

A recipe that must touch the source before pub runs orders itself **before `do_archive_pub_cache`** — that is the layer's convention, and the appstream_dart app uses it to inject its `hooks:` section into `pubspec.yaml`.

This class makes that task `noexec`, but a noexec task is **still in the graph**, so ordering against it inherits the convention. Against `do_patch` alone the two were siblings with no relative order, and the edit could land *after* resolution. Pub then re-resolves, fetches security advisories from pub.dev, and fails:

```
ClientException with SocketException: Failed host lookup: 'pub.dev'
Failed to update packages.
```

Exactly what that recipe's own comment warns about:

> Editing pubspec.yaml afterwards makes the offline pub get in do_compile re-resolve, which tries to fetch security advisories and fails with no network.

## Analytics

Opt out explicitly rather than letting the first flutter run in a fresh `XDG_CONFIG_HOME` decide. The opt-out is a local settings file and needs no network of its own; what needs network is the first-run work that happens when the setting is absent. `common.inc` does the same before its own pub invocations, and this class was not getting the benefit since it stands that path down.

Both command forms verified against a real app and the staged cache:

```
$ flutter --suppress-analytics pub get --offline --enforce-lockfile
Got dependencies!
```

#855 rebases onto this.