### PR TITLE
roll: regenerate the SDK app recipes as part of the roll

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -81,6 +81,27 @@ An app declaring `resolution: workspace` has no lockfile of its own; the roll
 follows the `workspace` list to the root and uses the one there, and says
 `(pub workspace)`. See `tools/pubvendor/README.md`.
 
+### Flutter SDK apps
+
+The apps the SDK itself ships have no manifest entry and no SRCREV: they move
+with `FLUTTER_SDK_TAG`, so the roll regenerates their recipes rather than
+tracking them. It clones `flutter/flutter` at the commit the pinned release
+names -- blobless and narrowed to three directories, about 130 MB -- and emits
+one recipe per candidate into `recipes-graphics/flutter-sdk/apps/`, plus a
+single fragment vendoring the workspace's pub cache for all of them.
+
+Apps that are not candidates are reported with a reason rather than dropped.
+Anything hand-tuned belongs in `sdk-apps-overrides.json`, keyed by app path, so
+the next roll cannot lose it.
+
+If the clone fails the roll says so and continues: it has already updated the
+pinned SDK by that point, and one unreachable remote should not discard that.
+The warning matters, though -- recipes left describing the previous SDK keep
+parsing, and only the two built in CI would notice.
+
+    tools/sdk_apps.py --path .              # regenerate by hand
+    tools/sdk_apps.py --clone /path/to/ff   # reuse an existing checkout
+
 ## Manifest keys
 
 `meta-flutter-apps/conf/flutter-apps.json`, one entry per repository. `uri` and

--- a/tools/roll_meta_flutter.py
+++ b/tools/roll_meta_flutter.py
@@ -470,6 +470,17 @@ def main():
     print_banner(f'Updating dart-sdk recipe')
     update_dart_recipe(args.path, flutter_sdk_version)
 
+    #
+    # The apps the SDK itself ships. These have no manifest entry and no
+    # SRCREV: they move with FLUTTER_SDK_TAG, so they are regenerated here
+    # rather than tracked. After update_flutter_version_inc() above, because
+    # that is what makes the pinned version current -- generating first would
+    # emit recipes for the SDK being replaced.
+    #
+    print_banner('Updating Flutter SDK app recipes')
+    from sdk_apps import roll_sdk_apps
+    roll_sdk_apps(args.path)
+
     print_banner(f'Updating meta-flutter-apps from {args.json}')
     repos = get_flutter_apps(args.json)
 

--- a/tools/sdk_apps.py
+++ b/tools/sdk_apps.py
@@ -227,11 +227,55 @@ def generate(layer_root, clone_root, overrides_path, output_dir, read_yaml):
     return written, rejected
 
 
-def main(argv=None):
-    import argparse
+def roll_sdk_apps(layer_root, clone=None):
+    """Regenerate the SDK app recipes. Called by the roll; returns True on success.
+
+    Not fatal when it cannot run. A roll that reaches this point has already
+    updated the pinned SDK and the dart-sdk recipe, and one unavailable clone
+    should not throw that away -- but it says so loudly, because recipes left
+    describing the previous SDK would keep parsing and only the handful built
+    in CI would notice.
+    """
     import tempfile
 
     import yaml
+
+    output_dir = os.path.join(layer_root, 'recipes-graphics', 'flutter-sdk', 'apps')
+    overrides = os.path.join(output_dir, 'sdk-apps-overrides.json')
+
+    tmp = None
+    if clone is None:
+        release_hash = pinned_release_hash(layer_root)
+        if not release_hash:
+            print('WARNING: no release hash for the pinned SDK; '
+                  'SDK app recipes not regenerated and now describe an older SDK')
+            return False
+        tmp = tempfile.mkdtemp(prefix='flutter-sdk-apps-')
+        try:
+            clone = clone_pinned(release_hash, os.path.join(tmp, 'flutter'))
+        except subprocess.CalledProcessError as e:
+            shutil.rmtree(tmp, ignore_errors=True)
+            print(f'WARNING: could not clone flutter/flutter at {release_hash}: '
+                  f'{e.stderr.strip()[:200]}\n'
+                  f'SDK app recipes not regenerated and now describe an older SDK')
+            return False
+
+    try:
+        written, rejected = generate(layer_root, clone, overrides, output_dir,
+                                     lambda p: yaml.safe_load(open(p)))
+    finally:
+        if tmp:
+            shutil.rmtree(tmp, ignore_errors=True)
+
+    print(f'{len(written)} SDK app recipe(s) written')
+    print(f'{len(rejected)} app(s) not generated:')
+    for rel, reason in rejected:
+        print(f'  {rel}: {reason}')
+    return True
+
+
+def main(argv=None):
+    import argparse
 
     ap = argparse.ArgumentParser(
         description="Generate recipes for the apps inside the Flutter SDK")
@@ -240,34 +284,7 @@ def main(argv=None):
                     help='an existing flutter/flutter checkout to use instead '
                          'of cloning (must be at the pinned commit)')
     args = ap.parse_args(argv)
