### PR TITLE
wrynose: flutter-app-native.bbclass fixes

### DIFF
--- a/classes/flutter-app-native.bbclass
+++ b/classes/flutter-app-native.bbclass
@@ -15,6 +15,20 @@ TOOLCHAIN = "clang"
 # Required to make dart happy
 DEPENDS:append = " lld-native"
 
+# Force lld use and using compiler-rt and libunwind instead of libgcc.
+# Ideally these could just be added to LDFLAGS, but they have to go into the
+# general flags variables: the resulting CMAKE_<LANG>_LINK_FLAGS in the
+# toolchain.cmake that cmake.bbclass writes do not appear to be used, perhaps
+# from behaviour changes in cmake 4.3.
+DEPENDS:append = " libunwind"
+CFLAGS += "-rtlib=compiler-rt -unwindlib=libunwind -fuse-ld=lld"
+CXXFLAGS += "-rtlib=compiler-rt -unwindlib=libunwind -fuse-ld=lld"
+
+# Force libc++ instead of the default libstdc++, which is what upstream
+# expects. TOOLCHAIN = "clang" alone does not get there: oe-core only selects
+# libc++ when TC_CXX_RUNTIME is overridden for the whole toolchain build.
+CXXFLAGS += "-stdlib=libc++"
+
 # NOTE: conf/include/flutter-app.inc already requires gn-utils.inc and appends
 # "--target-platform linux-${@gn_target_arch_name(d)}" to FLUTTER_BUILD_ARGS.
 # This class must not repeat that, or --target-platform is passed twice.
@@ -104,8 +118,16 @@ do_install:append() {
     fi
 }
 
-# Ensure do_compile has a clean slate when it runs
-do_compile[cleandirs] = "${S}/.dart_tool"
+# Ensure do_compile has a clean slate when it runs.
+#
+# Narrowed to the hook output. Other tasks put things under .dart_tool that
+# do_compile needs: pub-cache.bbclass resolves offline before do_compile and
+# leaves package_config.json there, and wiping the directory would throw that
+# resolution away and send pub back to the network to redo it.
+#
+# The path carries FLUTTER_APPLICATION_PATH because this layer supports an app
+# in a subdirectory of its repository, where ${S}/.dart_tool is not the app's.
+do_compile[cleandirs] += "${S}/${FLUTTER_APPLICATION_PATH}/.dart_tool/hooks_runner"
 
 # Quiet QA warnings about debug libraries under /usr/share/flutter/.../lib/.debug
 INSANE_SKIP:${PN}-dbg += " libdir"


### PR DESCRIPTION
Authored by **Scott Murray <scott.murray@konsulko.com>**, ported from meta-agl where this class lives as `meta-agl-flutter/classes-recipe/flutter-app-plugins.bbclass`:

> [meta-agl-flutter: flutter-app-plugins.bbclass fixes](https://gerrit.automotivelinux.org/gerrit/c/AGL/meta-agl/+/31989) — Bug-AGL: SPEC-5680

Authorship is preserved on the commit; I am only the committer.

- libc++ as the stdlib, which upstream expects. `TOOLCHAIN = "clang"` alone does not get there — oe-core selects libc++ only when `TC_CXX_RUNTIME` is overridden for the whole toolchain build.
- lld, compiler-rt and libunwind forced. These go into `CFLAGS`/`CXXFLAGS` rather than `LDFLAGS` because the `CMAKE_<LANG>_LINK_FLAGS` that `cmake.bbclass` writes into `toolchain.cmake` do not appear to be used, possibly from cmake 4.3 behaviour changes.
- `do_compile[cleandirs]` narrowed from the whole `.dart_tool` to just the hook output.

## One adaptation

The cleandirs path is `${S}/${FLUTTER_APPLICATION_PATH}/.dart_tool/hooks_runner`, not `${S}/.dart_tool/hooks_runner`. This layer supports an app in a subdirectory of its repository, and all three recipes inheriting this class set `FLUTTER_APPLICATION_PATH` — so the unqualified path would clean a directory that does not exist and leave the hook output in place.

Worth noting the narrowing matters more here than upstream: `pub-cache.bbclass` resolves offline in a task *before* `do_compile` and leaves `package_config.json` under `.dart_tool`. Wiping the whole directory would discard that resolution and send pub back to the network to redo it — the exact failure #862 exists to prevent. That class is master-only today, so this is not yet live on wrynose, but it will be when it ports.

## Exercised by

`flatpak-minimal-appstream-dart-flathub-catalog`, `jwinarske-bluez-native-flutter-ble-scanner`, `jwinarske-packagekit-dart-packagekit-catalog`.

`-unwindlib=libunwind` resolves against oe-core's `recipes-support/libunwind` (nongnu), since `libcxx_git.bb` installs only LLVM's static `libunwind.a` to avoid colliding with it. Same as upstream AGL, but CI is the thing that settles it.

wrynose first, per the usual order; master port to follow once this is green.