### PR TITLE
pub-cache: do not seed pub's metadata cache from the SDK

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -79,7 +79,24 @@ python do_seed_pub_cache() {
     dest = d.getVar('PUB_CACHE')
 
     added = 0
-    for root, _, files in os.walk(sdk_cache):
+    for root, dirs, files in os.walk(sdk_cache):
+        # Skip pub's own metadata cache. It holds cached version listings and
+        # advisory responses, not packages, and carrying them across is what
+        # lets pub reach the network from an offline resolve:
+        #
+        #   hosted.dart:981  _versionInfo() returns null when offline and no
+        #                    cached listing exists, so status() comes back
+        #                    empty and advisoriesUpdated is null
+        #   hosted.dart:774  _getAdvisories() returns immediately on a null
+        #                    advisoriesUpdated -- but with a listing present it
+        #                    proceeds, and has no isOffline guard of its own
+        #
+        # So a listing for a package turns an offline `pub get` into one that
+        # will fetch https://pub.dev/api/packages/<pkg>/advisories whenever the
+        # cached advisory response is older than the listing says it should be.
+        # Without the listings that path cannot be entered at all.
+        if '.cache' in dirs:
+            dirs.remove('.cache')
         rel = os.path.relpath(root, sdk_cache)
         target = os.path.join(dest, rel) if rel != '.' else dest
         bb.utils.mkdirhier(target)


### PR DESCRIPTION
This is the cause of the advisory fetch that #855 kept dying on. Found by reading pub's source rather than by another round of hypotheses.

## The mechanism

Seeding the SDK's `.pub-cache` (added in #857) brought its `hosted/pub.dev/.cache` directory along — **169 cached version listings and advisory responses**, not packages. From `third_party/pkg/pub/lib/src/source/hosted.dart`:

```dart
// :981  _versionInfo()
if (cache.isOffline) {
  final versionListing = await _cachedVersionListingResponse(ref, cache);
  if (versionListing == null) return null;      // ← no listing: nothing to report
  return versionListing.firstWhereOrNull((l) => l.version == version);
}
```

```dart
// :774  _getAdvisories()
final advisoriesUpdated = (await status(...)).advisoriesUpdated;
if (advisoriesUpdated == null) return null;     // ← the only thing stopping it
```

`_getAdvisories` has **no `isOffline` guard of its own** — the guards in that file are all elsewhere (`:1048`, `:1158`, `:1205`…). Its sole gate is whether `status()` returned something, and offline `status()` returns something **only when a cached version listing exists**.

Then `:793`: a cached advisory response older than the listing says it should be is deleted, and the fetch goes to the network.

So one `.cache` directory is the difference between an offline `pub get` that cannot ask pub.dev anything and one that will ask for `https://pub.dev/api/packages/<pkg>/advisories`. That is exactly the request #855 died on — for `archive`, a package that appears nowhere in the app's lockfile. It is in the SDK's cache, and its listing came along with it.

## Why this one is different from the previous attempts

The five earlier theories were each consistent with what I could observe and each turned out to be wrong or incidental. This is not an observation about one machine: **without the listings the code path cannot be entered.** It is a property of the guard.

It also explains why every local reproduction passed. My fragment-only cache had **zero** version listings; CI's seeded cache had 169.

## What still seeds

The packages, which is what the SDK cache is there for — 18,550 files rather than 18,721. Only pub's own metadata is skipped.

Independent of #859, though both touch this class; whichever lands second may want a trivial rebase.