### PR TITLE
roll: follow path dependencies when gating on the pinned SDK

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -59,6 +59,20 @@ reason rather than generating a recipe that fails to build later:
   packages/foo/example: needs Dart >=3.20.0 <4.0.0, this layer pins Dart 3.13.1
 ```
 
+Dependencies by path are followed too, transitively: an app can declare a range
+the pinned SDK satisfies and still fail to resolve because something beside it
+in the same repository does not. That is the monorepo case, and it costs
+nothing to check because those pubspecs are already on disk. The reason names
+the dependency:
+
+```
+  foo/example: depends on foo_core by path, which needs Dart >=2.17.0 <3.0.0,
+               this layer pins Dart 3.13.2
+```
+
+Dependencies from pub are not followed -- knowing whether those resolve needs a
+real `pub get`, which the roll does not run for every app.
+
 This is deliberately conservative: a constraint it cannot parse, a missing
 `environment`, or an unknown pinned version all mean *do not skip*. A gate that
 misfires drops an app silently, which is worse than the build failure it

--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -667,6 +667,15 @@ def create_yocto_recipes(directory,
 
         reason = sdk_constraint.excluded_reason(
             yaml_obj, pinned_flutter, pinned_dart)
+        if not reason:
+            # An app can declare a range the pinned SDK satisfies and still
+            # fail to resolve because something it depends on does not. In
+            # general that needs a real pub get, which the roll cannot afford
+            # per app; dependencies by path are the exception, since their
+            # pubspecs are already on disk. See #850.
+            reason = sdk_constraint.path_dependency_reason(
+                os.path.dirname(filename), yaml_obj,
+                pinned_flutter, pinned_dart, get_yaml_obj)
         if reason:
             incompatible.append((os.path.relpath(filename, directory), reason))
             continue

--- a/tools/sdk_constraint.py
+++ b/tools/sdk_constraint.py
@@ -128,6 +128,55 @@ def excluded_reason(yaml_obj, flutter_version, dart_version):
     return None
 
 
+def path_dependency_reason(app_dir, spec, flutter_version, dart_version,
+                           read_yaml, _seen=None):
+    """Why a path dependency of this app excludes the pinned SDK, or None.
+
+    An app can declare a range the pinned SDK satisfies and still fail to
+    resolve, because something it depends on does not. Detecting that in
+    general needs a real `pub get`, which the roll cannot afford for every app.
+
+    Dependencies by path are the exception: they live in the same repository,
+    their pubspecs are already on disk, and reading them costs nothing. That
+    covers the monorepo case, which is most of what the manifest tracks -- an
+    app beside a package that has not been updated for the current Dart.
+
+    Followed transitively, since a path dependency may have its own, with a
+    visited set because they can be mutually referential.
+    """
+    if _seen is None:
+        _seen = set()
+    app_dir = os.path.realpath(app_dir)
+    if app_dir in _seen:
+        return None
+    _seen.add(app_dir)
+
+    deps = (spec or {}).get('dependencies')
+    if not isinstance(deps, dict):
+        return None
+
+    for name, value in sorted(deps.items()):
+        if not isinstance(value, dict) or 'path' not in value:
+            continue
+        dep_dir = os.path.normpath(os.path.join(app_dir, str(value['path'])))
+        pubspec = os.path.join(dep_dir, 'pubspec.yaml')
+        if not os.path.isfile(pubspec):
+            # A path that does not resolve is a problem for pub, not for this
+            # gate; saying so here would be guessing at a different failure.
+            continue
+        dep_spec = read_yaml(pubspec)
+        if not dep_spec:
+            continue
+        reason = excluded_reason(dep_spec, flutter_version, dart_version)
+        if reason:
+            return f'depends on {name} by path, which {reason}'
+        deeper = path_dependency_reason(dep_dir, dep_spec, flutter_version,
+                                        dart_version, read_yaml, _seen)
+        if deeper:
+            return f'depends on {name} by path, which {deeper}'
+    return None
+
+
 def pinned_versions(layer_root=None):
     """(flutter, dart) this layer pins, either possibly None.
 

--- a/tools/tests/test_sdk_constraint.py
+++ b/tools/tests/test_sdk_constraint.py
@@ -115,3 +115,80 @@ def test_pinned_versions_reads_the_layer():
     flutter, dart = sc.pinned_versions()
     assert flutter and dart
     assert sc.parse_version(flutter) and sc.parse_version(dart)
+
+
+# --- path dependencies (#850 case 2) -----------------------------------------
+
+def _repo(tmp_path, app_env, dep_env, dep_rel='../pkg'):
+    import yaml
+    app = tmp_path / 'app'
+    pkg = tmp_path / 'pkg'
+    app.mkdir(); pkg.mkdir()
+    (app / 'pubspec.yaml').write_text(yaml.safe_dump({
+        'name': 'app', 'environment': {'sdk': app_env},
+        'dependencies': {'pkg': {'path': dep_rel}}}))
+    (pkg / 'pubspec.yaml').write_text(yaml.safe_dump({
+        'name': 'pkg', 'environment': {'sdk': dep_env}}))
+    return app
+
+
+def _read(p):
+    import yaml
+    return yaml.safe_load(open(p))
+
+
+def _reason(app):
+    return sc.path_dependency_reason(str(app), _read(app / 'pubspec.yaml'),
+                                     '3.47.1', '3.13.1', _read)
+
+
+def test_an_incompatible_path_dependency_excludes_the_app(tmp_path):
+    # the app itself is fine; what it depends on is not, and only a resolve
+    # would otherwise find that
+    app = _repo(tmp_path, '^3.11.0-0', '>=2.17.0 <3.0.0')
+    r = _reason(app)
+    assert r is not None
+    assert 'depends on pkg by path' in r and 'Dart' in r
+
+
+def test_a_compatible_path_dependency_is_not_an_exclusion(tmp_path):
+    assert _reason(_repo(tmp_path, '^3.11.0-0', '^3.11.0-0')) is None
+
+
+def test_it_follows_path_dependencies_transitively(tmp_path):
+    import yaml
+    app = _repo(tmp_path, '^3.11.0-0', '^3.11.0-0')
+    deep = tmp_path / 'deep'
+    deep.mkdir()
+    (deep / 'pubspec.yaml').write_text(yaml.safe_dump({
+        'name': 'deep', 'environment': {'sdk': '>=2.16.0 <3.0.0'}}))
+    (tmp_path / 'pkg' / 'pubspec.yaml').write_text(yaml.safe_dump({
+        'name': 'pkg', 'environment': {'sdk': '^3.11.0-0'},
+        'dependencies': {'deep': {'path': '../deep'}}}))
+    r = _reason(app)
+    assert r is not None and 'deep' in r
+
+
+def test_mutually_referential_paths_do_not_recurse_forever(tmp_path):
+    import yaml
+    app = _repo(tmp_path, '^3.11.0-0', '^3.11.0-0')
+    (tmp_path / 'pkg' / 'pubspec.yaml').write_text(yaml.safe_dump({
+        'name': 'pkg', 'environment': {'sdk': '^3.11.0-0'},
+        'dependencies': {'app': {'path': '../app'}}}))
+    assert _reason(app) is None
+
+
+def test_a_path_that_does_not_exist_is_not_our_failure(tmp_path):
+    # pub will complain about it; guessing here would report the wrong problem
+    app = _repo(tmp_path, '^3.11.0-0', '^3.11.0-0', dep_rel='../nowhere')
+    assert _reason(app) is None
+
+
+def test_hosted_dependencies_are_not_followed(tmp_path):
+    import yaml
+    app = tmp_path / 'app'
+    app.mkdir()
+    (app / 'pubspec.yaml').write_text(yaml.safe_dump({
+        'name': 'app', 'environment': {'sdk': '^3.11.0-0'},
+        'dependencies': {'http': '^1.0.0', 'flutter': {'sdk': 'flutter'}}}))
+    assert _reason(app) is None


### PR DESCRIPTION
Case (2) of #850 — an app that declares a range the pinned SDK satisfies and still fails to resolve, because something it depends on does not.

Detecting that in general needs a real `pub get`, which the roll cannot afford across 24 repositories, most of them monorepos. **Dependencies by path are the exception**: they live in the same repository, their pubspecs are already on disk, and reading them costs nothing.

That covers the shape the manifest mostly tracks — an app beside a package nobody updated for the current Dart. The reason names the dependency, so the skip points at what to fix:

```
foo/example: depends on foo_core by path, which needs Dart >=2.17.0 <3.0.0,
             this layer pins Dart 3.13.2
```

Followed transitively, since a path dependency may have its own.

## Real-world check

Scanned the Flutter SDK at the pinned release: **87 pubspecs, 7 with path dependencies, 0 excluded** — correct, and evidence it does not over-exclude, which is the failure mode that matters for a gate.

## Tests

Seven new, covering both directions and the awkward cases:

- an incompatible path dependency excludes the app, naming it
- a compatible one does not
- transitive: a dependency's own dependency
- **mutually referential paths do not recurse forever**
- a path that does not resolve is left to pub, since guessing here would report the wrong problem
- hosted dependencies are not followed

`102 passed`.

## What is still not covered

Dependencies from pub. Case (2) remains partly open, and #850 should stay open for it. This buys the part that costs nothing; the rest costs a resolve per app, which is worth revisiting when #864's auto-roll exists and nobody is waiting on the run.