### PR TITLE
master: keep the hash equivalence database with the sstate

### DIFF
--- a/conf/distro/include/ci-build.inc
+++ b/conf/distro/include/ci-build.inc
@@ -10,6 +10,25 @@ INHIBIT_PACKAGE_DEBUG_SPLIT = "1"
 DL_DIR = "/home/dev/dl"
 SSTATE_DIR = "/home/dev/sstate"
 
+# Keep the hash equivalence database with the sstate it describes.
+#
+# With BB_HASHSERVE = "auto" the database defaults to PERSISTENT_DIR or CACHE,
+# both inside the build directory -- and each branch builds in its own
+# (wrynose-linux-dummy, master-linux-dummy, ...) while sharing one SSTATE_DIR.
+# The hashes that say which sstate objects are equivalent then live in one
+# build tree and are invisible to the next, so the shared sstate is there but
+# largely unusable. oe-core says so at every start:
+#
+#   WARNING: Sstate directory is shared between several builds ... but hash
+#   equivalency database is inside this particular build directory ... This
+#   will prevent sstate reuse
+#
+# Safe here: bitbake refuses this only when the directory is on NFS, and the
+# warning above is the branch oe/sanity.py takes when SSTATE_DIR is not, so
+# that is settled by the message itself. bitbake creates the directory if it
+# is missing.
+BB_HASHSERVE_DB_DIR ?= "${SSTATE_DIR}"
+
 INIT_MANAGER = "systemd"
 
 # ***************************************


### PR DESCRIPTION
Port of #873, now merged to wrynose. The added block is byte-identical to what wrynose carries — verified with a diff, not by eye.

With `BB_HASHSERVE = "auto"` the hash equivalence database falls back to `PERSISTENT_DIR` or `CACHE`, both inside the build directory. Each branch builds in its own (`master-linux-dummy`, `wrynose-linux-dummy`, …) while sharing one `SSTATE_DIR`, so the hashes recording which sstate objects are equivalent get written into one build tree and are invisible from the next.

**The gain is cross-branch, so it needs both ends.** With only wrynose pointing at the shared database, a master build still writes its own and neither side can see the other's work — which is why this follows #873 rather than waiting.

Safety is settled by the warning itself: `cooker.py:331` refuses this only when the directory is on NFS, and the message we get is the branch `oe/sanity.py:936` takes when `SSTATE_DIR` is **not** on NFS. Full reasoning in #873.

`scarthgap`, `kirkstone` and `dunfell` carry the same omission and are unported — they are `workflow_dispatch`-only, so they want a deliberate dispatch rather than being swept in here.

## What this will and will not show

A green matrix here means it did not break anything. It cannot show the benefit: the first build after the change writes a fresh database at the new location. The gain appears on subsequent builds and across branches. Today's wrynose per-job times are the baseline worth comparing against — x86-64 5m42s, arm 12m48s, arm64 33m30s.