### PR TITLE
flutter-sdk: build the SDK's own example apps, and fix the rebuild that broke it

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -357,6 +357,21 @@ jobs:
           # rounds reporting a failure the build did not have.
 
       #
+      # The first app that ships inside the Flutter SDK rather than in a
+      # repository of its own (#867). It has no source of its own at all: the
+      # SDK is already staged in recipe-sysroot-native, so the recipe copies
+      # the workspace out of it.
+      - name: Build flutter-sdk-examples-hello-world
+        # flutter build bundle has no linux-arm target platform,
+        # so the app recipes do not parse for a 32-bit machine
+        if: ${{ !cancelled() && steps.base.outcome == 'success' && matrix.machine != 'qemuarm' }}
+        shell: bash
+        working-directory: ../master-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          bitbake flutter-sdk-examples-hello-world
+
+      #
       # bluez_native: compiles a vendored sdbus-c++ from its own hook.
       - name: Build jwinarske-bluez-native-flutter-ble-scanner
         # flutter build bundle has no linux-arm target platform,

--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -487,6 +487,18 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
         build_folder = os.path.join(source_root, 'build')
         if os.path.exists(build_folder):
             run_command(d, 'flutter clean -v', source_root, env)
+            # `flutter clean` removes .dart_tool, and the build below carries
+            # --no-pub whenever do_compile has no network, so nothing puts the
+            # resolution back. The snapshot is then handed a package_config.json
+            # that was deleted moments after do_compile resolved it. Resolve
+            # again -- offline, against the cache the earlier get populated.
+            #
+            # Only visible on a rebuild, since a first build has no build/ for
+            # the clean to trigger on. It bites hardest on a pub workspace,
+            # where .dart_tool/pub/workspace_ref.json goes with it and the
+            # snapshot silently falls back to a member package_config.json that
+            # a workspace member never has.
+            run_command(d, 'flutter pub get --offline', source_root, env)
 
         if runtime_mode == 'jit_release':
             cmd = (f'flutter build {flutter_build_args} --local-engine -v')

--- a/conf/include/flutter-sdk-app.inc
+++ b/conf/include/flutter-sdk-app.inc
@@ -1,0 +1,93 @@
+#
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
+#
+# Shared bits for an app that ships inside the Flutter SDK.
+#
+# These are not third-party repositories and they need no source of their own.
+# flutter-sdk-native is already a dependency of every flutter-app recipe
+# (conf/include/common.inc), so the SDK -- and with it every app it ships -- is
+# staged in recipe-sysroot-native before this recipe configures. Fetching the
+# release archive again to get at source already on disk would cost a 1.5 GB
+# download and a 2.5 GB unpack per app.
+#
+# Copy the workspace out of the sysroot instead, at about 127 MB:
+#
+#   pubspec.yaml           the workspace root
+#   packages dev examples  every member it lists, which all must exist
+#   LICENSE                for LIC_FILES_CHKSUM
+#
+# Everything left behind is what made the archive large and none of it is read
+# from ${S}: bin (1.8 GB) is the toolchain, which the build takes from
+# ${FLUTTER_SDK}; .git and .pub-preload-cache are not source.
+#
+# The whole workspace comes across rather than the one app because SDK apps
+# declare "resolution: workspace" and pub requires every member the root
+# pubspec lists to exist. conf/include/common.inc already follows
+# .dart_tool/pub/workspace_ref.json to that root when building the snapshot.
+#
+# A recipe using this sets PUBSPEC_APPNAME and FLUTTER_APPLICATION_PATH.
+
+# flutter-version.inc is not required here: flutter-app.inc pulls it in, and
+# requiring it twice warns. FLUTTER_SDK_VERSION comes from common.inc.
+
+DESCRIPTION ?= "Flutter SDK example application"
+AUTHOR = "Google"
+HOMEPAGE = "https://github.com/flutter/flutter"
+BUGTRACKER = "https://github.com/flutter/flutter/issues"
+SECTION = "graphics"
+
+LICENSE = "BSD-3-Clause"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1d84cf16c48e571923f837136633a265"
+
+# No source of its own; see above.
+SRC_URI = ""
+
+S = "${UNPACKDIR}/flutter-sdk-workspace"
+
+# The app is whatever the pinned SDK ships, so that is its version.
+PV = "${FLUTTER_SDK_VERSION}"
+
+# Keep the lockfile. Unlike the third-party apps, the SDK ships a real one --
+# at the workspace root, covering all 78 members, and `flutter update-packages`
+# during the SDK build leaves it byte-identical. It is an authored resolution,
+# so there is nothing to gain by discarding it and re-resolving per build.
+PUBSPEC_IGNORE_LOCKFILE = "0"
+
+FLUTTER_APPLICATION_INSTALL_SUFFIX ?= "flutter-sdk-${@(d.getVar('FLUTTER_APPLICATION_PATH') or '').replace('/', '-').replace('_', '-')}"
+
+# pubspec.lock is not optional here. A workspace member resolves against the
+# root lockfile -- `pub get --enforce-lockfile` from the member reports
+# "Cannot do --enforce-lockfile without an existing pubspec.lock ... to create
+# ../../pubspec.lock" -- and without it the resolve fails, the root .dart_tool
+# is never written, and common.inc falls back to a member package_config.json
+# that a workspace member does not have.
+SDK_WORKSPACE_PATHS ?= "pubspec.yaml pubspec.lock LICENSE analysis_options.yaml packages dev examples"
+
+# Ordered against three things, all of which matter:
+#
+#   after do_unpack  -- do_unpack[cleandirs] is UNPACKDIR, and S lives under
+#                       it, so staging first would be undone
+#   after do_prepare_recipe_sysroot -- that is what puts the SDK in place
+#   before do_patch  -- so ${S} exists by the time do_populate_lic reads
+#                       LICENSE
+#
+# S has to be under UNPACKDIR rather than WORKDIR: insane.bbclass:1450 makes
+# anything else fatal.
+do_stage_sdk_workspace() {
+    rm -rf ${S}
+    install -d ${S}
+    for p in ${SDK_WORKSPACE_PATHS}; do
+        if [ ! -e "${FLUTTER_SDK}/$p" ]; then
+            bbfatal "the staged Flutter SDK has no $p; ${FLUTTER_SDK} is not a full SDK"
+        fi
+        cp -a "${FLUTTER_SDK}/$p" ${S}/
+    done
+    if [ ! -f "${S}/${FLUTTER_APPLICATION_PATH}/pubspec.yaml" ]; then
+        bbfatal "no app at ${FLUTTER_APPLICATION_PATH} in the SDK this layer pins (${FLUTTER_SDK_VERSION})"
+    fi
+}
+addtask stage_sdk_workspace after do_unpack do_prepare_recipe_sysroot before do_patch
+
+inherit flutter-app

