### PR TITLE
US spelling outside tools/

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -43,7 +43,7 @@ on:
 # Cancelling is limited to pull_request on purpose. A workflow_dispatch is
 # someone deliberately asking for a build, and a second dispatch on the same
 # ref should not silently kill the first; the release branches are dispatch
-# only, so there it would be the sole behaviour.
+# only, so there it would be the sole behavior.
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}

--- a/README.md
+++ b/README.md
@@ -197,7 +197,7 @@ other -- so do not "fix" one to match the other, and take care when
 cherry-picking a recipe or a manifest entry between branches.
 
 The dividing line is oe-core commit 51c7930220 (2026-07-15, "lib/oe: Add SPDX
-license library"). Before it, `license.py` recognised only `& | ( )` as
+license library"). Before it, `license.py` recognized only `& | ( )` as
 operators, and a bare `AND` matched the license *name* pattern -- so it was
 read as a license called "AND" and failed. Since it, `AND` is the native SPDX
 operator; `&` is accepted only because `_substitute_legacy_license()` rewrites

--- a/classes/flutter-app-native.bbclass
+++ b/classes/flutter-app-native.bbclass
@@ -19,7 +19,7 @@ DEPENDS:append = " lld-native"
 # Ideally these could just be added to LDFLAGS, but they have to go into the
 # general flags variables: the resulting CMAKE_<LANG>_LINK_FLAGS in the
 # toolchain.cmake that cmake.bbclass writes do not appear to be used, perhaps
-# from behaviour changes in cmake 4.3.
+# from behavior changes in cmake 4.3.
 DEPENDS:append = " libunwind"
 CFLAGS += "-rtlib=compiler-rt -unwindlib=libunwind -fuse-ld=lld"
 CXXFLAGS += "-rtlib=compiler-rt -unwindlib=libunwind -fuse-ld=lld"


### PR DESCRIPTION
Counterpart to #914. The three this branch had left, all prose:

- `master-build.yml:46` behaviour -> behavior
- `flutter-app-native.bbclass:22` behaviour -> behavior
- `README.md:200` recognised -> recognized, in the note on oe-core
  51c7930220

The third differs from #914, which had `licence` in `ivi-homescreen-v3.inc`
instead, so this is a hand-applied port rather than a cherry-pick. A
tree-wide sweep is clean after it. The `cancelled()` calls in the workflow
are the GitHub Actions function and stay as they are.

Same cost note as #914: the workflow and bbclass are not in paths-ignore,
so all four machines rebuild for three comment lines. The bbclass comment
is at file scope and changes no task signature.