### PR TITLE
flutter-sdk: add flutter_gallery

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -383,7 +383,11 @@ jobs:
         working-directory: ../master-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-sdk-examples-hello-world
+          # hello_world proves the shape; flutter_gallery proves it holds for an
+          # app with real dependencies -- ten of them, including url_launcher,
+          # whose Linux implementation exercises plugin registration. The SDK's
+          # apps are otherwise mostly dependency-free.
+          bitbake flutter-sdk-examples-hello-world flutter-sdk-flutter-gallery
 
       #
       # bluez_native: compiles a vendored sdbus-c++ from its own hook.

--- a/recipes-graphics/flutter-sdk/apps/flutter-sdk-flutter-gallery.bb
+++ b/recipes-graphics/flutter-sdk/apps/flutter-sdk-flutter-gallery.bb
@@ -1,0 +1,19 @@
+#
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
+#
+
+SUMMARY = "flutter_gallery"
+DESCRIPTION = "The Flutter gallery: material and cupertino demos, the SDK's \
+largest example app and the first with dependencies that resolve to something."
+
+PUBSPEC_APPNAME = "flutter_gallery"
+FLUTTER_APPLICATION_PATH = "dev/integration_tests/flutter_gallery"
+
+# The manifest entry removed in #872 carried this, having worked out that the
+# gallery reaches for the user directories at runtime. Kept rather than
+# rediscovered.
+RDEPENDS:${PN} += "xdg-user-dirs"
+
+require conf/include/flutter-sdk-app.inc


### PR DESCRIPTION
The second SDK app, towards #867. Built locally end to end before pushing.

`hello_world` declares no dependencies, so it proved the recipe shape and little else. The gallery has ten, and `url_launcher` among them is a real plugin with a Linux implementation — so this is the first SDK app that exercises hosted dependency resolution against the workspace lockfile *and* plugin registration.

```
.flutter-plugins-dependencies   linux: url_launcher_linux
registrant                      generated
packaged libapp.so              9,110,408 bytes
  _PluginRegistrant             1
  UrlLauncherLinux              2
```

## A correction worth recording

I previously reported that **none** of the 14 candidate SDK apps uses Flutter plugins, and used that to argue they would not cover the registrant path. That was wrong — I classified by dependency count and name without checking which were plugins. `url_launcher` is one, and the gallery pulls it. The SDK apps do cover that path.

## First non-vacuous run of the registrant check

The `do_package` check added with the pubvendor opt-in fails when an app declares Linux plugins and ships a `libapp.so` without a registrant. Until now every app it saw either had no plugins, or was the single app it was written for. Here it had a real plugin list and passed on the merits.

## Runtime dependency

`RDEPENDS` carries `xdg-user-dirs`, taken from the `flutter/flutter` manifest entry removed in #872. Someone had already worked out that the gallery reaches for the user directories at runtime; keeping it means the next person does not rediscover it by debugging a broken install.

## On CI budget

Two apps now, at roughly 16 minutes each on the three machines that build Flutter apps. #867 lists 14 candidates — that is nearly four hours per machine if all are built, so the generated set and the built set will have to diverge before this scales. Worth deciding before adding a third.