### PR TITLE
roll: vendor the pub cache for hand-written recipes too

### DIFF
--- a/meta-flutter-apps/conf/flutter-apps.json
+++ b/meta-flutter-apps/conf/flutter-apps.json
@@ -420,5 +420,19 @@
                 "\nSRC_URI[model_file.sha256sum] = \"cbdecd08b44c5dea3821f77c5468e2936ecfbf43cde0795a2729fdb43401e58b\""
             ]
         }
-    }   
+    }   ,
+    {
+        "uri": "https://github.com/flatpak-minimal/appstream_dart.git",
+        "branch": "main",
+        "rev": "c44e741569f4fb5d6f9dd5bdc6960d91314b174c",
+        "license_file": "LICENSE",
+        "license_type": "Apache-2.0",
+        "author": "Joel Winarske",
+        "folder": "third-party",
+        "pubvendor": true,
+        "generate_recipes": false,
+        "ignore": [
+            ""
+        ]
+    }
 ]

--- a/tools/README.md
+++ b/tools/README.md
@@ -81,6 +81,19 @@ An app declaring `resolution: workspace` has no lockfile of its own; the roll
 follows the `workspace` list to the root and uses the one there, and says
 `(pub workspace)`. See `tools/pubvendor/README.md`.
 
+### Hand-written recipes that vendor
+
+The generator only ever emits `inherit flutter-app` or `inherit flutter-web`. A
+recipe that needs anything else -- `flutter-app-native`, an extra task, a
+`do_install:append` -- has to be written by hand, and generating over it would
+quietly drop whatever made it work.
+
+`"generate_recipes": false` covers that case: the roll clones the repository and
+regenerates the app's `-pubcache.inc` and `-pubspec.lock` against the pinned SDK,
+and writes no recipe. Without it a vendored fragment ages silently against a
+moving SDK, and the eventual failure is a `PUBSPEC_LOCK_SHA256` mismatch that
+says nothing about why.
+
 ### Flutter SDK apps
 
 The apps the SDK itself ships have no manifest entry and no SRCREV: they move
@@ -120,6 +133,7 @@ skip past.
 | `output_folder`, `variables`, `src_folder`, `src_files`, `entry_files` | per-app recipe overrides |
 | `compiler_requires_network` | apps whose build hooks fetch |
 | `pubvendor` | `true` to vendor the pub cache, `"resolve"` to always replace a committed lockfile |
+| `generate_recipes` | `false` for a repository whose recipes are hand-written; the roll still vendors its pub cache |
 
 ## Requirements
 

--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -380,7 +380,8 @@ def create_recipe(directory,
                   src_files,
                   variables,
                   patch_dir,
-                  pubvendor=False) -> str:
+                  pubvendor=False,
+                  generate_recipes=True) -> str:
     is_web = False
     # TODO detect web
 
@@ -423,6 +424,14 @@ def create_recipe(directory,
             recipe_name=recipe_name,
             output_path=output_path,
             always_resolve=(pubvendor == 'resolve'))
+
+    # An app whose recipe is maintained by hand, but whose vendored pub cache
+    # should still follow the pinned SDK. The generator emits `inherit
+    # flutter-app` and nothing else -- no flutter-app-native, no extra tasks --
+    # so generating over such a recipe would quietly drop whatever made it work.
+    # Vendor the cache, leave the recipe alone.
+    if not generate_recipes:
+        return ''
 
     if project_version is not None:
         version = project_version.split('+')
@@ -611,7 +620,8 @@ def create_yocto_recipes(directory,
                          entry_files,
                          variables,
                          patch_dir,
-                         pubvendor=False):
+                         pubvendor=False,
+                         generate_recipes=True):
     """Create bb recipe for each pubspec.yaml file in path"""
     import glob
 
@@ -708,7 +718,8 @@ def create_yocto_recipes(directory,
                                src_files=src_files,
                                variables=variables,
                                patch_dir=patch_dir,
-                               pubvendor=pubvendor)
+                               pubvendor=pubvendor,
+                               generate_recipes=generate_recipes)
 
         if recipe != '':
             recipes.append([recipe, flutter_application_path])

--- a/tools/roll_meta_flutter.py
+++ b/tools/roll_meta_flutter.py
@@ -60,7 +60,8 @@ def get_repo(repo_path: str, output_path: str,
              entry_files: dict,
              variables: dict,
              patch_dir: str,
-             pubvendor: bool = False):
+             pubvendor: bool = False,
+             generate_recipes: bool = True):
     """ Clone Git Repo """
 
     print(f'repo_path: {repo_path}')
