### PR TITLE
flutter-app: stamp the SDK resolution on the way in, not just on the way out

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -40,6 +40,71 @@ PUBSPEC_IGNORE_LOCKFILE ??= "0"
 
 FLUTTER_SDK = "${STAGING_DIR_NATIVE}/usr/share/flutter/sdk"
 
+# The flutter tool re-runs `pub get` on a package whose package_config.json does
+# not look newer than the pubspec beside it. That resolve carries no --offline,
+# so in a task with no network it hangs until something kills it.
+#
+# flutter-sdk stamps the staged SDK so the resolution wins that comparison, but
+# the stamp cannot be relied on to arrive: mtimes are part of a task's output
+# hash only for do_package (see include_timestamps in oe/sstatesig.py), so an
+# mtime-only change to the SDK's do_install produces an identical output hash,
+# hash equivalence calls the task equivalent, and a builder with warm sstate
+# restores the object built before the stamp existed.
+#
+# So stamp it again here, on the way in, where it always runs.
+python flutter_stamp_sdk_resolution() {
+    import os
+
+    sdk_root = d.getVar('FLUTTER_SDK')
+    if not sdk_root or not os.path.isdir(sdk_root):
+        return
+
+    def restamp(path, when):
+        # STAGING_DIR_NATIVE is hardlinked from the sysroot-components tree, so
+        # utime() here would also move the mtime of a file shared with every
+        # other recipe staging this SDK. Break the link first.
+        try:
+            if os.stat(path).st_nlink > 1:
+                tmp = path + '.stamp.tmp'
+                with open(path, 'rb') as src, open(tmp, 'wb') as dst:
+                    dst.write(src.read())
+                os.chmod(tmp, os.stat(path).st_mode & 0o7777)
+                os.replace(tmp, path)
+            os.utime(path, (when, when))
+        except OSError as e:
+            bb.warn('could not stamp %s: %s' % (path, e))
+            return False
+        return True
+
+    stamped = 0
+    for root, dirs, files in os.walk(sdk_root):
+        if 'package_config.json' not in files:
+            continue
+
+        cfg = os.path.join(root, 'package_config.json')
+        pubspecs = [os.path.join(root, os.pardir, n)
+                    for n in ('pubspec.yaml', 'pubspec.lock')]
+        pubspecs = [p for p in pubspecs if os.path.isfile(p)]
+        if not pubspecs:
+            continue
+
+        newest = max(os.stat(p).st_mtime for p in pubspecs)
+        if os.stat(cfg).st_mtime > newest:
+            continue
+
+        when = newest + 2
+        if restamp(cfg, when):
+            stamped += 1
+        graph = os.path.join(root, 'package_graph.json')
+        if os.path.isfile(graph):
+            restamp(graph, when)
+
+    if stamped:
+        bb.note('stamped %d package_config.json file(s) in the staged SDK '
+                'as newer than their pubspec' % stamped)
+}
+do_prepare_recipe_sysroot[postfuncs] += "flutter_stamp_sdk_resolution"
+
 require conf/include/clang-utils.inc
 
 python () {


### PR DESCRIPTION
#897 stamps the staged SDK so each `package_config.json` is newer than the
pubspec beside it, keeping the flutter tool from re-running a `pub get` that
carries no `--offline` and hangs in a task with no network.

That stamp does not reliably arrive. mtimes enter a task's output hash only for
`do_package` -- `include_timestamps` in `oe/sstatesig.py` is set for that task
alone -- so an mtime-only change to the SDK's `do_install` hashes identically to
the code before it, hash equivalence calls the two outputs equivalent, and a
builder with warm sstate restores the object built before the stamp existed.

Every machine in #897's own CI run took that path:

```
bitbake flutter-sdk-native
NOTE: Tasks Summary: Attempted 1305 tasks of which 1305 didn't need to be rerun
```

So stamp it again from `do_prepare_recipe_sysroot`, which runs for every app on
every build and cannot be substituted away by sstate. `STAGING_DIR_NATIVE` is
hardlinked from `sysroot-components`, so the link is broken before mtimes are
touched rather than moving the timestamp of a file shared with every other
recipe staging the same SDK.

Verified against a staged SDK in the failing shape: the config ends up 2s newer,
content is unchanged, the shared inode keeps its own mtime, and a second run is
a no-op.
