### PR TITLE
test-runner: add recipe with the build options as PACKAGECONFIG

### DIFF
--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -289,6 +289,15 @@ jobs:
           . ./openembedded-core/oe-init-build-env
           bitbake flutter-pi
 
+      # The remote test-runner daemon. No Flutter involvement, so unlike the
+      # app recipes below it builds on qemuarm too.
+      - name: Build test-runner
+        shell: bash
+        working-directory: ../wrynose-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          bitbake test-runner
+
       # The ivi-homescreen v3 integration tests. All ten come from one upstream
       # tree at HOMESCREEN_COMMIT through ivi-homescreen-test.inc, so they share
       # a source revision and stand or fall together far more often than not.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,29 @@
 # Changelog
 
+August 31, 2026
+1. add test-runner recipe (toyota-connected/test_runner)
+   - Cap'n Proto RPC daemon that injects uinput events, records /dev/input and
+     captures Weston screenshots on a device under test
+   - CMake switches exposed as PACKAGECONFIG: server, examples, recorder,
+     libinput, weston-screenshooter, agl-health, coverage
+   - without 'server' only libTestRunnerClient is built, needing neither uinput
+     nor Wayland, so native/nativesdk default to a client-only package and
+     wayland is required only by the screenshooter plugin's server half
+   - BUILD_CAPNP pinned OFF; capnproto.bbclass supplies the native compiler and
+     target runtime. BUILD_TESTS and BUILD_UNIT_TESTS excluded and pinned OFF,
+     both broken upstream for a cross build
+   - 'recorder' off drops libTestRunnerRecorder, the TestRunner-Recorder tool
+     and the always-on snapshot recorder; the Recorder RPC methods stay in the
+     schema answering "unimplemented", so clients need no rebuild
+   - no SOVERSION on the libraries, so SOLIBS/FILES_SOLIBSDEV keep the .so
+     files out of -dev
+   - built for qemux86-64, covered by wrynose-build on every machine
+2. build capnproto position independent (capnproto_%.bbappend)
+   - meta-oe builds it static and non-PIC, so linking capnp or kj into a shared
+     library fails on kj/exception.c++'s thread-local
+   - code model only; packaging unchanged, capnproto's sstate invalidated
+   - belongs in meta-oe, either this way or as shared libraries
+
 August 19, 2026
 1. roll Flutter SDK to 3.47.1 (Dart 3.13.1)
    - dart-sdk recipe 3.10.1 -> 3.13.1

--- a/conf/distro/include/maintainers.inc
+++ b/conf/distro/include/maintainers.inc
@@ -15,3 +15,4 @@ RECIPE_MAINTAINER_pn-flutter-video-player-plugin = "Joel Winarse <jwinarske@gmai
 RECIPE_MAINTAINER_pn-flutter-wayland-client = "Joel Winarse <jwinarske@gmail.com>"
 RECIPE_MAINTAINER_pn-flutter-wayland-so = "Joel Winarse <jwinarske@gmail.com>"
 RECIPE_MAINTAINER_pn-flutter-x11-client = "Joel Winarse <jwinarske@gmail.com>"
+RECIPE_MAINTAINER_pn-test-runner = "Joel Winarse <jwinarske@gmail.com>"

--- a/recipes-devtools/capnproto/capnproto_%.bbappend
+++ b/recipes-devtools/capnproto/capnproto_%.bbappend
@@ -1,0 +1,17 @@
+#
+# SPDX-FileCopyrightText: (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
+#
+# meta-oe builds capnproto static and non-PIC, so linking capnp or kj into a
+# shared library fails on kj/exception.c++'s thread-local:
+#
+#   libkj.a(exception.c++.o): relocation R_X86_64_TPOFF32 against
+#   `kj::(anonymous namespace)::threadLocalCallback' can not be used when making
+#   a shared object; local-exec is incompatible with -shared
+#
+# test-runner hits this: libTestRunnerClient is SHARED and links both. Code model
+# only -- still static, no .so, no new packages -- but capnproto's sstate is
+# invalidated. Belongs in meta-oe; drop this when it lands there.
+#
+EXTRA_OECMAKE:append = " -DCMAKE_POSITION_INDEPENDENT_CODE=ON"

