### PR TITLE
tools: declare the roll's dependencies where they can be checked

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -38,7 +38,12 @@ jobs:
           python-version: ${{ matrix.python }}
 
       - name: 📦 Install Dependencies
-        run: python -m pip install --disable-pip-version-check pytest pyyaml
+        # From the file, not a second hand-kept list. The two drifted before:
+        # the README named pycurl and pyyaml, CI installed pytest and pyyaml,
+        # and certifi -- which the roll actually needs -- was in neither.
+        run: |
+          python -m pip install --disable-pip-version-check pytest
+          python -m pip install --disable-pip-version-check -r tools/requirements.txt
 
       - name: 🧪 Run tools test suites
         # Discovers every tests/ dir under tools/, so a new tool with tests

--- a/tools/README.md
+++ b/tools/README.md
@@ -139,11 +139,17 @@ skip past.
 
 Python 3.10 or newer, and:
 
-    pip install pycurl pyyaml
+    pip install -r tools/requirements.txt
 
-`pycurl` downloads `releases_linux.json` and the version files; `pyyaml` reads
-every `pubspec.yaml`. Neither is optional, and `pycurl` needs libcurl headers
-to build (`libcurl4-openssl-dev` on Debian, `libcurl-devel` on Fedora).
+`pycurl` and `certifi` download `releases_linux.json` and the version files;
+`pyyaml` reads every `pubspec.yaml`. None is optional, and `pycurl` needs
+libcurl headers to build (`libcurl4-openssl-dev` on Debian, `libcurl-devel` on
+Fedora).
+
+The list is checked against the code: `tools/tests/test_requirements.py` walks
+every import under `tools/` and fails if one is missing from the file, or if
+the file names something nothing imports. A hand-kept list drifted twice before
+that existed.
 
 The roll also needs `git`, and `flutter` on `PATH` for any app that sets
 `"pubvendor"` -- at the version this layer pins, since that is what the

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,0 +1,14 @@
+# What the roll needs, beyond the standard library.
+#
+# Kept honest by tools/tests/test_requirements.py, which walks every import in
+# tools/ and fails if one is missing here. Written by hand this list was
+# already wrong: the README named pycurl and pyyaml and omitted certifi, which
+# get_version_files() reaches through get_engine_commit().
+#
+# pycurl needs libcurl headers to build:
+#   Debian/Ubuntu  libcurl4-openssl-dev
+#   Fedora         libcurl-devel
+
+certifi
+pycurl
+PyYAML

--- a/tools/tests/test_requirements.py
+++ b/tools/tests/test_requirements.py
@@ -1,0 +1,61 @@
+# SPDX-License-Identifier: MIT
+"""requirements.txt has to describe what the code actually imports.
+
+Hand-maintained dependency lists drift, and this one had: the README named
+pycurl and pyyaml while get_engine_commit() also needs certifi, and CI
+installed a third set again. Nothing noticed, because pycurl and certifi are
+imported inside functions -- importing a module does not fail without them, so
+the tests passed and a fresh virtualenv did not. See #889.
+"""
+import ast
+import pathlib
+import sys
+
+TOOLS = pathlib.Path(__file__).resolve().parent.parent
+
+# import name -> distribution name, where they differ
+DISTRIBUTION = {'yaml': 'pyyaml'}
+
+
+def _declared():
+    lines = (TOOLS / 'requirements.txt').read_text().splitlines()
+    return {l.strip().lower() for l in lines
+            if l.strip() and not l.startswith('#')}
+
+
+def _imported():
+    stdlib = set(sys.stdlib_module_names)
+    local = {p.stem for p in TOOLS.rglob('*.py')}
+    found = set()
+    for path in TOOLS.rglob('*.py'):
+        if 'tests' in path.parts:
+            continue
+        tree = ast.parse(path.read_text(), str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    found.add(alias.name.split('.')[0])
+            elif isinstance(node, ast.ImportFrom) and node.module and not node.level:
+                found.add(node.module.split('.')[0])
+    return {DISTRIBUTION.get(m, m) for m in found - stdlib - local}
+
+
+def test_every_third_party_import_is_declared():
+    missing = _imported() - _declared()
+    assert not missing, (
+        f'imported by tools/ but absent from requirements.txt: {sorted(missing)}')
+
+
+def test_nothing_declared_is_unused():
+    # a dependency nobody imports is one someone installs for no reason, and a
+    # hint that the code it supported has gone
+    unused = _declared() - _imported()
+    assert not unused, (
+        f'in requirements.txt but imported nowhere: {sorted(unused)}')
+
+
+def test_the_scan_actually_finds_things():
+    # a scan that silently returns nothing would make both tests above vacuous
+    found = _imported()
+    assert found, 'the import scan found nothing, so it is not checking anything'
+    assert 'pycurl' in found, 'pycurl is imported inside functions and must still be found'


### PR DESCRIPTION
Answering the question #890 left open: document them, or generate a file? **Generate a file** — because documenting had already failed, and I proved it by writing the documentation.

## Three lists, no two alike

| where | contents |
|---|---|
| `tools/README.md` (written in #890) | `pycurl pyyaml` |
| `.github/workflows/tools-tests.yml` | `pytest pyyaml` |
| what `tools/` actually imports | `certifi pycurl yaml` |

**`certifi` was in neither list.** It is on the roll's critical path — `get_version_files()` submits `get_engine_commit()`, which calls `certifi.where()` to give pycurl a CA bundle. A fresh virtualenv following the README gets through the connectivity check and fails downloading the version files.

## Why a smoke test would not have caught it

`pycurl` and `certifi` are imported *inside* functions, so `import roll_meta_flutter` succeeds without them. `test_roll_meta_flutter.py` already imports the entry point and passes — which is precisely why CI was green while a fresh virtualenv was broken.

## What actually closes it

`tools/requirements.txt` as the single source, and `test_requirements.py` walking every import under `tools/` to check it both ways:

- imported but not declared → fail, naming what is missing
- declared but imported nowhere → fail, since that is a dependency installed for no reason and a hint the code it supported is gone
- and a third test asserting the scan finds `pycurl`, because a scan that silently returned nothing would make the other two vacuous

Verified it catches the real drift: deleting `certifi` from the file fails with

```
AssertionError: imported by tools/ but absent from requirements.txt: ['certifi']
```

CI now installs from the file instead of keeping its own list.

`99 passed`. Tools only, so no machine builds.