### PR TITLE
pub-cache: install the lockfile after any pubspec edit

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -56,7 +56,12 @@ python do_install_pubspec_lock() {
 # can change pubspec.yaml or pubspec.lock. Resolving before that lands means
 # resolving against source that is not what gets built, and an edit arriving
 # afterwards makes pub re-resolve, which reaches for the network.
-addtask install_pubspec_lock after do_unpack do_patch before do_check_pubspec_lock
+# Also after do_archive_pub_cache, for the same reason do_pub_get_offline is:
+# a recipe that edits pubspec.yaml orders itself before that task, and this
+# class makes it noexec without removing it from the graph. Installing the
+# lock first leaves pubspec.yaml newer, which is one of the conditions pub
+# uses to decide the lockfile is stale and re-resolve.
+addtask install_pubspec_lock after do_unpack do_patch do_archive_pub_cache before do_check_pubspec_lock
 
 # do_unpack stages the app's dependencies into PUB_CACHE, and nothing else.
 # flutter's own tool packages are not among them: flutter_tools has its own


### PR DESCRIPTION
Split out of #855, which is being closed. Correct on its own merits, and its effect is measured rather than argued.

`do_install_pubspec_lock` was ordered `after do_unpack do_patch`. But a recipe that edits `pubspec.yaml` orders itself **before `do_archive_pub_cache`** — that is the layer's convention, and the appstream_dart app uses it to append its `hooks:` section. This class makes that task `noexec` **without removing it from the graph**, so ordering against it is what puts the lock install after the edit.

`do_pub_get_offline` already did this. `do_install_pubspec_lock` was missed when I fixed that one.

## Measured, not argued

A diagnostic prefunc recorded the state pub sees immediately before resolving, on the same recipe, before and after this change:

```
before:  pubspec newer than lock: yes
after:   pubspec newer than lock: no
```

A pubspec newer than its lockfile is one of the conditions pub uses to decide the lock is stale, so leaving it that way invites a re-resolve — a network operation, in a task whose whole purpose is not needing one.

## What this does not claim

It does **not** make that app build offline. It still resolves, for a reason I have not identified — five hypotheses in, I am not offering a sixth. The ordering is wrong regardless of that, and correct independently of it.

Class-only, and no recipe inherits `pub-cache` on master, so this lands inert.