### PR TITLE
US spelling outside tools/

### DIFF
--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -42,7 +42,7 @@ on:
 # Cancelling is limited to pull_request on purpose. A workflow_dispatch is
 # someone deliberately asking for a build, and a second dispatch on the same
 # ref should not silently kill the first; the release branches are dispatch
-# only, so there it would be the sole behaviour.
+# only, so there it would be the sole behavior.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/classes/flutter-app-native.bbclass
+++ b/classes/flutter-app-native.bbclass
@@ -19,7 +19,7 @@ DEPENDS:append = " lld-native"
 # Ideally these could just be added to LDFLAGS, but they have to go into the
 # general flags variables: the resulting CMAKE_<LANG>_LINK_FLAGS in the
 # toolchain.cmake that cmake.bbclass writes do not appear to be used, perhaps
-# from behaviour changes in cmake 4.3.
+# from behavior changes in cmake 4.3.
 DEPENDS:append = " libunwind"
 CFLAGS += "-rtlib=compiler-rt -unwindlib=libunwind -fuse-ld=lld"
 CXXFLAGS += "-rtlib=compiler-rt -unwindlib=libunwind -fuse-ld=lld"

--- a/recipes-graphics/toyota/ivi-homescreen-v3.inc
+++ b/recipes-graphics/toyota/ivi-homescreen-v3.inc
@@ -30,7 +30,7 @@ SECTION = "graphics"
 CVE_PRODUCT = "homescreen"
 
 # The plugins tree (Apache-2.0) and the v4l2-webrtc-codec encoder sources (MIT)
-# are only fetched when they are actually built, so both the licence list and its
+# are only fetched when they are actually built, so both the license list and its
 # checksums follow the PACKAGECONFIG.
 LICENSE = "Apache-2.0\
 ${@bb.utils.contains('PACKAGECONFIG', 'disable-plugins', '', ' & Apache-2.0', d)}\


### PR DESCRIPTION
The three #912 left behind, all comments:

- `wrynose-build.yml:45` behaviour -> behavior
- `flutter-app-native.bbclass:22` behaviour -> behavior
- `ivi-homescreen-v3.inc:33` licence -> license

Nothing outside a comment moves, and a tree-wide sweep is clean after it.
The `cancelled()` calls in the workflow are the GitHub Actions function
and stay as they are.

Worth knowing this one costs a full matrix: it touches the workflow, a
bbclass and a recipe .inc, none of which are in paths-ignore, so all four
machines rebuild for three comment lines. The bbclass comment sits at file
scope and changes no task signature, so nothing should come out of sstate
differently.