### PR TITLE
roll: check that an app's dependencies actually solve

### DIFF
--- a/tools/README.md
+++ b/tools/README.md
@@ -70,8 +70,21 @@ the dependency:
                this layer pins Dart 3.13.2
 ```
 
-Dependencies from pub are not followed -- knowing whether those resolve needs a
-real `pub get`, which the roll does not run for every app.
+Dependencies from pub need a real `pub get` to check, which costs one resolve
+per app. `--resolve-all` turns that on; the roll workflow passes it, and a roll
+someone is watching does not. An app whose dependencies do not solve is skipped
+with pub's own explanation:
+
+```
+  foo/example: dependencies do not solve against the pinned SDK: Because
+               foo/example depends on bar >=2.0.0 which requires SDK version
+               >=3.20.0, version solving failed.
+```
+
+Only pub saying the graph cannot be satisfied counts. A network failure, a
+timeout, no `flutter` on `PATH`, or output that matches neither shape all mean
+*do not skip* -- a roll that dropped apps because pub.dev blinked would be
+worse than one that does not check.
 
 This is deliberately conservative: a constraint it cannot parse, a missing
 `environment`, or an unknown pinned version all mean *do not skip*. A gate that

--- a/tools/create_recipes.py
+++ b/tools/create_recipes.py
@@ -239,6 +239,65 @@ def copy_src_file(file: str, src_folder: str, patch_dir: str, output_path: str):
     shutil.copy2(src_file, dst_file)
 
 
+# Markers pub prints when it has decided the graph cannot be satisfied, as
+# opposed to when it could not find out. Only the first kind is a reason to
+# skip an app: the second means the roll could not tell, and dropping an app on
+# "could not tell" is the misfire this whole family of gates has to avoid.
+_UNSOLVABLE = (
+    'version solving failed',
+    'requires sdk version',
+    'doesn\'t support null safety',
+)
+_CANNOT_TELL = (
+    'socketexception', 'connection', 'could not resolve host', 'timed out',
+    'temporary failure', 'network is unreachable', 'failed host lookup',
+)
+
+
+def resolve_check(app_dir, recipe_name, timeout=300):
+    """Does this app's dependency graph actually solve against the pinned SDK?
+
+    The static gate reads declared constraints, which catches an app that says
+    outright it needs a different Dart. It cannot catch an app that declares a
+    range the pinned SDK satisfies and still fails to resolve, because a
+    dependency of a dependency does not -- for that, something has to run pub.
+
+    Returns a reason when pub says the graph cannot be satisfied, and None
+    otherwise. None also covers every case where the answer is unknown: no
+    flutter on PATH, a network failure, a timeout, output that does not match
+    either shape. A roll that drops apps because pub.dev was briefly
+    unreachable would be worse than one that does not check at all.
+    """
+    import shutil
+    import subprocess
+
+    if shutil.which('flutter') is None:
+        return None
+    try:
+        r = subprocess.run(['flutter', '--suppress-analytics', 'pub', 'get'],
+                           cwd=app_dir, capture_output=True, text=True,
+                           timeout=timeout)
+    except (subprocess.TimeoutExpired, OSError) as e:
+        print(f'NOTE: {recipe_name}: could not resolve ({e}); not treating that '
+              f'as incompatible')
+        return None
+    if r.returncode == 0:
+        return None
+
+    blob = f'{r.stdout}\n{r.stderr}'.lower()
+    if any(m in blob for m in _CANNOT_TELL):
+        print(f'NOTE: {recipe_name}: resolve failed for a reason that is not the '
+              f'app; not treating that as incompatible')
+        return None
+    if any(m in blob for m in _UNSOLVABLE):
+        first = next((l.strip() for l in f'{r.stdout}\n{r.stderr}'.splitlines()
+                      if l.strip().startswith('Because')), '')
+        return f'dependencies do not solve against the pinned SDK{": " + first if first else ""}'
+    print(f'NOTE: {recipe_name}: pub get failed but said nothing about solving; '
+          f'not treating that as incompatible\n{r.stderr.strip()[:300]}')
+    return None
+
+
 def workspace_root_for(app_dir):
     """The pub workspace root this app belongs to, or None if it is not a member.
 
@@ -621,7 +680,8 @@ def create_yocto_recipes(directory,
                          variables,
                          patch_dir,
                          pubvendor=False,
-                         generate_recipes=True):
+                         generate_recipes=True,
+                         resolve_all=False):
     """Create bb recipe for each pubspec.yaml file in path"""
     import glob
 
@@ -669,13 +729,20 @@ def create_yocto_recipes(directory,
             yaml_obj, pinned_flutter, pinned_dart)
         if not reason:
             # An app can declare a range the pinned SDK satisfies and still
-            # fail to resolve because something it depends on does not. In
-            # general that needs a real pub get, which the roll cannot afford
-            # per app; dependencies by path are the exception, since their
-            # pubspecs are already on disk. See #850.
+            # fail to resolve because something it depends on does not.
+            # Dependencies by path are free to check, since their pubspecs are
+            # already on disk. See #850.
             reason = sdk_constraint.path_dependency_reason(
                 os.path.dirname(filename), yaml_obj,
                 pinned_flutter, pinned_dart, get_yaml_obj)
+        if not reason and resolve_all:
+            # Dependencies from pub are not free: knowing whether those solve
+            # means running pub, once per app. Off by default so a roll being
+            # watched stays quick, on for the unattended one, where the time
+            # costs nobody anything and an unexplained build failure costs
+            # most.
+            reason = resolve_check(os.path.dirname(filename),
+                                   os.path.relpath(filename, directory))
         if reason:
             incompatible.append((os.path.relpath(filename, directory), reason))
             continue

--- a/tools/roll_meta_flutter.py
+++ b/tools/roll_meta_flutter.py
@@ -61,7 +61,8 @@ def get_repo(repo_path: str, output_path: str,
              variables: dict,
              patch_dir: str,
              pubvendor: bool = False,
-             generate_recipes: bool = True):
+             generate_recipes: bool = True,
+             resolve_all: bool = False):
     """ Clone Git Repo """
 
     print(f'repo_path: {repo_path}')
@@ -206,10 +207,12 @@ def get_repo(repo_path: str, output_path: str,
                          variables=variables,
                          patch_dir=patch_dir,
                          pubvendor=pubvendor,
-                         generate_recipes=generate_recipes)
+                         generate_recipes=generate_recipes,
+                         resolve_all=resolve_all)
 
 
-def get_workspace_repos(repo_path, repos, output_path, package_output_path, patch_dir):
+def get_workspace_repos(repo_path, repos, output_path, package_output_path,
+                        patch_dir, resolve_all=False):
     """ Clone GIT repos referenced in config repos dict to base_folder """
 
     import concurrent.futures
@@ -234,6 +237,7 @@ def get_workspace_repos(repo_path, repos, output_path, package_output_path, patc
                                     compiler_requires_network_list=r.get('compiler_requires_network'),
                                     pubvendor=r.get('pubvendor', False),
                                     generate_recipes=r.get('generate_recipes', True),
+                                    resolve_all=resolve_all,
                                     src_folder=r.get('src_folder'),
                                     src_files=r.get('src_files'),
                                     entry_files=r.get('entry_files'),
@@ -402,6 +406,12 @@ def main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument('--channel', default='stable', type=str, help='Flutter Channel - beta, dev, stable')
+    parser.add_argument('--resolve-all', action='store_true',
+                        help='run pub get for every app, not only those that '
+                             'vendor, so an app whose dependencies do not solve '
+                             'against the pinned SDK is skipped rather than '
+                             'generated. Costs one resolve per app; meant for '
+                             'the unattended roll.')
     parser.add_argument('--version', default=None, type=str, help='Flutter SDK version')
     parser.add_argument('--path', default='.', type=str, help='meta-flutter root path')
     parser.add_argument('--json', default=None, type=str,
@@ -499,7 +509,8 @@ def main():
     output_path = os.path.join(args.path, 'meta-flutter-apps')
     make_sure_path_exists(output_path)
 
-    get_workspace_repos(repo_path, repos, output_path, package_output_path, args.patch_dir)
+    get_workspace_repos(repo_path, repos, output_path, package_output_path,
+                        args.patch_dir, resolve_all=args.resolve_all)
 
     clear_folder(repo_path)
 

--- a/tools/tests/test_resolve_check.py
+++ b/tools/tests/test_resolve_check.py
@@ -1,0 +1,84 @@
+# SPDX-License-Identifier: MIT
+"""Running pub to find out whether an app's dependencies actually solve.
+
+The static gate reads declared constraints. This catches the case it cannot:
+an app that declares a range the pinned SDK satisfies and still fails to
+resolve because a dependency of a dependency does not. See #850 case (2).
+
+Every test here is about the same risk: a roll must not drop an app because
+pub.dev was briefly unreachable. Anything that is not clearly pub saying "this
+cannot be satisfied" has to mean "do not skip".
+"""
+import os
+import stat
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+import create_recipes  # noqa: E402
+
+
+@pytest.fixture
+def flutter(tmp_path, monkeypatch):
+    """A fake `flutter` whose output and exit code each test chooses."""
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    shim = bin_dir / 'flutter'
+
+    def program(stdout='', stderr='', rc=0):
+        shim.write_text(
+            '#!/bin/sh\n'
+            f'cat <<\'OUT\'\n{stdout}\nOUT\n'
+            f'cat >&2 <<\'ERR\'\n{stderr}\nERR\n'
+            f'exit {rc}\n')
+        shim.chmod(shim.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv('PATH', str(bin_dir), prepend=os.pathsep)
+    return program
+
+
+def test_a_clean_resolve_is_not_a_reason(tmp_path, flutter):
+    flutter(stdout='Got dependencies!', rc=0)
+    assert create_recipes.resolve_check(str(tmp_path), 'app') is None
+
+
+def test_version_solving_failure_is_a_reason(tmp_path, flutter):
+    flutter(stderr='Because app depends on foo >=2.0.0 which requires SDK '
+                   'version >=3.20.0, version solving failed.', rc=1)
+    r = create_recipes.resolve_check(str(tmp_path), 'app')
+    assert r is not None
+    assert 'do not solve' in r
+    assert 'Because app depends on foo' in r
+
+
+@pytest.mark.parametrize('err', [
+    'Got socket error trying to find package foo at https://pub.dev.',
+    'SocketException: Failed host lookup: pub.dev',
+    'Connection closed before full header was received',
+    'pub get failed: connection timed out',
+])
+def test_a_network_failure_is_not_an_incompatibility(tmp_path, flutter, err):
+    # dropping an app because pub.dev blinked would be worse than not checking
+    flutter(stderr=err, rc=1)
+    assert create_recipes.resolve_check(str(tmp_path), 'app') is None
+
+
+def test_an_unrecognised_failure_is_not_an_incompatibility(tmp_path, flutter):
+    flutter(stderr='something nobody has seen before', rc=1)
+    assert create_recipes.resolve_check(str(tmp_path), 'app') is None
+
+
+def test_no_flutter_on_path_is_not_an_incompatibility(tmp_path, monkeypatch):
+    monkeypatch.setenv('PATH', str(tmp_path / 'empty'))
+    assert create_recipes.resolve_check(str(tmp_path), 'app') is None
+
+
+def test_a_hang_is_not_an_incompatibility(tmp_path, monkeypatch):
+    bin_dir = tmp_path / 'bin'
+    bin_dir.mkdir()
+    shim = bin_dir / 'flutter'
+    shim.write_text('#!/bin/sh\nsleep 30\n')
+    shim.chmod(shim.stat().st_mode | stat.S_IEXEC)
+    monkeypatch.setenv('PATH', str(bin_dir), prepend=os.pathsep)
+    assert create_recipes.resolve_check(str(tmp_path), 'app', timeout=1) is None


### PR DESCRIPTION
Case (2) of #850 — the half that needs a real resolve. Stacked on #894, since the flag is only useful once the roll workflow exists to pass it; retarget to `master` when that merges.

The static gate catches an app that says outright it needs a different Dart. #893 added path dependencies, which are free to check. **This is the remainder: dependencies from pub, which cost one `pub get` per app to know about.**

```
foo/example: dependencies do not solve against the pinned SDK: Because
             foo/example depends on bar >=2.0.0 which requires SDK version
             >=3.20.0, version solving failed.
```

## Why it is opt-in

191 generated app recipes, one resolve each. A roll someone is watching should stay quick; the unattended roll from #894 is where the time costs nobody anything and an unexplained build failure costs most. `--resolve-all` is off by default and passed by the workflow.

That is a change of position from what I argued on #850, and #894 is the reason: I deferred this on the grounds that nobody wants to wait 30 extra minutes on a roll they are watching. An unattended roll removes that objection.

## Everything ambiguous means "do not skip"

Only pub saying the graph cannot be satisfied counts. A network error, a timeout, no `flutter` on `PATH`, or output matching neither shape all leave the app alone and print why.

This matters more than the check itself. A wrongly *kept* app fails a build, loudly, with a log. A wrongly *dropped* app just is not there — no error, no trace, and it would look exactly like the 108 hand-written `ignore` paths that this whole family of gates exists to stop accumulating.

So the tests weight that way: one test for a clean resolve, one for a real solving failure, and **six for the ways it must decline** — four network shapes, an unrecognized failure, a missing `flutter`, and a hang.

`114 passed`.

## Not covered

The SDK apps and `appstream_dart` resolve through different paths and are not touched by this. Worth a follow-up if the check proves its worth.
