### PR TITLE
flutter-sdk: make the staged resolution newer than what it resolves

### DIFF
--- a/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
+++ b/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
@@ -184,6 +184,7 @@ do_install:append:class-target () {
 python relativize_dart_package_configs() {
     import json
     import os
+    import time
     import urllib.parse
 
     s_root = os.path.realpath(d.getVar('S'))
@@ -221,6 +222,31 @@ python relativize_dart_package_configs() {
                 json.dump(cfg, f, indent=2)
             bb.note('%s: made %d rootUri entries relative'
                     % (os.path.relpath(path, sdk_root), rewritten))
+
+        # Make the resolution unambiguously newer than what it resolves.
+        #
+        # The flutter tool re-runs `pub get` on packages/flutter_tools when its
+        # package_config.json does not look newer than the pubspec beside it --
+        # and that resolve carries no --offline, so in a task with no network it
+        # hangs until something kills it. Relative rootUris (above) stopped the
+        # paths dangling; they do not say anything about freshness.
+        #
+        # do_install copies with `cp -rT`, which stamps mtimes at copy time in
+        # traversal order, so which of the two ends up newer is not decided by
+        # anything. sstate then preserves whatever it got, which is why the same
+        # SDK can build clean once and hang the next time it is restored.
+        #
+        # Stamp it here instead, after the file is written, and let sstate carry
+        # that.
+        stamp = time.time()
+        for near in (os.path.join(root, os.pardir, 'pubspec.yaml'),
+                     os.path.join(root, os.pardir, 'pubspec.lock')):
+            if os.path.isfile(near):
+                os.utime(near, (stamp - 2, stamp - 2))
+        os.utime(path, (stamp, stamp))
+        graph = os.path.join(root, 'package_graph.json')
+        if os.path.isfile(graph):
+            os.utime(graph, (stamp, stamp))
 }
 do_install[postfuncs] += "relativize_dart_package_configs"
 


### PR DESCRIPTION
#894's CI hit the `flutter_tools` re-resolve again — the stall #865 fixed — on **both** vendored apps:

```
dart pub --directory .../recipe-sysroot-native/.../packages/flutter_tools get --example
[+599795 ms] Running 1 shutdown hook
```

The probes confirm the task is network-isolated, so this is the resolve reaching for pub.dev and waiting, not connectivity.

## Why it came back

#865 made the `rootUri` entries relative, which stopped them dangling in a consuming sysroot. That says nothing about **freshness**, and the tool also re-resolves when `package_config.json` does not look newer than the pubspec beside it.

`do_install` copies with `cp -rT`, which stamps mtimes at copy time in traversal order — so which of the two lands newer is decided by nothing in particular, and sstate preserves whatever it got.

That predicts exactly what happened: **the same 3.47.2 SDK built clean in #886 and hung when #894 restored it from sstate.** Same content, opposite outcomes.

It is also the same shape as #859, where a pubspec appearing newer than its lockfile caused a re-resolve.

## Honest status

**This is hypothesis-driven and unverified.** The mechanism fits every observation — identical stall, identical command, green on a fresh build, red on a restore of the same sstate — but I could not reproduce it locally: the tree that would have shown it was cleaned by the 3.47.2 roll and `rm_work`.

CI is the test. The change is inert if the cause lies elsewhere, and the 600s timeout from #862 means a wrong guess costs ten minutes rather than an hour.

I have been wrong on this code path more than once, so I would rather label it than let a green run imply more than it shows. If it goes green, that is consistent with the hypothesis, not proof of it — the previous build was green too.

Stacked on #894, which it unblocks.