### PR TITLE
roll: skip apps whose declared SDK excludes the pinned one

### DIFF
--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -13,6 +13,8 @@ from common import get_yaml_obj
 from common import make_sure_path_exists
 from common import print_banner
 
+import sdk_constraint
+
 
 def get_file_md5(file_name):
     import hashlib
@@ -600,12 +602,26 @@ def create_yocto_recipes(directory,
     # Iterate all pubspec.yaml files
     #
     recipes = []
+    # An app whose declared environment excludes the pinned SDK cannot work
+    # here, and generating a recipe for it just moves the discovery to a build
+    # failure and then to a hand-written 'ignore' entry weeks later. Gate it
+    # with a reason instead. Reported at the end rather than silently: an app
+    # disappearing from the layer with no trace is the thing to avoid. See #850.
+    pinned_flutter, pinned_dart = sdk_constraint.pinned_versions()
+    incompatible = []
+
     for filename in glob.iglob(directory + '**/pubspec.yaml', recursive=True):
 
         # handle invalid pubspec.yaml files
         yaml_obj = get_yaml_obj(filename)
         if len(yaml_obj) == 0:
             print(f'Invalid YAML: {filename}')
+            continue
+
+        reason = sdk_constraint.excluded_reason(
+            yaml_obj, pinned_flutter, pinned_dart)
+        if reason:
+            incompatible.append((os.path.relpath(filename, directory), reason))
             continue
 
         path_tokens = filename.split('/')
@@ -663,6 +679,12 @@ def create_yocto_recipes(directory,
     create_package_group(org, unit, recipes,
                          output_path_override_list,
                          package_output_path)
+
+    if incompatible:
+        print(f'\n{len(incompatible)} app(s) skipped: the pinned SDK is '
+              f'outside their declared environment')
+        for rel, reason in sorted(incompatible):
+            print(f'  {os.path.dirname(rel) or "."}: {reason}')
 
     print_banner("Creating Yocto Recipes done.")
 

--- a/tools/sdk_constraint.py
+++ b/tools/sdk_constraint.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (C) 2026 Joel Winarske
+# SPDX-License-Identifier: MIT
+#
+# Does an app's declared SDK constraint admit the SDK this layer pins?
+#
+# Deliberately conservative. Every function returns None for anything it does
+# not fully understand, and a None is never treated as an exclusion: a gate
+# that misfires drops an app from the layer silently, which is worse than the
+# build failure it was meant to prevent. See #850.
+
+import os
+import re
+
+_VERSION = re.compile(
+    r'^(\d+)\.(\d+)\.(\d+)'          # core
+    r'(?:-([0-9A-Za-z.-]+))?'          # prerelease
+    r'(?:\+[0-9A-Za-z.-]+)?$')         # build metadata, ignored
+_TERM = re.compile(r'^(>=|<=|>|<|\^)?\s*(.+)$')
+
+
+def _prerelease_key(part):
+    # semver: numeric identifiers compare numerically and rank below
+    # alphanumeric ones.
+    return (0, int(part), '') if part.isdigit() else (1, 0, part)
+
+
+def parse_version(text):
+    """A sortable key for a version, or None if it is not one.
+
+    Prereleases are handled rather than declined. The dominant constraint in
+    real pubspecs is the form `^3.11.0-0` -- 132 of 139 in the Flutter SDK
+    alone -- so refusing them leaves the gate inert on almost everything it
+    would be asked about.
+
+    The key sorts a release above its own prereleases, which is what semver
+    says and what the `-0` idiom relies on: `^3.11.0-0` exists precisely to
+    admit 3.11.0 prereleases, so 3.13.1 must compare greater than 3.11.0-0.
+    """
+    if not isinstance(text, str):
+        return None
+    m = _VERSION.match(text.strip())
+    if not m:
+        return None
+    core = tuple(int(g) for g in m.groups()[:3])
+    pre = m.group(4)
+    if pre is None:
+        return core + (1, ())
+    return core + (0, tuple(_prerelease_key(p) for p in pre.split('.')))
+
+
+def parse_constraint(spec):
+    """[(op, version)] for a pub version constraint, or None if not understood.
+
+    Handles the forms that actually appear in a pubspec environment: a list of
+    comparators ('>=3.0.0 <4.0.0'), a caret ('^3.10.0'), a bare version, and
+    'any'. Ranges with commas, '||' alternatives and prereleases are not
+    understood, and say so.
+    """
+    if not isinstance(spec, str):
+        return None
+    spec = spec.strip()
+    if not spec or spec == 'any':
+        return []
+    if '||' in spec or ',' in spec:
+        return None
+
+    terms = []
+    for token in spec.split():
+        m = _TERM.match(token)
+        if not m:
+            return None
+        op, raw = m.group(1) or '', m.group(2)
+        version = parse_version(raw)
+        if version is None:
+            return None
+        if op == '^':
+            # pub's caret: up to the next breaking version, which for a 0.x
+            # release is the next minor rather than the next major. The upper
+            # bound is exclusive and carries no prerelease, so nothing at or
+            # above it qualifies.
+            major, minor = version[0], version[1]
+            core = (major + 1, 0, 0) if major else (0, minor + 1, 0)
+            upper = core + (0, ())
+            terms.append(('>=', version))
+            terms.append(('<', upper))
+        else:
+            terms.append((op or '>=', version))
+    return terms
+
+
+def satisfies(version_text, spec):
+    """True / False / None, where None means 'not understood, do not act'."""
+    version = parse_version(version_text)
+    terms = parse_constraint(spec)
+    if version is None or terms is None:
+        return None
+    for op, bound in terms:
+        if op == '>=' and not version >= bound:
+            return False
+        if op == '>' and not version > bound:
+            return False
+        if op == '<=' and not version <= bound:
+            return False
+        if op == '<' and not version < bound:
+            return False
+    return True
+
+
+def excluded_reason(yaml_obj, flutter_version, dart_version):
+    """Why the pinned SDK is excluded by this pubspec, or None if it is not.
+
+    None covers both 'compatible' and 'cannot tell', which are the same thing
+    as far as the caller is concerned: do not skip the app.
+    """
+    env = (yaml_obj or {}).get('environment')
+    if not isinstance(env, dict):
+        return None
+
+    for key, pinned, label in (('sdk', dart_version, 'Dart'),
+                               ('flutter', flutter_version, 'Flutter')):
+        spec = env.get(key)
+        if spec is None or pinned is None:
+            continue
+        if satisfies(pinned, spec) is False:
+            return (f'needs {label} {spec}, '
+                    f'this layer pins {label} {pinned}')
+    return None
+
+
+def pinned_versions(layer_root=None):
+    """(flutter, dart) this layer pins, either possibly None.
+
+    Read from the layer rather than passed in: roll_meta_flutter.py updates
+    flutter-version.inc before rolling any repo, so the file is already current
+    by the time recipes are generated.
+    """
+    import json
+
+    if layer_root is None:
+        layer_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+    include = os.path.join(layer_root, 'conf', 'include')
+
+    flutter = None
+    try:
+        with open(os.path.join(include, 'flutter-version.inc')) as f:
+            for line in f:
+                if 'FLUTTER_SDK_TAG' in line and '=' in line:
+                    m = re.search(r'"([^"]+)"', line)
+                    if m:
+                        flutter = m.group(1)
+                    break
+    except OSError:
+        return None, None
+    if flutter in (None, 'AUTOINC'):
+        return None, None
+
+    dart = None
+    try:
+        with open(os.path.join(include, 'releases_linux.json')) as f:
+            for release in json.load(f).get('releases', []):
+                if release.get('version') == flutter:
+                    dart = release.get('dart_sdk_version')
+                    break
+    except (OSError, ValueError):
+        pass
+    # Releases carry "3.13.2" or occasionally "3.13.2 (build 3.13.2-x.y.z)".
+    if isinstance(dart, str) and ' ' in dart:
+        dart = dart.split()[0]
+    return flutter, dart

--- a/tools/tests/test_sdk_constraint.py
+++ b/tools/tests/test_sdk_constraint.py
@@ -1,0 +1,117 @@
+# SPDX-License-Identifier: MIT
+"""A gate that misfires drops an app from the layer silently.
+
+That is worse than the build failure it prevents, so everything here is
+checked from both directions: it excludes what it should, and it declines to
+act on anything it does not fully understand. See #850.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import sdk_constraint as sc  # noqa: E402
+
+
+@pytest.mark.parametrize('text, want', [
+    # a sortable key, not a bare triple: the trailing 1 marks a release, which
+    # is what makes it sort above its own prereleases
+    ('3.13.1', (3, 13, 1, 1, ())),
+    ('  3.0.0 ', (3, 0, 0, 1, ())),
+    ('3.13', None),
+    ('', None),
+    (None, None),
+])
+def test_parse_version(text, want):
+    assert sc.parse_version(text) == want
+
+
+@pytest.mark.parametrize('spec, version, want', [
+    ('>=3.0.0 <4.0.0', '3.13.1', True),
+    ('>=3.0.0 <4.0.0', '4.0.0', False),
+    ('>=3.14.0 <4.0.0', '3.13.1', False),
+    ('^3.10.1', '3.13.1', True),
+    ('^3.10.1', '4.0.0', False),
+    ('^3.10.1', '3.10.0', False),
+    ('^0.1.2', '0.1.9', True),
+    ('^0.1.2', '0.2.0', False),   # 0.x caret stops at the next minor
+    ('any', '3.13.1', True),
+    ('', '3.13.1', True),
+    ('>=3.10.0', '3.47.1', True),
+    # The dominant real-world form: `-0` admits prereleases of the lower
+    # bound, and a release must still compare above it. 132 of the 139
+    # pubspecs in the Flutter SDK are written this way, so a parser that
+    # declines them is a gate that never fires.
+    ('^3.11.0-0', '3.13.1', True),
+    ('>=3.5.0-0 <4.0.0', '3.13.1', True),
+    ('^4.0.0-0', '3.13.1', False),
+    ('^3.11.0-0', '3.11.0', True),
+    ('^3.11.0-0', '3.10.9', False),
+])
+
+def test_satisfies(spec, version, want):
+    assert sc.satisfies(version, spec) is want
+
+@pytest.mark.parametrize('lower, higher', [
+    ('3.11.0-0', '3.11.0'),        # a release outranks its prereleases
+    ('3.11.0-1', '3.11.0-2'),      # numeric identifiers compare numerically
+    ('3.11.0-1', '3.11.0-beta'),   # numeric ranks below alphanumeric
+    ('3.10.9', '3.11.0'),
+])
+def test_version_ordering(lower, higher):
+    assert sc.parse_version(lower) < sc.parse_version(higher)
+
+
+def test_build_metadata_is_ignored():
+    assert sc.parse_version('3.13.1+hotfix') == sc.parse_version('3.13.1')
+
+
+@pytest.mark.parametrize('spec', [
+    '>=3.0.0 <4.0.0 || >=5.0.0',   # alternatives
+    '>=3.0.0, <4.0.0',             # comma ranges
+    'not a constraint',
+    None,
+])
+def test_unparseable_declines_rather_than_excluding(spec):
+    assert sc.satisfies('3.13.1', spec) is None
+    assert sc.excluded_reason({'environment': {'sdk': spec}}, '3.47.1', '3.13.1') is None
+
+
+def test_excluded_reason_names_the_offender():
+    r = sc.excluded_reason({'environment': {'sdk': '>=3.20.0 <4.0.0'}},
+                           '3.47.1', '3.13.1')
+    assert r is not None
+    assert 'Dart' in r and '3.13.1' in r and '>=3.20.0' in r
+
+
+def test_flutter_constraint_is_checked_too():
+    r = sc.excluded_reason({'environment': {'flutter': '>=4.0.0'}},
+                           '3.47.1', '3.13.1')
+    assert r is not None and 'Flutter' in r
+
+
+def test_compatible_app_is_not_excluded():
+    # the shape the appstream_dart example app declares
+    assert sc.excluded_reason({'environment': {'sdk': '^3.10.1'}},
+                              '3.47.1', '3.13.1') is None
+
+
+@pytest.mark.parametrize('obj', [
+    {}, {'environment': None}, {'environment': 'nonsense'}, None,
+])
+def test_a_pubspec_without_a_usable_environment_is_not_excluded(obj):
+    assert sc.excluded_reason(obj, '3.47.1', '3.13.1') is None
+
+
+def test_unknown_pinned_version_disables_the_gate():
+    # pinned_versions() returns None when FLUTTER_SDK_TAG is AUTOINC or the
+    # release feed has no dart_sdk_version. Nothing should be excluded then.
+    assert sc.excluded_reason({'environment': {'sdk': '>=99.0.0'}},
+                              None, None) is None
+
+
+def test_pinned_versions_reads_the_layer():
+    flutter, dart = sc.pinned_versions()
+    assert flutter and dart
+    assert sc.parse_version(flutter) and sc.parse_version(dart)


### PR DESCRIPTION
Addresses the static gate in #850. Version-solving failures (its case 2) already surface through the roll-time resolve from #843; API drift (case 3) stays CI's job.

The roll generated a recipe for every `pubspec.yaml` it found, whether or not the app could work with the pinned SDK. Incompatible ones got discovered by a build failing and pruned by hand into `ignore` — 108 paths across 9 entries, mostly monorepo noise, so "we don't want this" and "this cannot work here" are no longer distinguishable there.

Now `environment.sdk` and `environment.flutter` are compared against the pinned versions and the app is skipped **with a reason**, listed at the end of the run.

## It fails open, deliberately

An unparseable constraint, an absent `environment`, or an unknown pinned version all mean *do not skip*. A gate that misfires drops an app from the layer silently, which is worse than the build failure it prevents.

## Where the first cut was wrong

I initially declined prereleases outright, on the grounds that ordering them is subtle. Scanning real pubspecs showed that would have been useless:

```
before:  139 pubspecs, 0 excluded, 137 constraints not understood
after:   139 pubspecs, 0 excluded,   0 constraints not understood
```

`^3.11.0-0` is the dominant real-world form — 132 of those 139 — and the `-0` exists precisely to admit prereleases of the lower bound. Declining it meant a gate that never fires. Versions now carry a sortable key ranking a release above its own prereleases, which is what semver says and what the idiom relies on.

Zero excluded is the expected answer there: those apps ship with the SDK being pinned.

## Tests

`tools/tests/test_sdk_constraint.py`, 32 cases, checked from both directions — that it excludes what it should, and that it declines to act on what it does not understand. Includes version-ordering cases (`3.11.0-0 < 3.11.0`, numeric prerelease identifiers below alphanumeric) and the `^0.x` caret stopping at the next minor.

`64 passed` for the whole tools suite.