@@ -204,7 +205,8 @@ def get_repo(repo_path: str, output_path: str,
                          entry_files=entry_files,
                          variables=variables,
                          patch_dir=patch_dir,
-                         pubvendor=pubvendor)
+                         pubvendor=pubvendor,
+                         generate_recipes=generate_recipes)
 
 
 def get_workspace_repos(repo_path, repos, output_path, package_output_path, patch_dir):
@@ -231,6 +233,7 @@ def get_workspace_repos(repo_path, repos, output_path, package_output_path, patc
                                     output_path_override_list=r.get('output_folder'),
                                     compiler_requires_network_list=r.get('compiler_requires_network'),
                                     pubvendor=r.get('pubvendor', False),
+                                    generate_recipes=r.get('generate_recipes', True),
                                     src_folder=r.get('src_folder'),
                                     src_files=r.get('src_files'),
                                     entry_files=r.get('entry_files'),

--- a/tools/tests/test_generate_pubcache_inc.py
+++ b/tools/tests/test_generate_pubcache_inc.py
@@ -104,3 +104,35 @@ def test_the_lockfile_is_shipped_beside_the_fragment(app):
     shipped = out / 'probe-pubspec.lock'
     assert shipped.exists()
     assert shipped.read_text() == (app_dir / 'pubspec.lock').read_text()
+
+
+def test_vendor_only_leaves_the_recipe_alone(app, monkeypatch, tmp_path):
+    """An app whose recipe is hand-written but whose cache the roll maintains.
+
+    The generator only ever emits `inherit flutter-app`, so generating over a
+    recipe that inherits flutter-app-native, or carries extra tasks, silently
+    drops whatever made it work. generate_recipes=False vendors the cache and
+    writes no recipe. See #888.
+    """
+    import create_recipes
+    app_dir, out = app
+    (app_dir / 'pubspec.yaml').write_text('name: probe\nversion: 1.0.0\n')
+
+    result = create_recipes.create_recipe(
+        directory=str(app_dir.parent),
+        pubspec_yaml=str(app_dir / 'pubspec.yaml'),
+        flutter_application_path='app',
+        org='o', unit='u', submodules=False,
+        url='https://example.invalid/x.git', lfs=False, branch='main',
+        commit='deadbeef',
+        license_file=None, license_type='CLOSED', license_md5='',
+        author='x', recipe_folder='third-party', output_path=str(out),
+        rdepends_list=None, output_path_override_list=None,
+        compiler_requires_network_list=None, src_folder=None, src_files=None,
+        variables=None, patch_dir=None, pubvendor=True,
+        generate_recipes=False)
+
+    assert result == ''
+    assert not list(out.rglob('*.bb')), 'a recipe was written despite generate_recipes=False'
+    assert list(out.rglob('*-pubcache.inc')), 'the fragment was not vendored'
+    assert list(out.rglob('*-pubspec.lock')), 'the lockfile was not shipped'


### PR DESCRIPTION
Closes #888.

`flatpak-minimal-appstream-dart-flathub-catalog` is the one app on the vendored path and had **no manifest entry at all**. Its `-pubcache.inc` and `-pubspec.lock` were generated by hand when the opt-in landed, so nothing regenerates them against a moving SDK. The fragment carries `PUBSPEC_LOCK_SHA256` and `pub-cache.bbclass` fails the build on a mismatch — a check that is right, but whose eventual failure is a checksum error saying nothing about a fragment several SDK bumps old.

## The obvious fix does not work

I proposed on #888 that it just needed `"pubvendor": true`. Checking the generator first showed that would have been destructive:

```
create_recipes.py:534   inherit flutter-web
create_recipes.py:536   inherit flutter-app     ← the only two it emits
```

Nothing skips an app with an existing hand-written recipe, so the roll would have written over one that inherits `flutter-app-native`, injects a `hooks:` section so sqlite3 resolves from the system instead of downloading a prebuilt libsqlite3, declares `DEPENDS`/`RDEPENDS` on sqlite3, and symlinks the library into the bundle. That is the recipe #862 took four CI rounds to get right.

## So separate the two jobs

`"generate_recipes": false` clones the repository, regenerates the fragment and lockfile against the pinned SDK, and writes no recipe.

That is the shape `sdk_apps.py` already uses for the SDK's own apps — a fragment the roll maintains without the roll owning the recipes. Reusing it here rather than inventing a second mechanism.

The entry pins the same `rev` the recipe does, and ignores the repository root, which is a package rather than an app.

## Tests

One new, asserting both halves of the contract: **no `.bb` written anywhere**, and the fragment *and* lockfile both produced. Testing only the first would pass if vendoring silently stopped working.

`96 passed`. Six deleted lines, all signature reflow from threading the flag.

Tools and manifest only, so no machine builds.