### PR TITLE
ci: one run per branch, so superseded ones stop

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -33,6 +33,20 @@ on:
     types: [ published, created, edited ]
   workflow_dispatch:
 
+# One run per branch. Every push to a pull request starts a run and GitHub
+# does not stop the previous one, so an iterated branch leaves a queue of runs
+# against commits that have already been superseded -- on a sequential runner,
+# each one is roughly an hour of matrix that can only reproduce a result we
+# have moved past.
+#
+# Cancelling is limited to pull_request on purpose. A workflow_dispatch is
+# someone deliberately asking for a build, and a second dispatch on the same
+# ref should not silently kill the first; the release branches are dispatch
+# only, so there it would be the sole behaviour.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   master-build:


### PR DESCRIPTION
Every push to a pull request starts a run and GitHub does not stop the previous one. An iterated branch leaves a queue of runs against commits already superseded — on a sequential runner, each is about an hour of matrix that can only reproduce a result we have moved past.

**Six times today on this repo**, all cancelled by hand and only because someone looked at the queue:

| branch | stale runs |
|---|---|
| `jw/master-pubvendor-optin2` | 3 |
| `jw/master-roll-fail-loudly` | 2 |
| `jw/master-sdk-app-recipes` | 2 |

That is more runner time than any single change landed today used.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

## Why the expression rather than plain `true`

A `workflow_dispatch` is someone deliberately asking for a build, and a second dispatch on the same ref should not silently kill the first. `scarthgap`, `kirkstone` and `dunfell` are dispatch-only, so plain `true` would make cancellation the *only* behaviour they ever see — the opposite of what is wanted there. Restricting it to `pull_request` targets exactly the waste observed and leaves manual builds alone.

## Scope

master only. `wrynose` also has a `pull_request` trigger and wants the same block; the three release branches want it too, for when they gain one. Each needs its own PR against its own base, so I have kept this one reviewable rather than sweeping five branches at once.

Ironically this PR costs one matrix to land. It pays for itself the first time anyone force-pushes.