### PR TITLE
master: flutter-app-native.bbclass fixes

### DIFF
--- a/classes/flutter-app-native.bbclass
+++ b/classes/flutter-app-native.bbclass
@@ -15,6 +15,20 @@ TOOLCHAIN = "clang"
 # Required to make dart happy
 DEPENDS:append = " lld-native"
 
+# Force lld use and using compiler-rt and libunwind instead of libgcc.
+# Ideally these could just be added to LDFLAGS, but they have to go into the
+# general flags variables: the resulting CMAKE_<LANG>_LINK_FLAGS in the
+# toolchain.cmake that cmake.bbclass writes do not appear to be used, perhaps
+# from behaviour changes in cmake 4.3.
+DEPENDS:append = " libunwind"
+CFLAGS += "-rtlib=compiler-rt -unwindlib=libunwind -fuse-ld=lld"
+CXXFLAGS += "-rtlib=compiler-rt -unwindlib=libunwind -fuse-ld=lld"
+
+# Force libc++ instead of the default libstdc++, which is what upstream
+# expects. TOOLCHAIN = "clang" alone does not get there: oe-core only selects
+# libc++ when TC_CXX_RUNTIME is overridden for the whole toolchain build.
+CXXFLAGS += "-stdlib=libc++"
+
 # NOTE: conf/include/flutter-app.inc already requires gn-utils.inc and appends
 # "--target-platform linux-${@gn_target_arch_name(d)}" to FLUTTER_BUILD_ARGS.
 # This class must not repeat that, or --target-platform is passed twice.
@@ -104,8 +118,16 @@ do_install:append() {
     fi
 }
 
-# Ensure do_compile has a clean slate when it runs
-do_compile[cleandirs] = "${S}/.dart_tool"
+# Ensure do_compile has a clean slate when it runs.
+#
+# Narrowed to the hook output. Other tasks put things under .dart_tool that
+# do_compile needs: pub-cache.bbclass resolves offline before do_compile and
+# leaves package_config.json there, and wiping the directory would throw that
+# resolution away and send pub back to the network to redo it.
+#
+# The path carries FLUTTER_APPLICATION_PATH because this layer supports an app
+# in a subdirectory of its repository, where ${S}/.dart_tool is not the app's.
+do_compile[cleandirs] += "${S}/${FLUTTER_APPLICATION_PATH}/.dart_tool/hooks_runner"
 
 # Quiet QA warnings about debug libraries under /usr/share/flutter/.../lib/.debug
 INSANE_SKIP:${PN}-dbg += " libdir"


### PR DESCRIPTION
Port of #868, now merged to wrynose and green on all four machines there. The class is identical between the branches, so the diff is byte-identical to wrynose's.

Authored by **Scott Murray <scott.murray@konsulko.com>**, originally [meta-agl-flutter: flutter-app-plugins.bbclass fixes](https://gerrit.automotivelinux.org/gerrit/c/AGL/meta-agl/+/31989) (Bug-AGL: SPEC-5680). Authorship is preserved on the commit; I am only the committer.

- libc++ as the stdlib, which upstream expects — `TOOLCHAIN = "clang"` alone does not get there, since oe-core selects libc++ only when `TC_CXX_RUNTIME` is overridden for the whole toolchain build.
- lld, compiler-rt and libunwind forced, via `CFLAGS`/`CXXFLAGS` rather than `LDFLAGS` because the `CMAKE_<LANG>_LINK_FLAGS` in the generated `toolchain.cmake` do not appear to be used.
- `do_compile[cleandirs]` narrowed to the hook output.

One adaptation, same as wrynose: the cleandirs path carries `FLUTTER_APPLICATION_PATH`, because this layer supports an app in a subdirectory of its repository and all three recipes inheriting this class set it. Detail in #868.

Matters more here than on wrynose: `pub-cache.bbclass` is master-only and resolves offline in a task *before* `do_compile`, leaving `package_config.json` under `.dart_tool`. Wiping the whole directory would discard that resolution and send pub back to the network.