--- a/recipes-graphics/toyota/test-runner_git.bb
+++ b/recipes-graphics/toyota/test-runner_git.bb
@@ -1,0 +1,115 @@
+#
+# SPDX-FileCopyrightText: (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
+#
+# Cap'n Proto RPC daemon that runs on a device under test beside
+# ivi-homescreen, plus the client library a harness drives it with.
+#
+# Binds 0.0.0.0:4004 unauthenticated: test lab networks only. Needs
+# CONFIG_INPUT_UINPUT and /dev/uinput to inject, /dev/input/event* to record.
+#
+
+SUMMARY = "Remote input injection and recording daemon for ivi-homescreen"
+DESCRIPTION = "Cap'n Proto RPC server that injects mouse, keyboard, touchscreen \
+and multi-touch events through uinput, records /dev/input events for replay, and \
+captures Weston compositor screenshots. Ships the client library harnesses use."
+AUTHOR = "matt.everett@toyotaconnected.com"
+HOMEPAGE = "https://github.com/toyota-connected/test_runner"
+BUGTRACKER = "https://github.com/toyota-connected/test_runner/issues"
+SECTION = "devel"
+CVE_PRODUCT = "test_runner"
+
+# Sources say "GPLv3", which is not valid SPDX; LICENSE is the GPLv3 text.
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+
+TEST_RUNNER_COMMIT ??= "f544fc2bd5539ec4c9d0f867a46745745314e4f4"
+
+SRC_URI = "git://github.com/toyota-connected/test_runner.git;protocol=https;branch=main"
+SRCREV = "${TEST_RUNNER_COMMIT}"
+PV = "0.1+git"
+
+inherit cmake pkgconfig capnproto features_check
+
+# ON builds the vendored capnproto 0.9.1, which runs ./configure at configure
+# time and then hands CMake a target capnp to run on the build host.
+# capnproto.bbclass feeds upstream's if(NOT BUILD_CAPNP) path instead.
+EXTRA_OECMAKE += "-DBUILD_CAPNP=OFF"
+
+# Both are broken upstream (see below) and read undeclared cache variables, so
+# pin them rather than trust them to stay unset.
+EXTRA_OECMAKE += "-DBUILD_TESTS=OFF -DBUILD_UNIT_TESTS=OFF"
+
+PACKAGECONFIG ??= "server examples recorder weston-screenshooter agl-health"
+
+# Client only: the host side of a harness needs no uinput or Wayland.
+PACKAGECONFIG:class-native = "weston-screenshooter agl-health"
+PACKAGECONFIG:class-nativesdk = "weston-screenshooter agl-health"
+
+# Builds libTestRunnerServer and libTestRunnerRecorder; without it the project
+# produces only libTestRunnerClient.
+PACKAGECONFIG[server] = "-DBUILD_SERVER=ON,-DBUILD_SERVER=OFF,libxkbcommon udev"
+
+# Builds the executables, daemon included, so not optional in practice.
+PACKAGECONFIG[examples] = "-DBUILD_EXAMPLES=ON,-DBUILD_EXAMPLES=OFF"
+
+# libTestRunnerRecorder, the TestRunner-Recorder tool and the server's Recorder
+# RPC methods. OFF leaves those methods answering "unimplemented", so clients
+# need no rebuild.
+PACKAGECONFIG[recorder] = "-DBUILD_RECORDER=ON,-DBUILD_RECORDER=OFF"
+
+# Recorder input backend: libinput instead of raw evdev. Off matches upstream CI.
+PACKAGECONFIG[libinput] = "-DENABLE_LIBINPUT=ON,-DENABLE_LIBINPUT=OFF,libinput"
+
+# Only the plugin's server half links wayland-client, so that dependency is
+# added by server + this option together, below.
+PACKAGECONFIG[weston-screenshooter] = "-DENABLE_PLUGIN_WESTON_SCREENSHOOTER=ON,\
+    -DENABLE_PLUGIN_WESTON_SCREENSHOOTER=OFF"
+
+PACKAGECONFIG[agl-health] = "-DENABLE_PLUGIN_AGL_HEALTH=ON,-DENABLE_PLUGIN_AGL_HEALTH=OFF,curl"
+
+# Instrumented binaries only; the coverage targets run the tests and lcov on the
+# build host. GCOV_EXECUTABLE is seeded because coverage.cmake probes it
+# REQUIRED and no native gcov answers to that name.
+PACKAGECONFIG[coverage] = "-DENABLE_COVERAGE=ON \
+    -DGCOV_EXECUTABLE=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}gcov,\
+    -DENABLE_COVERAGE=OFF,lcov-native"
+
+#
+# Not exposed:
+#
+#   BUILD_TESTS       compiles kj_client.cpp and kj_server.cpp, absent from the
+#                     tree, and depends on a renamed target
+#   BUILD_UNIT_TESTS  hard-codes the vendored capnproto 0.9.1 include path,
+#                     searched ahead of the sysroot while linking target libcapnp
+#
+
+DEPENDS += "${@bb.utils.contains('PACKAGECONFIG', 'server', \
+    bb.utils.contains('PACKAGECONFIG', 'weston-screenshooter', 'wayland', '', d), '', d)}"
+
+REQUIRED_DISTRO_FEATURES = "${@bb.utils.contains('PACKAGECONFIG', 'server', \
+    bb.utils.contains('PACKAGECONFIG', 'weston-screenshooter', 'wayland', '', d), '', d)}"
+
+python () {
+    pc = set((d.getVar('PACKAGECONFIG') or '').split())
+    pn = d.getVar('PN')
+
+    if 'examples' in pc and 'server' not in pc:
+        bb.fatal("%s: 'examples' links the libraries 'server' builds -- enable both" % pn)
+
+    if 'server' in pc and 'examples' not in pc:
+        bb.warn("%s: 'server' without 'examples' ships libraries but no daemon" % pn)
+
+    if 'recorder' in pc and 'server' not in pc:
+        bb.warn("%s: 'recorder' needs 'server'; the client builds no recorder" % pn)
+
+    if 'libinput' in pc and 'recorder' not in pc:
+        bb.warn("%s: 'libinput' is the recorder's input backend, and 'recorder' is off" % pn)
+}
+
+# No SOVERSION on any of the libraries, so keep the .so files out of -dev.
+SOLIBS = ".so"
+FILES_SOLIBSDEV = ""
+
+BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
Adds a recipe for [toyota-connected/test_runner](https://github.com/toyota-connected/test_runner) — the Cap'n Proto RPC daemon that runs on a device under test beside ivi-homescreen. It injects mouse, keyboard, touchscreen and multi-touch events through uinput, records `/dev/input` for replay, and captures Weston screenshots. The client half is the library a harness drives it with.

`TEST_RUNNER_COMMIT` is `f544fc2`, which has the upstream fixes this recipe was waiting on (toyota-connected/test_runner#15 and #17).

### Options

| Option | CMake | Default | DEPENDS |
|---|---|---|---|
| `server` | `BUILD_SERVER` | on | `libxkbcommon udev` |
| `examples` | `BUILD_EXAMPLES` | on | — |
| `recorder` | `BUILD_RECORDER` | on | — |
| `libinput` | `ENABLE_LIBINPUT` | off | `libinput` |
| `weston-screenshooter` | `ENABLE_PLUGIN_WESTON_SCREENSHOOTER` | on | `wayland` (with `server` only) |
| `agl-health` | `ENABLE_PLUGIN_AGL_HEALTH` | on | `curl` |
| `coverage` | `ENABLE_COVERAGE` | off | `lcov-native` |

The server/client split is kept. Without `server` the project builds only `libTestRunnerClient`, needing neither uinput nor Wayland — so `native`/`nativesdk` default to a client-only package, and `wayland` is a dependency of the screenshooter plugin's *server* half alone.

`recorder` off drops `libTestRunnerRecorder`, the `TestRunner-Recorder` tool and the snapshot recorder the daemon otherwise starts at startup. The `Recorder` methods stay in the schema and answer `unimplemented`, so clients need no rebuild. Useful for a device that must not record.

`BUILD_CAPNP` is pinned OFF and `capnproto.bbclass` supplies the build-host schema compiler and target runtime. ON would run the vendored capnproto 0.9.1 `./configure` at configure time, then hand CMake a target `capnp` to run on the build host.

### Not exposed

`BUILD_TESTS` compiles `kj_client.cpp` and `kj_server.cpp`, neither in the tree, and depends on a renamed target. `BUILD_UNIT_TESTS` hard-codes the vendored capnproto 0.9.1 include path, searched ahead of the sysroot while linking target libcapnp, so the generated headers' `CAPNP_VERSION` guard fires. Both are also pinned OFF, since they read undeclared cache variables rather than declared `option()`s.

### `capnproto_%.bbappend` — please review this one

meta-oe builds capnproto static and non-PIC, so linking capnp or kj into **any** shared library fails:

```
libkj.a(exception.c++.o): relocation R_X86_64_TPOFF32 against
`kj::(anonymous namespace)::threadLocalCallback' can not be used when making
a shared object; local-exec is incompatible with -shared
```

`kj/exception.c++` has a thread-local; non-PIC code gets the local-exec TLS model, which a shared object cannot use. `libTestRunnerClient` is `SHARED` and links both.

The bbappend sets `CMAKE_POSITION_INDEPENDENT_CODE=ON`: still static, no `.so`, no new packages, no ABI surface — only the code model changes. It does invalidate capnproto's sstate.

This belongs in meta-oe, either this way or by building shared libraries as Debian and Fedora do. Flagging it because it is a layer-wide change to a shared recipe; happy to drop it and land a meta-oe change first, though this recipe cannot build until that merges.

### CI

Added a `Build test-runner` step to `wrynose-build`, on every machine including qemuarm — the recipe pulls in no Flutter tooling.

### Testing

Built for qemux86-64 against oe-core and meta-oe wrynose, from cold sstate, both ways:

| `recorder` on | `recorder` off |
|---|---|
| `usr/bin/TestRunner-Server` | `usr/bin/TestRunner-Server` |
| `usr/bin/TestRunner-Recorder` | `usr/bin/TestRunnerClientTest` |
| `usr/bin/TestRunnerClientTest` | `usr/lib/libTestRunnerClient.so` |
| `usr/lib/libTestRunnerClient.so` | `usr/lib/libTestRunnerServer.so` |
| `usr/lib/libTestRunnerRecorder.so` | |
| `usr/lib/libTestRunnerServer.so` | |

Every file comes from upstream's own `install()` rules; the recipe adds no `do_install` of its own. Also parse-checked the `native` variant: `PACKAGECONFIG` drops to the client-only set and `DEPENDS` loses wayland, xkbcommon and udev.