-
-    layer = args.path
-    output_dir = os.path.join(layer, 'recipes-graphics', 'flutter-sdk', 'apps')
-    overrides = os.path.join(output_dir, 'sdk-apps-overrides.json')
-
-    clone = args.clone
-    tmp = None
-    if clone is None:
-        release_hash = pinned_release_hash(layer)
-        if not release_hash:
-            print('ERROR: no release hash for the pinned SDK')
-            return 1
-        tmp = tempfile.mkdtemp(prefix='flutter-sdk-apps-')
-        clone = clone_pinned(release_hash, os.path.join(tmp, 'flutter'))
-
-    try:
-        written, rejected = generate(layer, clone, overrides, output_dir,
-                                     lambda p: yaml.safe_load(open(p)))
-    finally:
-        if tmp:
-            shutil.rmtree(tmp, ignore_errors=True)
-
-    print(f'{len(written)} recipe(s) written to '
-          f'{os.path.relpath(output_dir, layer)}')
-    print(f'{len(rejected)} app(s) not generated:')
-    for rel, reason in rejected:
-        print(f'  {rel}: {reason}')
-    return 0
+    return 0 if roll_sdk_apps(args.path, args.clone) else 1
 
 
 if __name__ == '__main__':

--- a/tools/tests/test_sdk_apps.py
+++ b/tools/tests/test_sdk_apps.py
@@ -129,3 +129,45 @@ def test_apps_are_emitted_in_a_stable_order(tmp_path):
         _app(tmp_path, rel)
     cands, _ = _find(tmp_path)
     assert [c['path'] for c in cands] == sorted(c['path'] for c in cands)
+
+
+def test_roll_sdk_apps_is_not_fatal_when_the_clone_fails(tmp_path, monkeypatch, capsys):
+    """A roll that has already bumped the SDK must not be thrown away.
+
+    But it has to say so: recipes left describing the previous SDK keep
+    parsing, and only the handful built in CI would ever notice.
+    """
+    import subprocess as sp
+    monkeypatch.setattr(sdk_apps, 'pinned_release_hash', lambda root: 'deadbeef')
+
+    def boom(*a, **kw):
+        raise sp.CalledProcessError(128, 'git', stderr='could not read from remote')
+    monkeypatch.setattr(sdk_apps, 'clone_pinned', boom)
+
+    assert sdk_apps.roll_sdk_apps(str(tmp_path)) is False
+    out = capsys.readouterr().out
+    assert 'WARNING' in out
+    assert 'describe an older SDK' in out
+
+
+def test_roll_sdk_apps_reports_a_missing_release_hash(tmp_path, monkeypatch, capsys):
+    monkeypatch.setattr(sdk_apps, 'pinned_release_hash', lambda root: None)
+    assert sdk_apps.roll_sdk_apps(str(tmp_path)) is False
+    assert 'no release hash' in capsys.readouterr().out
+
+
+def test_roll_sdk_apps_generates_from_an_existing_clone(tmp_path):
+    clone = tmp_path / 'flutter'
+    _app(clone, 'examples/hello_world')
+    (clone / 'pubspec.yaml').write_text('name: _flutter_packages\n')
+    layer = tmp_path / 'layer'
+    (layer / 'conf' / 'include').mkdir(parents=True)
+    (layer / 'conf' / 'include' / 'flutter-version.inc').write_text(
+        'FLUTTER_SDK_TAG ??= "3.47.1"\n')
+    (layer / 'conf' / 'include' / 'releases_linux.json').write_text(
+        '{"releases": [{"version": "3.47.1", "dart_sdk_version": "3.13.1"}]}')
+
+    assert sdk_apps.roll_sdk_apps(str(layer), str(clone)) is True
+    written = sorted(p.name for p in
+                     (layer / 'recipes-graphics' / 'flutter-sdk' / 'apps').iterdir())
+    assert 'flutter-sdk-examples-hello-world.bb' in written


### PR DESCRIPTION
Closes #867.

The generator landed in #883 and **nothing called it**. The recipes in the layer were produced by running it by hand, so the next SDK bump would have left all fourteen describing the previous SDK — and because they still parse, only the two built in CI would have noticed. The other twelve would have gone stale silently, which is exactly the failure this family of recipes exists to prevent.

The roll now calls it, after `update_flutter_version_inc()` — that is what makes the pinned version current, and generating before it would emit recipes for the SDK being replaced.

## Failure behaviour

Not fatal. A roll that reaches this point has already updated `FLUTTER_SDK_TAG` and the dart-sdk recipe; one unreachable remote should not throw that away. But it warns with the *consequence* rather than just the error:

```
WARNING: could not clone flutter/flutter at <hash>: could not read from remote
SDK app recipes not regenerated and now describe an older SDK
```

Both failure paths are tested — a clone that fails and a missing release hash — along with generation from an existing checkout.

`91 passed`, up from 88.

## Docs

`tools/README.md` gains a section on how SDK apps differ from manifest entries: no entry, no SRCREV, regenerated rather than tracked, overrides preserved across rolls, and what the warning means if you see it.

Tools-only, so no machine builds.