### PR TITLE
roll: make the roll able to fail

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -15,6 +15,10 @@ on:
       - '**/*.md'
       - 'docs/**'
       - 'tools/**'
+      # Roll input, not build input: nothing bitbake parses reads it. The
+      # recipes it generates are committed separately, so a real roll touches
+      # those too and triggers a build on its own.
+      - 'meta-flutter-apps/conf/flutter-apps.json'
       - '.github/workflows/runner-maintenance.yml'
       # Runs on a GitHub-hosted runner and never touches a build.
       - '.github/workflows/tools-tests.yml'

--- a/meta-flutter-apps/conf/flutter-apps.json
+++ b/meta-flutter-apps/conf/flutter-apps.json
@@ -143,19 +143,6 @@
         ]
     },
     {
-        "uri": "https://github.com/flutter/flutter.git",
-        "ver": "5874a72aa4c779a02553007c47dacbefba2374dc",
-        "license_file": "LICENSE",
-        "license_type": "BSD-3-Clause",
-        "author": "Google",
-        "folder": "first-party",
-        "rdepends": {
-            "dev/integration_tests/flutter_gallery": [
-                "xdg-user-dirs"
-            ]
-        }
-    },
-    {
         "uri": "https://github.com/mogol/flutter_secure_storage.git",
         "branch": "develop",
         "license_file": "LICENSE",

--- a/meta-flutter-apps/conf/flutter-apps.json
+++ b/meta-flutter-apps/conf/flutter-apps.json
@@ -2,7 +2,6 @@
     {
         "uri": "https://github.com/flutter/packages.git",
         "branch": "main",
-        "ver": "0af905d779d52fc81ffc239c211e8c5956154f34",
         "license_file": "LICENSE",
         "license_type": "BSD-3-Clause",
         "author": "Google",
@@ -341,7 +340,6 @@
     {
         "uri": "https://github.com/rive-app/rive-flutter.git",
         "branch": "master",
-        "ver": "0.8.4",
         "license_file": "LICENSE",
         "license_type": "MIT",
         "author": "Rive",

--- a/tools/roll_meta_flutter.py
+++ b/tools/roll_meta_flutter.py
@@ -20,6 +20,15 @@ from common import make_sure_path_exists
 from common import print_banner
 
 
+class RollError(Exception):
+    """A repo could not be rolled.
+
+    Raised rather than exit()ed: get_repo() runs in a worker thread, where
+    SystemExit ends that thread and nothing else. It reads like it stops the
+    script and does not.
+    """
+
+
 def get_flutter_apps(filename) -> dict:
     filepath = os.path.join(filename)
     with open(filepath, 'r') as f:
@@ -66,12 +75,14 @@ def get_repo(repo_path: str, output_path: str,
     # if not output_path_override_list:
     #    output_path_override_list = []
 
+    # Not "skip": a manifest entry that cannot be cloned is a manifest bug,
+    # and skipping it produced a roll that quietly generated nothing for that
+    # repo. The flutter/flutter entry sat branchless in flutter-apps.json
+    # doing exactly that.
     if not uri:
-        print("repo entry needs a 'uri' key.  Skipping")
-        return
+        raise RollError("repo entry has no 'uri'")
     if not branch:
-        print("repo entry needs a 'branch' key.  Skipping")
-        return
+        raise RollError(f"{uri}: repo entry has no 'branch'")
 
     # get repo folder name
     from urllib.parse import urlparse
@@ -121,7 +132,7 @@ def get_repo(repo_path: str, output_path: str,
         license_path = os.path.join(repo_path, repo_name, license_file)
         if not os.path.isfile(license_path):
             print_banner(f'ERROR: {license_path} is not present')
-            exit(1)
+            raise RollError(f'{repo_name}: {license_file} is not present')
 
         # Check the declared license against the text the recipe will ship.
         # flutter-apps.json states a license for someone else's repository and
@@ -142,7 +153,9 @@ def get_repo(repo_path: str, output_path: str,
                 f'  declared: {license_type}\n'
                 f'Fix license_type in flutter-apps.json. See the LICENSE '
                 f'operator note in README.')
-            exit(1)
+            raise RollError(
+                f'{repo_name}: license_type joins licenses with "{wrong}", '
+                f'but this branch uses "{LICENSE_OPERATOR}"')
 
         if validate_license:
             detected = detect_licenses(license_path)
@@ -156,7 +169,9 @@ def get_repo(repo_path: str, output_path: str,
                     f'  {license_file} contains: {" AND ".join(detected)}\n'
                     f'Fix license_type in flutter-apps.json, or set '
                     f'"license_validate": false for a license this check reads wrong.')
-                exit(1)
+                raise RollError(
+                    f'{repo_name}: declared license {license_type} does not '
+                    f'match {license_file}')
 
         if license_type != 'CLOSED':
             from create_recipes import get_file_md5
@@ -166,7 +181,8 @@ def get_repo(repo_path: str, output_path: str,
         # A license type with no file to back it cannot produce LIC_FILES_CHKSUM.
         print_banner(f'ERROR: {repo_name}: license_type "{license_type}" declared '
                      f'without a license_file')
-        exit(1)
+        raise RollError(f'{repo_name}: license_type "{license_type}" declared '
+                        f'without a license_file')
 
     repo_path = os.path.join(repo_path, repo_name)
 
@@ -194,31 +210,51 @@ def get_repo(repo_path: str, output_path: str,
 def get_workspace_repos(repo_path, repos, output_path, package_output_path, patch_dir):
     """ Clone GIT repos referenced in config repos dict to base_folder """
 
-    futures = []
     import concurrent.futures
+
+    futures = {}
     with concurrent.futures.ThreadPoolExecutor() as executor:
         for r in repos:
-            futures.append(executor.submit(get_repo, repo_path=repo_path,
-                                           output_path=output_path,
-                                           package_output_path=package_output_path,
-                                           uri=r.get('uri'),
-                                           branch=r.get('branch'),
-                                           rev=r.get('rev'),
-                                           license_file=r.get('license_file'),
-                                           license_type=r.get('license_type'),
-                                           validate_license=r.get('license_validate', True),
-                                           author=r.get('author'),
-                                           recipe_folder=r.get('folder'),
-                                           ignore_list=r.get('ignore'),
-                                           rdepends_list=r.get('rdepends'),
-                                           output_path_override_list=r.get('output_folder'),
-                                           compiler_requires_network_list=r.get('compiler_requires_network'),
-                                          pubvendor=r.get('pubvendor', False),
-                                           src_folder=r.get('src_folder'),
-                                           src_files=r.get('src_files'),
-                                           entry_files=r.get('entry_files'),
-                                           variables=r.get('variables'),
-                                           patch_dir=patch_dir))
+            futures[executor.submit(get_repo, repo_path=repo_path,
+                                    output_path=output_path,
+                                    package_output_path=package_output_path,
+                                    uri=r.get('uri'),
+                                    branch=r.get('branch'),
+                                    rev=r.get('rev'),
+                                    license_file=r.get('license_file'),
+                                    license_type=r.get('license_type'),
+                                    validate_license=r.get('license_validate', True),
+                                    author=r.get('author'),
+                                    recipe_folder=r.get('folder'),
+                                    ignore_list=r.get('ignore'),
+                                    rdepends_list=r.get('rdepends'),
+                                    output_path_override_list=r.get('output_folder'),
+                                    compiler_requires_network_list=r.get('compiler_requires_network'),
+                                    pubvendor=r.get('pubvendor', False),
+                                    src_folder=r.get('src_folder'),
+                                    src_files=r.get('src_files'),
+                                    entry_files=r.get('entry_files'),
+                                    variables=r.get('variables'),
+                                    patch_dir=patch_dir)] = r.get('uri') or '<no uri>'
+
+    # Read every future. Submitting and never calling result() means an
+    # exception in a worker is captured in its Future and re-raised nowhere:
+    # a failed clone, a license mismatch, anything create_yocto_recipes()
+    # raises. The roll then exits 0 having generated nothing for that repo,
+    # which run by hand scrolls past and run from CI is a green build with
+    # recipes silently missing.
+    failed = []
+    for future, uri in futures.items():
+        try:
+            future.result()
+        except BaseException as e:
+            failed.append((uri, e))
+
+    if failed:
+        print_banner(f'{len(failed)} of {len(futures)} repos failed to roll')
+        for uri, e in failed:
+            print(f'  {uri}\n      {type(e).__name__}: {e}')
+        sys.exit(1)
 
     print_banner("Repos Cloned")
 

--- a/tools/tests/test_roll_meta_flutter.py
+++ b/tools/tests/test_roll_meta_flutter.py
@@ -1,0 +1,90 @@
+# SPDX-License-Identifier: MIT
+"""The roll has to be able to fail.
+
+get_workspace_repos() runs one get_repo() per manifest entry in a thread pool.
+A ThreadPoolExecutor captures a worker's exception in its Future and re-raises
+it only on result(), so a roll that never read its futures exited 0 no matter
+what happened inside -- a failed clone, a license mismatch, a manifest entry it
+could not use. See #863.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import roll_meta_flutter as roll  # noqa: E402
+
+
+def _repos(n):
+    return [{'uri': f'https://example.invalid/{i}.git', 'branch': 'main'}
+            for i in range(n)]
+
+
+def _run(monkeypatch, behaviour):
+    monkeypatch.setattr(roll, 'get_repo', behaviour)
+    roll.get_workspace_repos('/nonexistent', _repos(4), '/out', '/pkg', None)
+
+
+def test_all_succeeding_returns(monkeypatch):
+    _run(monkeypatch, lambda **kw: None)
+
+
+def test_one_worker_raising_fails_the_roll(monkeypatch, capsys):
+    def one_bad(**kw):
+        if kw['uri'].endswith('2.git'):
+            raise roll.RollError('license_type does not match its source')
+
+    with pytest.raises(SystemExit) as e:
+        _run(monkeypatch, one_bad)
+    assert e.value.code == 1
+    out = capsys.readouterr().out
+    assert '1 of 4 repos failed to roll' in out
+    assert 'https://example.invalid/2.git' in out
+    assert 'license_type does not match its source' in out
+
+
+def test_every_failure_is_reported_not_just_the_first(monkeypatch, capsys):
+    def all_bad(**kw):
+        raise RuntimeError(f'boom {kw["uri"]}')
+
+    with pytest.raises(SystemExit):
+        _run(monkeypatch, all_bad)
+    out = capsys.readouterr().out
+    assert '4 of 4 repos failed to roll' in out
+    for i in range(4):
+        assert f'https://example.invalid/{i}.git' in out
+
+
+def test_a_worker_calling_sys_exit_still_fails_the_roll(monkeypatch):
+    # SystemExit in a worker thread ends that thread and nothing else, which is
+    # why get_repo() raises instead. Catching BaseException means the old form
+    # would not slip through either.
+    def bad(**kw):
+        if kw['uri'].endswith('0.git'):
+            sys.exit(1)
+
+    with pytest.raises(SystemExit) as e:
+        _run(monkeypatch, bad)
+    assert e.value.code == 1
+
+
+@pytest.mark.parametrize('entry, missing', [
+    ({'uri': None, 'branch': 'main'}, 'uri'),
+    ({'uri': 'https://example.invalid/x.git', 'branch': None}, 'branch'),
+])
+def test_manifest_entry_missing_a_key_is_an_error(entry, missing):
+    # These used to print "Skipping" and return, which is how the
+    # flutter/flutter entry sat branchless in flutter-apps.json generating
+    # nothing on every roll without anyone noticing.
+    with pytest.raises(roll.RollError) as e:
+        roll.get_repo(repo_path='/nonexistent', output_path='/out',
+                      uri=entry['uri'], branch=entry['branch'], rev=None,
+                      license_file=None, license_type='CLOSED',
+                      validate_license=False, author=None, recipe_folder=None,
+                      package_output_path='/pkg', ignore_list=None,
+                      rdepends_list=None, output_path_override_list=None,
+                      compiler_requires_network_list=None, src_folder=None,
+                      src_files=None, entry_files=None, variables=None,
+                      patch_dir=None)
+    assert missing in str(e.value)


### PR DESCRIPTION
Closes #863. Blocker under #864 — unattended rolling is not safe while the roll cannot fail.

`get_workspace_repos()` submitted one `get_repo()` per manifest entry and never read the futures, so every failure inside a worker was captured in its `Future` and discarded. The roll printed `Repos Cloned` and exited 0.

Now: read every future, report **all** failures, exit non-zero. `get_repo()` raises rather than `exit()`s — `SystemExit` from a worker thread ends that thread and nothing else — and the aggregator catches `BaseException` so the old form would not slip through either.

## It found something immediately

A manifest entry with no `uri` or `branch` used to print "Skipping" and return. The `flutter/flutter` entry had neither:

```json
{
  "uri": "https://github.com/flutter/flutter.git",
  "ver": "5874a72aa4c779a02553007c47dacbefba2374dc",
  "license_file": "LICENSE",
  ...
  "rdepends": { "dev/integration_tests/flutter_gallery": ["xdg-user-dirs"] }
}
```

`ver` is read nowhere in the tooling — three entries carry it, it is dead in all three — and with no `branch` this entry was skipped on every roll. **None of the 160 recipes in `first-party` derive from flutter/flutter.** It has never produced anything.

Removed rather than repaired: giving it a branch would have the next roll generate recipes for every app in the Flutter SDK, which is #867's job and wants its own review. Its `rdepends` naming `dev/integration_tests/flutter_gallery` says that is exactly what it was for. Quoted in #867 so nothing is lost.

Removal is 13 lines out, 0 in — no reformatting.

## Tests

Six new, in `tools/tests/`, picked up by the existing `pytest tools` discovery:

- all workers succeeding returns normally
- one worker raising fails the roll, naming the repo and the message
- **every** failure reported, not just the first
- a worker calling `sys.exit(1)` still fails the roll
- a manifest entry missing `uri` or `branch` raises

`20 passed` for the whole tools suite.