### PR TITLE
roll: follow a pub workspace to its lockfile

### DIFF
--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -239,6 +239,39 @@ def copy_src_file(file: str, src_folder: str, patch_dir: str, output_path: str):
     shutil.copy2(src_file, dst_file)
 
 
+def workspace_root_for(app_dir):
+    """The pub workspace root this app belongs to, or None if it is not a member.
+
+    An app that declares `resolution: workspace` has no lockfile of its own;
+    the resolution lives at the root, covers every member, and is where pub
+    must be run. The Flutter SDK's own apps are all like this -- one lockfile
+    at the SDK root for 78 members -- so an app-directory lookup finds nothing
+    and would generate a per-app resolution, which is the wrong unit.
+
+    Found the way pub finds it: walk up looking for a pubspec that names this
+    app in its `workspace` list.
+    """
+    pubspec = os.path.join(app_dir, 'pubspec.yaml')
+    if not os.path.isfile(pubspec):
+        return None
+    spec = get_yaml_obj(pubspec)
+    if not spec or spec.get('resolution') != 'workspace':
+        return None
+
+    app_dir = os.path.abspath(app_dir)
+    current = os.path.dirname(app_dir)
+    while True:
+        candidate = os.path.join(current, 'pubspec.yaml')
+        if os.path.isfile(candidate):
+            root_spec = get_yaml_obj(candidate) or {}
+            if os.path.relpath(app_dir, current) in (root_spec.get('workspace') or []):
+                return current
+        parent = os.path.dirname(current)
+        if parent == current:
+            return None
+        current = parent
+
+
 def generate_pubcache_inc(app_dir, recipe_name, output_path,
                           always_resolve=False) -> bool:
     """Emit the SRC_URI fragment for an app's pub cache.
@@ -272,17 +305,21 @@ def generate_pubcache_inc(app_dir, recipe_name, output_path,
         return False
 
     def resolve(*args):
-        return subprocess.run(['flutter', 'pub', 'get', *args], cwd=app_dir,
+        return subprocess.run(['flutter', 'pub', 'get', *args], cwd=resolve_dir,
                               capture_output=True, text=True)
 
-    lock = os.path.join(app_dir, 'pubspec.lock')
+    # A workspace member resolves at the root, not in its own directory.
+    workspace = workspace_root_for(app_dir)
+    resolve_dir = workspace or app_dir
+    lock = os.path.join(resolve_dir, 'pubspec.lock')
     shipped = os.path.exists(lock)
+    ws = ' (pub workspace)' if workspace else ''
 
     if not shipped:
-        provenance = 'created by the roll; the app ships none'
+        provenance = f'created by the roll; none is shipped{ws}'
         r = resolve()
     elif always_resolve:
-        provenance = 're-resolved by the roll (pubvendor: resolve)'
+        provenance = f're-resolved by the roll (pubvendor: resolve){ws}'
         os.remove(lock)
         r = resolve()
     else:
@@ -291,11 +328,11 @@ def generate_pubcache_inc(app_dir, recipe_name, output_path,
         # hold against the SDK this layer pins?
         r = resolve('--enforce-lockfile')
         if r.returncode == 0:
-            provenance = "the app's own, unchanged"
+            provenance = f"the project's own, unchanged{ws}"
         else:
             print(f'NOTE: {recipe_name}: the committed lockfile does not hold '
                   f'against the pinned SDK, re-resolving')
-            provenance = 're-resolved by the roll; the app\'s own did not hold'
+            provenance = f're-resolved by the roll; the shipped one did not hold{ws}'
             os.remove(lock)
             r = resolve()
 

--- a/tools/pubvendor/README.md
+++ b/tools/pubvendor/README.md
@@ -46,6 +46,19 @@ hold against the pinned SDK, and the roll says so as it goes.
 Set `"pubvendor": "resolve"` instead of `true` for an app whose committed
 lockfile must always be replaced.
 
+### Workspace members
+
+An app that declares `resolution: workspace` has no lockfile of its own. The
+resolution lives at the workspace root, covers every member, and is where pub
+has to be run, so the roll follows the `workspace` list up to that root and
+uses the lockfile there. The header says `(pub workspace)` when it did.
+
+Every app the Flutter SDK ships is like this: one lockfile at the SDK root
+covering 78 members. That makes the resolution shared rather than per-app --
+generating a fragment for one SDK app produces the same 167 entries as
+generating it for any other, so the cost is paid once however many are
+vendored.
+
 An app that cannot resolve against the pinned SDK is reported and skipped
 rather than failing the roll, and its recipe is written *without* the
 `require` line -- a recipe requiring a fragment that was never generated is

--- a/tools/tests/test_generate_pubcache_inc.py
+++ b/tools/tests/test_generate_pubcache_inc.py
@@ -66,7 +66,7 @@ def _header(out, name='probe'):
 def test_no_lockfile_is_created_not_replaced(app):
     app_dir, out = app
     assert create_recipes.generate_pubcache_inc(str(app_dir), 'probe', str(out))
-    assert 'Lockfile: created by the roll; the app ships none' in _header(out)
+    assert 'Lockfile: created by the roll; none is shipped' in _header(out)
 
 
 def test_a_holding_lockfile_is_kept(app, monkeypatch):
@@ -74,7 +74,7 @@ def test_a_holding_lockfile_is_kept(app, monkeypatch):
     (app_dir / 'pubspec.lock').write_text(LOCK)
     monkeypatch.setenv('ENFORCE_RC', '0')
     assert create_recipes.generate_pubcache_inc(str(app_dir), 'probe', str(out))
-    assert "Lockfile: the app's own, unchanged" in _header(out)
+    assert "Lockfile: the project's own, unchanged" in _header(out)
     # the author's resolution was never re-run
     assert not (app_dir / 'resolved.marker').exists()
 

--- a/tools/tests/test_workspace_lockfile.py
+++ b/tools/tests/test_workspace_lockfile.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+"""A pub workspace member has no lockfile of its own.
+
+The resolution lives at the workspace root and covers every member, so looking
+in the app directory finds nothing and generates a per-app resolution -- the
+wrong unit. Every app the Flutter SDK ships is like this: one lockfile at the
+root for 78 members. See #867.
+"""
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import create_recipes  # noqa: E402
+
+
+def _workspace(tmp_path, member='examples/hello_world', declared=True):
+    root = tmp_path / 'flutter'
+    app = root / member
+    app.mkdir(parents=True)
+    members = f'  - {member}\n' if declared else '  - some/other\n'
+    (root / 'pubspec.yaml').write_text(
+        f'name: _flutter_packages\nworkspace:\n{members}')
+    (root / 'pubspec.lock').write_text('packages: {}\n')
+    (app / 'pubspec.yaml').write_text(
+        'name: hello_world\nresolution: workspace\n')
+    return root, app
+
+
+def test_member_resolves_to_the_workspace_root(tmp_path):
+    root, app = _workspace(tmp_path)
+    assert create_recipes.workspace_root_for(str(app)) == str(root)
+
+
+def test_nested_member_walks_all_the_way_up(tmp_path):
+    root, app = _workspace(tmp_path, member='dev/integration_tests/ui')
+    assert create_recipes.workspace_root_for(str(app)) == str(root)
+
+
+def test_an_app_not_declaring_workspace_resolution_is_standalone(tmp_path):
+    root, app = _workspace(tmp_path)
+    (app / 'pubspec.yaml').write_text('name: hello_world\n')
+    assert create_recipes.workspace_root_for(str(app)) is None
+
+
+def test_a_root_that_does_not_list_the_app_is_not_its_workspace(tmp_path):
+    # declaring `resolution: workspace` is not enough; the root has to agree
+    root, app = _workspace(tmp_path, declared=False)
+    assert create_recipes.workspace_root_for(str(app)) is None
+
+
+def test_no_ancestor_pubspec_at_all(tmp_path):
+    app = tmp_path / 'standalone'
+    app.mkdir()
+    (app / 'pubspec.yaml').write_text('name: x\nresolution: workspace\n')
+    assert create_recipes.workspace_root_for(str(app)) is None
+
+
+def test_a_missing_pubspec_is_not_a_crash(tmp_path):
+    assert create_recipes.workspace_root_for(str(tmp_path / 'nope')) is None


### PR DESCRIPTION
Towards #867, and the gap I found while looking at what vendoring an SDK app would mean.

An app that declares `resolution: workspace` has **no lockfile of its own**. The resolution lives at the workspace root, covers every member, and is where pub has to be run. `generate_pubcache_inc` looked in the app directory, found nothing, and took the "ships none" path from #874 — generating a per-app resolution, which is the wrong unit and would disagree with what the project actually resolves.

## Why this matters more than it looks

Every app the Flutter SDK ships is a workspace member: **one lockfile at the SDK root covering 78 members**, shipped in the release archive and left byte-identical by `flutter update-packages`. pubvendor already reads it without complaint:

```
165 hosted, 2 git, 2 skipped
Skipped (not fetched): flutter_tools (path), sky_engine (sdk)
```

So the resolution is *shared*, not per-app. Generating a fragment for one SDK app produces the same 167 entries as for any other — the vendoring cost is paid once however many get vendored, which inverts the economics that make per-app vendoring expensive.

It also means these are the first apps to exercise #874's "keep what the project shipped" branch, since the SDK commits a real lockfile.

## How the root is found

The way pub finds it: walk up from an app declaring workspace resolution, looking for an ancestor pubspec whose `workspace` list names it. Declaring the resolution is not sufficient — the root has to agree, which is what distinguishes a member from an app that merely sits inside a workspace tree.

Checked against the staged SDK:

```
examples/hello_world        -> SDK root
dev/integration_tests/ui    -> SDK root
examples/multiple_windows   -> None      (not in the workspace list)
```

That last one is not a miss: `multiple_windows` genuinely is not a member.

## Tests

Six new, plus two existing ones updated for the reworded provenance (`the project's own` rather than `the app's own`, since for a workspace it is not the app's). `70 passed`.

Tools-only, so no machine builds.