### PR TITLE
flutter-app: fail when an app ships with its plugins unregistered

### DIFF
--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -554,6 +554,38 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
             flutter_filesystem = ''
             flutter_app_dir = os.path.normpath(f'{source_dir}/{flutter_application_path}')
             dart_plugin_registrant_file = f'{flutter_app_dir}/.dart_tool/flutter_build/dart_plugin_registrant.dart'
+
+            # An app with no plugins gets neither .flutter-plugins-dependencies
+            # nor a generated registrant, so an absent registrant is an ordinary
+            # state and leaving the flags below empty is right. An app that has
+            # plugins for this platform and no registrant is not: the snapshot
+            # is built without registration and the image ships with those
+            # plugins inert -- no error, no missing file, just an app whose
+            # plugins do nothing. Nothing downstream reads it either, so the
+            # only place it shows is the artifact.
+            #
+            # Both files are written by `flutter build`, which has already run
+            # by the time this code executes, so reaching here with a plugin
+            # list and no registrant means that step did not generate it or
+            # something removed it afterwards. Distinguish the two cases rather
+            # than skipping both.
+            plugins_json = f'{flutter_app_dir}/.flutter-plugins-dependencies'
+            have_registrant = os.path.isfile(dart_plugin_registrant_file)
+            linux_plugins = []
+            if os.path.isfile(plugins_json):
+                with open(plugins_json, 'r') as f:
+                    linux_plugins = [p['name'] for p in
+                                     json.load(f).get('plugins', {}).get('linux', [])]
+
+            if not have_registrant and linux_plugins:
+                bb.fatal(
+                    f'{pubspec_appname}: .flutter-plugins-dependencies lists '
+                    f'Linux plugins ({", ".join(linux_plugins)}) but no '
+                    f'registrant was generated at '
+                    f'{dart_plugin_registrant_file}.\n'
+                    f'Building the snapshot without it would ship an image '
+                    f'whose plugins are never registered.')
+
             if os.path.isfile(dart_plugin_registrant_file):
                 # The registrant is the one library with no package: URI, so it
                 # is named to the frontend by path -- and that path becomes the

--- a/conf/include/flutter-app.inc
+++ b/conf/include/flutter-app.inc
@@ -112,3 +112,47 @@ FILES:${PN} = "\
     "
 
 RDEPENDS:${PN} = "flutter-engine"
+
+# An app that ships without its plugins registered is indistinguishable from
+# one that has none: no error, no missing file, just an app whose plugins do
+# nothing. The generated registrant is the only library an app links that has
+# no package: URI, so nothing downstream records whether it made it.
+#
+# Check the packaged image, which is what ships. Apps with no Linux plugins
+# legitimately have no registrant, so the plugin list decides whether its
+# absence is a fault -- the same test conf/include/common.inc applies before
+# building the snapshot.
+python flutter_check_packaged_registrant() {
+    import json
+    import os
+
+    pkgdest = d.getVar('PKGDEST')
+    if not pkgdest or not os.path.isdir(pkgdest):
+        return
+
+    app_dir = os.path.join(d.getVar('S'),
+                           d.getVar('FLUTTER_APPLICATION_PATH') or '')
+    plugins_json = os.path.join(app_dir, '.flutter-plugins-dependencies')
+    linux_plugins = []
+    if os.path.isfile(plugins_json):
+        with open(plugins_json, 'r') as f:
+            linux_plugins = [p['name'] for p in
+                             json.load(f).get('plugins', {}).get('linux', [])]
+
+    for dirpath, _, files in os.walk(pkgdest):
+        if 'libapp.so' not in files:
+            continue
+        path = os.path.join(dirpath, 'libapp.so')
+        if os.path.islink(path):
+            continue
+        with open(path, 'rb') as f:
+            count = f.read().count(b'_PluginRegistrant')
+        rel = os.path.relpath(path, pkgdest)
+        if linux_plugins and not count:
+            bb.fatal(
+                f'{rel} carries no plugin registrant, but this app declares '
+                f'Linux plugins ({", ".join(linux_plugins)}).\n'
+                f'It would install and run with those plugins silently inert.')
+        bb.note(f'plugin registrant in {rel}: {count}')
+}
+do_package[postfuncs] += "flutter_check_packaged_registrant"


### PR DESCRIPTION
Port from master, the last piece of the tooling parity gap.

Two checks for one fault. `common.inc` fails the build when
`.flutter-plugins-dependencies` lists Linux plugins and no registrant was
generated — `flutter build` writes both, so reaching the snapshot step with a
plugin list and no registrant means the app would ship with those plugins inert.
`flutter-app.inc` checks the packaged image, which is what installs.

The registrant is the only library an app links with no `package:` URI, so
nothing downstream records whether it made it: no error, no missing file, just an
app whose plugins do nothing. Hence checking twice.

`conf/include/flutter-app.inc` is now identical to master's.