--- a/recipes-graphics/flutter-sdk/apps/flutter-sdk-examples-hello-world.bb
+++ b/recipes-graphics/flutter-sdk/apps/flutter-sdk-examples-hello-world.bb
@@ -1,0 +1,13 @@
+#
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
+#
+
+SUMMARY = "hello_world"
+DESCRIPTION = "The smallest app the Flutter SDK ships: a single Text widget."
+
+PUBSPEC_APPNAME = "hello_world"
+FLUTTER_APPLICATION_PATH = "examples/hello_world"
+
+require conf/include/flutter-sdk-app.inc


### PR DESCRIPTION
Towards #867. The first SDK app, and the shape the other 46 can follow.

## No SRCREV, no manifest entry, no extra download

The source is the release archive `flutter-sdk-native` already fetches, named through `get_flutter_archive()` the same way. So the recipe follows `FLUTTER_SDK_TAG` automatically and shares the download — verified the URL is byte-identical to `flutter-sdk-native`'s and the tarball is already in `DL_DIR`.

That is simpler than #867 assumed. I had suggested there that whatever replaced the dead `flutter/flutter` manifest entry should take its revision from the pinned SDK; using the SDK's own archive means there is no revision to take.

## Why the whole tree unpacks

SDK apps declare `resolution: workspace` — they are members of a pub workspace rooted at the SDK, so an app copied out of it cannot resolve. `common.inc` already follows `.dart_tool/pub/workspace_ref.json` to the workspace root when building the snapshot, which is what makes this work at all.

The cost is real and worth naming: each such recipe unpacks the full SDK into its own `WORKDIR`. With `rm_work` only one or two exist at a time, but it is not free, and it is the main thing to weigh before scaling to 47.

## Layout

`recipes-graphics/flutter-sdk/apps/` rather than beside `flutter-sdk_git.bb`, which is one hand-maintained recipe that should not get buried as this family grows. `BBFILES` already globs three levels, so no `layer.conf` change.

## Verified before pushing

Parsed against the local build tree:

```
PN      flutter-sdk-examples-hello-world
PV      3.47.1
S       .../sources/flutter
SRC_URI .../stable/linux/flutter_linux_3.47.1-stable.tar.xz
FLUTTER_APPLICATION_INSTALL_SUFFIX  flutter-sdk-examples-hello-world
```

CI builds it on the three machines that can build Flutter apps.

## Not done here

Generating these from the roll. Hand-writing the first keeps "does this recipe shape work" separate from "how do we emit 47 of them" — the same order that worked for pubvendor in #862, where the shape turned out to need four fixes before anything built.