### PR TITLE
pub-cache: dump 200 lines on a failed resolve, not 80

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -256,8 +256,8 @@ do_pub_get_offline() {
         else
             bbplain "pub-get: network unreachable, as intended"
         fi
-        bbplain "pub-get: last 80 lines of pub --verbose"
-        bbplain "$(tail -n 80 "$pubget_log" 2>/dev/null)"
+        bbplain "pub-get: last 200 lines of pub --verbose"
+        bbplain "$(tail -n 200 "$pubget_log" 2>/dev/null)"
         if [ $rc -eq 124 ]; then
             bbfatal "offline pub get did not finish within ${PUB_GET_TIMEOUT}s. Resolving from a staged cache takes under a second, so this is a wait rather than work; the tail above is where it stopped."
         fi


### PR DESCRIPTION
Backport from wrynose. flutter's artifact pass alone is longer than 80 lines, so
the tail cut off whatever it did next — diagnosing the wrynose stall in #907 meant
inferring the cause rather than reading it.

Only fires on a failed resolve. `classes/pub-cache.bbclass` is now identical on
both branches.
