### PR TITLE
wrynose: keep the hash equivalence database with the sstate

### DIFF
--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -10,6 +10,25 @@ INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 DL_DIR = "/home/dev/dl"
 SSTATE_DIR = "/home/dev/sstate"
 
+# Keep the hash equivalence database with the sstate it describes.
+#
+# With BB_HASHSERVE = "auto" the database defaults to PERSISTENT_DIR or CACHE,
+# both inside the build directory -- and each branch builds in its own
+# (wrynose-linux-dummy, master-linux-dummy, ...) while sharing one SSTATE_DIR.
+# The hashes that say which sstate objects are equivalent then live in one
+# build tree and are invisible to the next, so the shared sstate is there but
+# largely unusable. oe-core says so at every start:
+#
+#   WARNING: Sstate directory is shared between several builds ... but hash
+#   equivalency database is inside this particular build directory ... This
+#   will prevent sstate reuse
+#
+# Safe here: bitbake refuses this only when the directory is on NFS, and the
+# warning above is the branch oe/sanity.py takes when SSTATE_DIR is not, so
+# that is settled by the message itself. bitbake creates the directory if it
+# is missing.
+BB_HASHSERVE_DB_DIR ?= "${SSTATE_DIR}"
+
 INIT_MANAGER = "systemd"
 
 # ***************************************


### PR DESCRIPTION
Every CI build opens with this:

```
WARNING: Sstate directory is shared between several builds (it is set via SSTATE_DIR to /home/dev/sstate),
        but hash equivalency database is inside this particular build directory /__w/meta-flutter/wrynose-linux-dummy/build.
        This will prevent sstate reuse
```

With `BB_HASHSERVE = "auto"` the database falls back to `PERSISTENT_DIR` or `CACHE` — both inside the build directory. Each branch builds in its own (`wrynose-linux-dummy`, `master-linux-dummy`, …) while sharing one `SSTATE_DIR`, so the hashes recording which sstate objects are equivalent get written into one build tree and are invisible from the next. The shared sstate is populated but largely unusable across branches.

On a sequential runner that is the difference between a matrix that restores and one that rebuilds.

`BB_HASHSERVE_DB_DIR ?= "${SSTATE_DIR}"` is what the warning recommends and what oe-core's own `bitbake-setup` writes (`bitbake/bin/bitbake-setup:1190`).

## Why this is safe

`cooker.py:331` is the only place that can refuse it, and it refuses only when the directory is on NFS. The warning above is the branch `oe/sanity.py:936` takes when `SSTATE_DIR` is **not** on NFS — the NFS case has different wording and recommends a hash equivalence server instead. So the message we are getting is itself proof the fatal cannot fire. bitbake creates the directory when missing (`os.makedirs(dbdir, exist_ok=True)`).

wrynose first, per the usual order. `ci-build.inc` differs between branches, so each port needs its own edit rather than a cherry-pick — master, scarthgap, kirkstone and dunfell all carry the same omission.