### PR TITLE
tools: stop the download meter drowning the roll output

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -121,6 +121,20 @@ skip past.
 | `compiler_requires_network` | apps whose build hooks fetch |
 | `pubvendor` | `true` to vendor the pub cache, `"resolve"` to always replace a committed lockfile |
 
+## Requirements
+
+Python 3.10 or newer, and:
+
+    pip install pycurl pyyaml
+
+`pycurl` downloads `releases_linux.json` and the version files; `pyyaml` reads
+every `pubspec.yaml`. Neither is optional, and `pycurl` needs libcurl headers
+to build (`libcurl4-openssl-dev` on Debian, `libcurl-devel` on Fedora).
+
+The roll also needs `git`, and `flutter` on `PATH` for any app that sets
+`"pubvendor"` -- at the version this layer pins, since that is what the
+lockfile is resolved against.
+
 ## Tests
 
 ```

--- a/tools/common.py
+++ b/tools/common.py
@@ -180,7 +180,17 @@ def get_yaml_obj(filepath: str):
 
 
 def fetch_https_progress(download_t, download_d, _upload_t, _upload_d):
-    """callback function for pycurl.XFERINFOFUNCTION"""
+    """callback function for pycurl.XFERINFOFUNCTION
+
+    Only when someone is watching. The meter redraws with \r, which is right
+    on a terminal and useless in a file: a roll downloads several files and
+    the result is thousands of Progress: lines interleaved with the output
+    that matters -- the repos that failed, the apps that were skipped, where
+    each lockfile came from. That output is the reason to read a roll log at
+    all, and it is the part that gets buried.
+    """
+    if not stream.isatty():
+        return
     stream.write('Progress: {}/{} kiB ({}%)\r'.format(str(int(download_d / KB)), str(int(download_t / KB)),
                                                       str(int(download_d / download_t * 100) if download_t > 0 else 0)))
     stream.flush()
@@ -289,68 +299,28 @@ def get_flutter_sdk_version() -> str:
         return flutter_version
 
 
-def test_internet_connection() -> bool:
-    """Test internet by connecting to nameserver"""
-    import pycurl
+def test_internet_connection(host='storage.googleapis.com', port=443,
+                             timeout=5) -> bool:
+    """Can the roll reach what it needs?
 
-    c = pycurl.Curl()
-    c.setopt(pycurl.URL, "https://dns.google")
-    c.setopt(pycurl.FOLLOWLOCATION, 0)
-    c.setopt(pycurl.CONNECTTIMEOUT, 5)
-    c.setopt(pycurl.NOSIGNAL, 1)
-    c.setopt(pycurl.NOPROGRESS, 1)
-    c.setopt(pycurl.NOBODY, 1)
+    A plain socket connect rather than pycurl. pycurl is still required --
+    fetch_https_binary_file() downloads releases_linux.json with it -- but a
+    reachability probe does not need it, and importing it here made a missing
+    pycurl fail at the connectivity check rather than at the download, which
+    reads like a network problem instead of a missing dependency.
+
+    Aimed at the host the roll actually uses, rather than at a general-purpose
+    nameserver: a check that passes while the endpoint the work depends on is
+    unreachable is worse than no check.
+    """
+    import socket
+
     try:
-        c.perform()
-    except pycurl.error as e:
-        error_code, message = e
-        print(f'pycurl exception: {error_code}: {message}')
-        pass
-
-    res = False
-    if c.getinfo(pycurl.RESPONSE_CODE) == 200:
-        res = True
-
-    return res
-
-
-# Phrases that identify a license, matched against the file's text with
-# whitespace collapsed. Titles are spelled without the comma that the
-# cross-references use ("Apache License Version 2.0" as a heading, versus
-# "the GNU Lesser General Public License, Version 2.1" where MPL-2.0 names its
-# secondary licenses) so that naming a license does not read as being it.
-_LICENSE_MARKERS = [
-    ('Apache-2.0',   (('apache license version 2.0',), ())),
-    ('GPL-3.0',      (('gnu general public license version 3',), ())),
-    ('GPL-2.0',      (('gnu general public license version 2',), ())),
-    ('LGPL-3.0',     (('gnu lesser general public license version 3',), ())),
-    ('LGPL-2.1',     (('gnu lesser general public license version 2.1',), ())),
-    ('MPL-2.0',      (('mozilla public license version 2.0',), ())),
-    # BSD-3-Clause is BSD-2-Clause plus non-endorsement, so the two-clause form
-    # is only itself when the third clause is absent.
-    ('BSD-3-Clause', (('redistribution and use in source and binary forms',
-                       'neither the name'), ())),
-    ('BSD-2-Clause', (('redistribution and use in source and binary forms',),
-                      ('neither the name',))),
-    # The SIL Open Font License opens with the same sentence as MIT but grants
-    # over "the Font Software"; flutter/games ships both, so MIT has to key on
-    # its own object to avoid claiming every font license as MIT.
-    ('OFL-1.1',      (('sil open font license',), ())),
-    ('MIT',          (('free of charge, to any person obtaining a copy of this software',), ())),
-    ('ISC',          (('permission to use, copy, modify, and/or distribute this software',), ())),
-]
-
-# Families where the license file alone cannot settle the identifier. A project
-# shipping the GPL ships the same COPYING whether it is "version 3 only" or
-# "version 3 or later" -- that distinction lives in the per-file headers, and
-# the license text's own appendix always shows the or-later wording. So detect
-# the family and accept either variant rather than guess.
-_LICENSE_FAMILIES = {
-    'GPL-3.0':  ('GPL-3.0-only', 'GPL-3.0-or-later'),
-    'GPL-2.0':  ('GPL-2.0-only', 'GPL-2.0-or-later'),
-    'LGPL-3.0': ('LGPL-3.0-only', 'LGPL-3.0-or-later'),
-    'LGPL-2.1': ('LGPL-2.1-only', 'LGPL-2.1-or-later'),
-}
+        with socket.create_connection((host, port), timeout=timeout):
+            return True
+    except OSError as e:
+        print(f'no connection to {host}:{port}: {e}')
+        return False
 
 
 def detect_licenses(license_path: str) -> list:

--- a/tools/tests/test_common.py
+++ b/tools/tests/test_common.py
@@ -1,0 +1,39 @@
+# SPDX-License-Identifier: MIT
+"""The roll's connectivity probe and its progress meter."""
+import io
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import common  # noqa: E402
+
+
+def test_no_connection_reports_false_without_raising(capsys):
+    # 203.0.113.0/24 is TEST-NET-3: reserved, never routable
+    assert common.test_internet_connection('203.0.113.1', 9, timeout=1) is False
+    assert 'no connection to' in capsys.readouterr().out
+
+
+def test_the_probe_needs_no_pycurl():
+    import inspect
+    src = inspect.getsource(common.test_internet_connection)
+    assert 'pycurl' not in src.split('"""')[2]
+
+
+def test_progress_is_silent_when_not_a_terminal(monkeypatch):
+    # a roll redirected to a file wrote thousands of \r-terminated meter lines
+    # over the output that matters
+    buf = io.StringIO()
+    monkeypatch.setattr(common, 'stream', buf)
+    common.fetch_https_progress(1000, 500, 0, 0)
+    assert buf.getvalue() == ''
+
+
+def test_progress_still_draws_on_a_terminal(monkeypatch):
+    class Tty(io.StringIO):
+        def isatty(self):
+            return True
+    buf = Tty()
+    monkeypatch.setattr(common, 'stream', buf)
+    common.fetch_https_progress(1024000, 512000, 0, 0)
+    assert 'Progress:' in buf.getvalue() and '50%' in buf.getvalue()


### PR DESCRIPTION
Addresses #889 — with one correction to what I claimed there.

## The progress flood is pycurl, not git

I attributed it to `git clone` in the issue. It is `fetch_https_progress` (`common.py:183`), pycurl's download callback, redrawing with `\r`. The two interleave in the log, which is how I got it wrong.

On a terminal the meter is right. In a file it is thousands of lines over the output that matters — which repos failed, which apps were skipped, where each lockfile came from. That output is the reason to read a roll log at all. It now draws only when stdout is a terminal.

## pycurl cannot be dropped

I also claimed in #889 it was "used for exactly one thing". Wrong: `fetch_https_binary_file()` downloads `releases_linux.json` and the version files with it. It is mandatory.

What changed is that the *connectivity probe* no longer imports it. A reachability check does not need pycurl, and importing it there meant a missing pycurl failed at the connectivity check rather than at the download — reading like a network problem rather than a missing dependency, which is exactly how it misled me.

The probe now also targets `storage.googleapis.com`, the host the roll actually uses, rather than a general-purpose nameserver. A check that passes while the endpoint the work depends on is unreachable is worse than no check.

## Requirements are written down

```
pip install pycurl pyyaml
```

Both mandatory; `pycurl` needs libcurl headers. CI never caught this because the tools suite does not import the roll's entry point — so a fresh virtualenv following the README failed immediately, as mine did.

## Tests

Four new: an unroutable address reports False without raising (TEST-NET-3, so it cannot accidentally succeed), the probe's body contains no pycurl, the meter is silent off-tty, and it still draws on one. `95 passed`.