### PR TITLE
pub-cache: correct the UNPACKDIR release note

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -26,10 +26,11 @@
 
 PUB_CACHE_LOCAL ?= "pub_cache"
 # The fragment stages the cache with SRC_URI subdir=, and subdir= is relative
-# to UNPACKDIR, which is ${WORKDIR}/sources from scarthgap on and WORKDIR
-# itself before that. Anchoring PUB_CACHE to WORKDIR unconditionally pointed
-# it at a directory the packages were never unpacked into: they landed in
-# ${WORKDIR}/sources/pub_cache while pub read ${WORKDIR}/pub_cache, which
+# to UNPACKDIR, which is ${WORKDIR}/sources-unpack from styhead on and does
+# not exist before that. Anchoring PUB_CACHE to WORKDIR unconditionally
+# pointed it at a directory the packages were never unpacked into: they
+# landed in ${WORKDIR}/sources-unpack/pub_cache while pub read
+# ${WORKDIR}/pub_cache, which
 # do_seed_pub_cache had filled from the SDK. Resolution then succeeded on
 # whatever the SDK's own cache happened to carry and failed on the first
 # package it did not -- with the vendored copy sitting unused one directory
@@ -51,7 +52,7 @@ python do_install_pubspec_lock() {
     name = d.getVar('PUBSPEC_LOCK_FILE')
     if not name:
         return
-    # file:// unpacks into UNPACKDIR from scarthgap on, and straight into
+    # file:// unpacks into UNPACKDIR from styhead on, and straight into
     # WORKDIR before that. Take whichever this release provides.
     base = d.getVar('UNPACKDIR') or d.getVar('WORKDIR')
     src = os.path.join(base, name)


### PR DESCRIPTION
Port of #916. Identical two spots, identical diff.

The comment claimed UNPACKDIR is `${WORKDIR}/sources` "from scarthgap on".
Both halves are wrong:

- oe-core `812dafbec1` (2024-04-25) introduced UNPACKDIR as `${WORKDIR}`,
  and `d24a7d0fb1` (2024-05-09) changed it to `${WORKDIR}/sources-unpack`.
  Both postdate the scarthgap branch and neither was backported.
- scarthgap has zero UNPACKDIR in `meta/`; styhead has it in 219 files.
- The value was never `${WORKDIR}/sources`.

Comment only -- `PUB_CACHE_BASE` and `_stage()` already take
`UNPACKDIR or WORKDIR`, so behavior is unchanged on every release.

Costs a full matrix for a comment: `classes/` is not in paths-ignore.