### PR TITLE
wrynose: one run per branch, so superseded ones stop

### DIFF
--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -32,6 +32,20 @@ on:
       - 'LICENSE'
   workflow_dispatch:
 
+# One run per branch. Every push to a pull request starts a run and GitHub
+# does not stop the previous one, so an iterated branch leaves a queue of runs
+# against commits that have already been superseded -- on a sequential runner,
+# each one is roughly an hour of matrix that can only reproduce a result we
+# have moved past.
+#
+# Cancelling is limited to pull_request on purpose. A workflow_dispatch is
+# someone deliberately asking for a build, and a second dispatch on the same
+# ref should not silently kill the first; the release branches are dispatch
+# only, so there it would be the sole behaviour.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
 
   wrynose-build:


### PR DESCRIPTION
Port of #879. The added block is byte-identical to master's — diffed, not eyeballed.

Every push to a pull request starts a run and GitHub does not stop the previous one, so an iterated branch leaves a queue of runs against commits already superseded. On a sequential runner each is about an hour of matrix reproducing a result we have moved past.

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.ref }}
  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

Cancellation is restricted to `pull_request` deliberately: a `workflow_dispatch` is someone asking for a build on purpose, and a second dispatch on the same ref should not silently kill the first.

Reasoning and the count of what this would have saved today are in #879.