### PR TITLE
tools: US spelling

### DIFF
--- a/tools/pubvendor/offline_check.py
+++ b/tools/pubvendor/offline_check.py
@@ -7,7 +7,7 @@
 #
 # The unit tests assert what pubvendor.py *emits*. They cannot assert that
 # the staged layout is one pub accepts, because that layout is a pub
-# internal reconstructed from behaviour rather than a documented contract.
+# internal reconstructed from behavior rather than a documented contract.
 # Only running `pub get --offline` against a staged cache shows that, and
 # only for the SDK it is run with -- hence the matrix in CI.
 #

--- a/tools/roll_meta_flutter.py
+++ b/tools/roll_meta_flutter.py
@@ -357,7 +357,7 @@ def report_removed_gn_options(root_path: str, recipe_path: str, sdk_clone: str, 
 
     The recipe is copied forward verbatim apart from SRCREV, so PACKAGECONFIG
     entries survive a version bump even when the option they pass no longer
-    exists. gn.py uses argparse, which exits 2 on an unrecognised option, so the
+    exists. gn.py uses argparse, which exits 2 on an unrecognized option, so the
     result is a do_configure failure well after the roll, with nothing pointing
     back at the cause.
     """
@@ -397,7 +397,7 @@ def report_removed_gn_options(root_path: str, recipe_path: str, sdk_clone: str, 
               f'does not accept')
     print('')
     print(f'Remove these from {os.path.relpath(recipe_path, root_path)} before '
-          f'building; gn.py exits 2 on an unrecognised option, so do_configure '
+          f'building; gn.py exits 2 on an unrecognized option, so do_configure '
           f'will fail otherwise.')
 
 

--- a/tools/tests/test_resolve_check.py
+++ b/tools/tests/test_resolve_check.py
@@ -64,7 +64,7 @@ def test_a_network_failure_is_not_an_incompatibility(tmp_path, flutter, err):
     assert create_recipes.resolve_check(str(tmp_path), 'app') is None
 
 
-def test_an_unrecognised_failure_is_not_an_incompatibility(tmp_path, flutter):
+def test_an_unrecognized_failure_is_not_an_incompatibility(tmp_path, flutter):
     flutter(stderr='something nobody has seen before', rc=1)
     assert create_recipes.resolve_check(str(tmp_path), 'app') is None
 

--- a/tools/tests/test_roll_meta_flutter.py
+++ b/tools/tests/test_roll_meta_flutter.py
@@ -21,8 +21,8 @@ def _repos(n):
             for i in range(n)]
 
 
-def _run(monkeypatch, behaviour):
-    monkeypatch.setattr(roll, 'get_repo', behaviour)
+def _run(monkeypatch, behavior):
+    monkeypatch.setattr(roll, 'get_repo', behavior)
     roll.get_workspace_repos('/nonexistent', _repos(4), '/out', '/pkg', None)
 
 


### PR DESCRIPTION
Port of #912. `tools/` here had the same five spots on the same lines, so
the cherry-pick is clean and the diff is identical.

`unrecognised` -> `unrecognized` (two in `roll_meta_flutter.py`, one test
name in `test_resolve_check.py`) and `behaviour` -> `behavior` (a comment
in `offline_check.py`, a helper parameter in `test_roll_meta_flutter.py`).

The test name is referenced nowhere else and every `_run` caller passes
positionally, so neither rename reaches anything. 114/114 pass.

Three more sit outside `tools/` on this branch -- a comment each in
`master-build.yml` and `flutter-app-native.bbclass`, and `recognised` in
README.md:200. Left alone here; say the word and they follow. The
`cancelled()` calls in the workflow are the GitHub Actions function and
stay as they are.