### PR TITLE
ci: move the actions off Node 20

### DIFF
--- a/.github/workflows/dunfell-build.yml
+++ b/.github/workflows/dunfell-build.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: ''
 

--- a/.github/workflows/kirkstone-build.yml
+++ b/.github/workflows/kirkstone-build.yml
@@ -70,7 +70,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: ''
 

--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -89,7 +89,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: ''
 

--- a/.github/workflows/roll.yml
+++ b/.github/workflows/roll.yml
@@ -34,7 +34,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -69,7 +69,7 @@ jobs:
 
     steps:
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           path: ''
 

--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -30,10 +30,10 @@ jobs:
         python: ['3.10', '3.13']
     steps:
       - name: 📚 Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: ${{ matrix.python }}
 
@@ -65,7 +65,7 @@ jobs:
         dart: ['3.6', 'stable']
     steps:
       - name: 📚 Git Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: 🎯 Setup Dart
         uses: dart-lang/setup-dart@v1
@@ -73,7 +73,7 @@ jobs:
           sdk: ${{ matrix.dart }}
 
       - name: 🐍 Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.13'
 


### PR DESCRIPTION
Every run warns that `actions/checkout@v4` targets Node 20 and is being forced
onto Node 24.

| action | was | now |
|---|---|---|
| `actions/checkout` | v4 | v5 |
| `actions/setup-python` | v5 | v6 |

`dart-lang/setup-dart@v1` already runs on node24, so it is untouched.

Both bumps require a runner of at least 2.327.1. The self-hosted runner is on
2.336.0; everything else here is GitHub-hosted.
