### PR TITLE
ci: build scarthgap per pull request

### DIFF
--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -1,18 +1,45 @@
 name: scarthgap-build
 
-# Release-branch builds are dispatch-only, but cover every machine master
-# covers. The runner is sequential, so the matrix queues and runs one machine
-# at a time against a single tree, which is how master's tmp comes to hold all
-# four already.
+# Builds per pull request, and covers every machine master covers. The runner
+# is sequential, so the matrix queues and runs one machine at a time against a
+# single tree, which is how master's tmp comes to hold all four already.
 #
-# Dispatch rather than per-pull-request is a disk constraint, not a coverage
-# one: a populated tmp is around 106G against 264G free, so master and the four
-# release branches cannot all keep one. The tree here is this branch's own, so
-# master's is never disturbed, and any other release branch's tmp is removed
-# first, which holds the release branches to one populated tree between them.
+# This was dispatch-only on the grounds that a populated tmp is around 106G
+# against 264G free. That figure was an assumption and it was wrong: measured,
+# the five trees come to 153G in total, 19G to 34G each, against terabytes
+# free -- see the reclaim step below, which has been conditional on the disk
+# actually being short since. With the real numbers there is room for this
+# branch to build per pull request, and it is the branch parity work is
+# landing on, so it should not go untested.
+#
+# The tree here is this branch's own, so master's is never disturbed.
 
 on:
+  pull_request:
+    # No 'closed': nothing here is conditioned on the event, so closing or
+    # merging would start a second full build of work already merged.
+    types: [ opened, synchronize, reopened ]
+    # A change that cannot affect a build should not cost four of them.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'tools/**'
+      - '.github/workflows/tools-tests.yml'
+      - '.gitignore'
+      - 'LICENSE'
   workflow_dispatch:
+
+# One run per branch. Every push to a pull request starts a run and GitHub does
+# not stop the previous one, so an iterated branch leaves a queue of runs
+# against commits that have already been superseded -- on a sequential runner,
+# each is roughly an hour of matrix reproducing a result we have moved past.
+#
+# Cancelling is limited to pull_request on purpose: a workflow_dispatch is
+# someone deliberately asking for a build, and a second dispatch on the same
+# ref should not silently kill the first.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
 


### PR DESCRIPTION
Gives this branch the `pull_request` trigger and `concurrency` block
wrynose has: same `paths-ignore`, same `types` list without `closed`, and
`cancel-in-progress` limited to `pull_request` so a deliberate dispatch is
never killed by a second one.

**The stated reason for dispatch-only does not hold.** The header claimed
a populated tmp is "around 106G against 264G free", so master plus four
release branches could not all keep one. That was an assumption. The
reclaim step *in this same file* already records the measurement that
replaced it:

> This used to run unconditionally, on the assumption that a tree measures
> around 106G and so only two would fit. Measured, the five trees come to
> 153G in total -- 19G to 34G each -- against terabytes free.

That is why reclaiming has been conditional on `MIN_FREE_GB` rather than
unconditional. The header was left saying the opposite. Rewritten to match
what the file does.

Nothing about tree ownership changes: the reclaim list here already
protects `master` and `scarthgap`, exactly as wrynose's protects `master`
and `wrynose`.

**Why now.** This is the branch the wrynose parity port is landing on, and
it has had no pull-request coverage of any kind -- `tools-tests.yml` from
#917 is currently the only thing that runs on a PR here. The stages still
to come change build behavior (`pub-cache.bbclass`, `common.inc`,
`flutter-app.inc`, then the SDK app includes), and they should not land
unbuilt.

Two follow-ups this implies, neither included here:

- `wrynose-build.yml`'s header carries the same stale 106G claim and adds
  "the older release branches stay dispatch-only, since a third and fourth
  tree would not [fit]". That is now both outdated and contradicted.
- With two branches building per PR, they can evict each other's tmp when
  free space drops under `MIN_FREE_GB` (300G). Not a problem at current
  free space, and the eviction is a cache loss that rebuilds from sstate,
  not a failure.