### PR TITLE
pub-cache: port the offline resolve from wrynose

### DIFF
--- a/classes/pub-cache.bbclass
+++ b/classes/pub-cache.bbclass
@@ -1,0 +1,289 @@
+# Copyright (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
+#
+# pub-cache.bbclass - consume a pubvendor.py-generated .inc
+#
+# Pairs with the SRC_URI fragment produced by tools/pubvendor/pubvendor.py:
+#   * points PUB_CACHE at the staged tree
+#   * installs PUBSPEC_LOCK_FILE, the lockfile the fragment was generated
+#     from, over the app's own -- they differ, because the roll re-resolves
+#     against the SDK this layer pins
+#   * asserts the result matches PUBSPEC_LOCK_SHA256, which now catches the
+#     layer's .inc and .lock drifting apart
+#   * synthesizes hosted-hashes/<host>/<pkg>-<ver>.sha256 files from the
+#     SRC_URI checksum flags, so newer Dart SDKs' content verification
+#     passes offline, and asserts while it is there that every package the
+#     fragment declared is staged where pub will look for it
+#   * runs `flutter pub get --offline --enforce-lockfile` -- flutter rather
+#     than dart, see the note above the task
+#   * marks do_archive_pub_cache and do_restore_pub_cache noexec, so the
+#     layer's own networked pub cache path stands down
+#
+# The recipe must set PUBSPEC_APP_DIR to the app source dir containing
+# pubspec.yaml/pubspec.lock (default ${S}), and PUBSPEC_LOCK_FILE to the
+# vendored lockfile it carries in SRC_URI.
+
+PUB_CACHE_LOCAL ?= "pub_cache"
+# The fragment stages the cache with SRC_URI subdir=, and subdir= is relative
+# to UNPACKDIR, which is ${WORKDIR}/sources-unpack from styhead on and does
+# not exist before that. Anchoring PUB_CACHE to WORKDIR unconditionally
+# pointed it at a directory the packages were never unpacked into: they
+# landed in ${WORKDIR}/sources-unpack/pub_cache while pub read
+# ${WORKDIR}/pub_cache, which
+# do_seed_pub_cache had filled from the SDK. Resolution then succeeded on
+# whatever the SDK's own cache happened to carry and failed on the first
+# package it did not -- with the vendored copy sitting unused one directory
+# away. Take the same base do_install_pubspec_lock takes.
+PUB_CACHE_BASE ?= "${@d.getVar('UNPACKDIR') or d.getVar('WORKDIR')}"
+PUB_CACHE = "${PUB_CACHE_BASE}/${PUB_CACHE_LOCAL}"
+PUBSPEC_APP_DIR ?= "${S}"
+
+export PUB_CACHE
+
+# The fragment is generated from a lockfile resolved against the SDK this
+# layer pins, which is not the one the app committed upstream. do_unpack
+# brings that resolved lockfile in through SRC_URI; install it over the app's
+# own before anything reads it, so what gets built is what was vendored.
+python do_install_pubspec_lock() {
+    import os
+    import shutil
+
+    name = d.getVar('PUBSPEC_LOCK_FILE')
+    if not name:
+        return
+    # file:// unpacks into UNPACKDIR from styhead on, and straight into
+    # WORKDIR before that. Take whichever this release provides.
+    base = d.getVar('UNPACKDIR') or d.getVar('WORKDIR')
+    src = os.path.join(base, name)
+    if not os.path.isfile(src):
+        bb.fatal("PUBSPEC_LOCK_FILE %s not found in %s; is it in SRC_URI?"
+                 % (name, base))
+    dst = os.path.join(d.getVar('PUBSPEC_APP_DIR'), 'pubspec.lock')
+    shutil.copyfile(src, dst)
+    bb.note("installed vendored pubspec.lock from %s" % name)
+}
+# after do_patch, not just do_unpack: a patch -- or a recipe task ordered
+# around one, as with the user_defines injection in the appstream_dart app --
+# can change pubspec.yaml or pubspec.lock. Resolving before that lands means
+# resolving against source that is not what gets built, and an edit arriving
+# afterwards makes pub re-resolve, which reaches for the network.
+# Also after do_archive_pub_cache, for the same reason do_pub_get_offline is:
+# a recipe that edits pubspec.yaml orders itself before that task, and this
+# class makes it noexec without removing it from the graph. Installing the
+# lock first leaves pubspec.yaml newer, which is one of the conditions pub
+# uses to decide the lockfile is stale and re-resolve.
+addtask install_pubspec_lock after do_unpack do_patch do_archive_pub_cache before do_check_pubspec_lock
+
+# do_unpack stages the app's dependencies into PUB_CACHE, and nothing else.
+# flutter's own tool packages are not among them: flutter_tools has its own
+# pubspec -- it depends on `test`, among others -- and resolving that is the
+# first thing `flutter pub get` does. Without them the tool goes to pub.dev
+# and fails, reporting a package the app never mentions.
+#
+# common.inc gets these by copying the SDK's .pub-cache wholesale, but it
+# rmtree's the destination first, which would discard everything do_unpack
+# staged. Merge instead, and let the staged copies win: those came through
+# SRC_URI with checksums bitbake verified.
+python do_seed_pub_cache() {
+    import os
+    import shutil
+
+    sdk_cache = os.path.join(d.getVar('FLUTTER_SDK'), '.pub-cache')
+    if not os.path.isdir(sdk_cache):
+        bb.fatal("no .pub-cache in %s; flutter-sdk-native did not stage one"
+                 % d.getVar('FLUTTER_SDK'))
+    dest = d.getVar('PUB_CACHE')
+
+    added = 0
+    for root, dirs, files in os.walk(sdk_cache):
+        # Skip pub's own metadata cache. It holds cached version listings and
+        # advisory responses, not packages, and carrying them across is what
+        # lets pub reach the network from an offline resolve:
+        #
+        #   hosted.dart:981  _versionInfo() returns null when offline and no
+        #                    cached listing exists, so status() comes back
+        #                    empty and advisoriesUpdated is null
+        #   hosted.dart:774  _getAdvisories() returns immediately on a null
+        #                    advisoriesUpdated -- but with a listing present it
+        #                    proceeds, and has no isOffline guard of its own
+        #
+        # So a listing for a package turns an offline `pub get` into one that
+        # will fetch https://pub.dev/api/packages/<pkg>/advisories whenever the
+        # cached advisory response is older than the listing says it should be.
+        # Without the listings that path cannot be entered at all.
+        if '.cache' in dirs:
+            dirs.remove('.cache')
+        rel = os.path.relpath(root, sdk_cache)
+        target = os.path.join(dest, rel) if rel != '.' else dest
+        bb.utils.mkdirhier(target)
+        for name in files:
+            dst = os.path.join(target, name)
+            if os.path.exists(dst):
+                continue
+            shutil.copy2(os.path.join(root, name), dst)
+            added += 1
+    bb.note("seeded %d files from the SDK pub cache" % added)
+}
+addtask seed_pub_cache after do_unpack do_patch before do_pub_get_offline
+
+python do_check_pubspec_lock() {
+    import hashlib, os
+
+    expected = d.getVar('PUBSPEC_LOCK_SHA256')
+    if not expected:
+        bb.warn("PUBSPEC_LOCK_SHA256 unset; lockfile integrity not enforced")
+        return
+    lock = os.path.join(d.getVar('PUBSPEC_APP_DIR'), 'pubspec.lock')
+    if not os.path.isfile(lock):
+        bb.fatal("pubspec.lock not found at %s" % lock)
+    with open(lock, 'rb') as f:
+        actual = hashlib.sha256(f.read()).hexdigest()
+    if actual != expected:
+        bb.fatal(
+            "pubspec.lock sha256 mismatch: recipe .inc was generated from a "
+            "different lockfile (expected %s, got %s). Re-run pubvendor.py."
+            % (expected, actual))
+}
+addtask check_pubspec_lock after do_install_pubspec_lock before do_configure
+
+python do_write_hosted_hashes() {
+    # Newer Dart SDKs verify hosted package content hashes against
+    # $PUB_CACHE/hosted-hashes/<host>/<pkg>-<ver>.sha256. Derive them
+    # from the SRC_URI entries the .inc already carries.
+    import os
+    from bb.fetch2 import decodeurl
+
+    pub_cache = d.getVar('PUB_CACHE')
+    marker = '/hosted/'
+    missing = []
+    for uri in (d.getVar('SRC_URI') or '').split():
+        _, _, _, _, _, parm = decodeurl(uri)
+        subdir = parm.get('subdir', '')
+        name = parm.get('name')
+        idx = subdir.find(marker)
+        if idx < 0 or not name:
+            continue
+        sha = d.getVarFlag('SRC_URI', name + '.sha256sum')
+        if not sha:
+            bb.warn("no sha256sum flag for SRC_URI name=%s" % name)
+            continue
+        # subdir tail: hosted/<encoded-host>/<pkg>-<ver>
+        host, pkgver = subdir[idx + len(marker):].split('/', 1)
+        dst = os.path.join(pub_cache, 'hosted-hashes', host)
+        bb.utils.mkdirhier(dst)
+        with open(os.path.join(dst, pkgver + '.sha256'), 'w') as f:
+            f.write(sha)
+
+        # Assert the package the fragment declared is actually where pub will
+        # look for it. This loop already derives the exact path, so the check
+        # is free -- and it is the one failure this class could not otherwise
+        # see. do_seed_pub_cache fills the same tree from the SDK, so a
+        # PUB_CACHE pointing somewhere the vendored packages were never
+        # unpacked into does not come out empty; it comes out holding the
+        # SDK's cache, and resolution gets as far as the first package the SDK
+        # does not happen to ship. That reads as an ordinary dependency error
+        # a long way from its cause, and every app whose dependencies the SDK
+        # already carries would have passed while vendoring nothing.
+        if not os.path.isdir(os.path.join(pub_cache, subdir[idx + 1:])):
+            missing.append(pkgver)
+
+    if missing:
+        bb.fatal(
+            "%d of the vendored packages are not staged under PUB_CACHE "
+            "(%s): %s.\nSRC_URI subdir= unpacks into UNPACKDIR; check "
+            "PUB_CACHE_BASE resolves to the same place."
+            % (len(missing), pub_cache, ', '.join(sorted(missing)[:5])
+               + (', ...' if len(missing) > 5 else '')))
+}
+addtask write_hosted_hashes after do_unpack do_patch before do_configure
+
+# `flutter pub get`, not `dart pub get`. Both resolve offline from the staged
+# cache, but only the flutter one writes .flutter-plugins-dependencies, which
+# is what tells the build which plugins to register and feeds the generated
+# dart_plugin_registrant.dart. With `dart pub get` an app builds green and
+# registers no plugins.
+# Resolving from a staged cache is sub-second work. A run that takes minutes
+# is not doing the work slowly, it is waiting on something, and an unbounded
+# wait inside a task that reports nothing until it ends is the worst shape for
+# diagnosing that: the build looks alive for as long as it takes. Bound it, and
+# let the timeout turn a stall into a failure with the verbose log attached.
+PUB_GET_TIMEOUT ?= "600"
+
+do_pub_get_offline() {
+    # The SDK is staged by flutter-sdk-native and is not on the task PATH by
+    # default. HOME and XDG_CONFIG_HOME are set for the same reasons
+    # common.inc sets them for its own pub invocations: dart and flutter both
+    # write into them and must not touch the builder's real home.
+    export PATH="${FLUTTER_SDK}/bin:${PUB_CACHE}/bin:$PATH"
+    export HOME="${WORKDIR}"
+    export XDG_CONFIG_HOME="${WORKDIR}"
+
+    # Opt out of analytics before resolving, while the config write is the
+    # only thing happening. It is a local settings file, so it needs no
+    # network itself, but leaving it unset makes the first flutter run in a
+    # fresh XDG_CONFIG_HOME do its first-run work -- which does.
+    flutter config --no-analytics --no-cli-animations >/dev/null 2>&1 || true
+
+    cd ${PUBSPEC_APP_DIR}
+
+    # Keep pub's own output in a file rather than letting it into the task
+    # log. bbfatal does not trigger bitbake's log dump, so anything written to
+    # stdout here is lost on the failure that matters; the tail below is put on
+    # the console deliberately instead.
+    #
+    # `|| rc=$?` and not `if ! ...`: after a negation $? is the status of the
+    # negation, which is always 0, so the timeout could never be told apart
+    # from an ordinary failure.
+    pubget_log="${T}/pub_get_verbose.log"
+    rc=0
+    timeout ${PUB_GET_TIMEOUT} flutter --suppress-analytics pub get \
+        --offline --enforce-lockfile --verbose > "$pubget_log" 2>&1 || rc=$?
+
+    if [ $rc -ne 0 ]; then
+        # Whether the task is actually network-isolated is worth recording
+        # rather than assuming. bitbake-worker honours [network] = "0" through
+        # bb.utils.to_boolean, but only applies it when bb.utils.is_local_uid()
+        # holds, and it says so at debug level -- so in a container the isolation
+        # can silently not happen. Probe DNS and TCP separately: a resolver with
+        # nowhere to go is the classic source of a long, quiet stall.
+        if timeout 5 getent hosts pub.dev >/dev/null 2>&1; then
+            bbplain "pub-get: DNS resolves pub.dev"
+        else
+            bbplain "pub-get: DNS cannot resolve pub.dev"
+        fi
+        if timeout 5 sh -c 'exec 3<>/dev/tcp/151.101.1.140/443' >/dev/null 2>&1; then
+            bbwarn "pub-get: the network is reachable in a task marked [network] = 0"
+        else
+            bbplain "pub-get: network unreachable, as intended"
+        fi
+        bbplain "pub-get: last 200 lines of pub --verbose"
+        bbplain "$(tail -n 200 "$pubget_log" 2>/dev/null)"
+        if [ $rc -eq 124 ]; then
+            bbfatal "offline pub get did not finish within ${PUB_GET_TIMEOUT}s. Resolving from a staged cache takes under a second, so this is a wait rather than work; the tail above is where it stopped."
+        fi
+        bbfatal "offline pub get failed with exit code $rc"
+    fi
+}
+# Ordered after do_archive_pub_cache as well, even though this class makes
+# that task noexec. It is the layer's convention for "before pub runs": a
+# recipe that must touch the source first orders itself before it, as the
+# appstream_dart app does to inject its hooks section. Ordering only against
+# do_patch left both siblings of it with no relative order, so the edit could
+# land after resolution -- and pub then re-resolves, fetching security
+# advisories from pub.dev and failing with no network.
+addtask pub_get_offline after do_check_pubspec_lock do_write_hosted_hashes do_seed_pub_cache do_patch do_archive_pub_cache before do_compile
+do_pub_get_offline[network] = "0"
+
+# The layer's own pub cache path fetches with the network and carries the
+# resolution artifacts through an archive (common.inc, the .project copy in
+# do_archive_pub_cache and the moves back in do_restore_pub_cache). A recipe
+# staging its cache through SRC_URI needs neither: do_unpack puts the packages
+# in place and do_pub_get_offline regenerates the artifacts locally. Leaving
+# both enabled would mean two populators of ${WORKDIR}/pub_cache, one of them
+# reaching for the network, which is the thing this class exists to avoid.
+#
+# Doing it here rather than in common.inc keeps opting in to exactly
+# "inherit pub-cache", with no effect on any recipe that does not.
+do_archive_pub_cache[noexec] = "1"
+do_restore_pub_cache[noexec] = "1"

--- a/conf/include/common.inc
+++ b/conf/include/common.inc
@@ -10,13 +10,6 @@ DEPENDS += " \
     "
 
 FLUTTER_APPLICATION_PATH ??= ""
-
-# Directory pub resolves from, relative to S. Defaults to the application, which
-# is where a standalone package resolves. A pub workspace member resolves from
-# the workspace root instead -- its own directory has no lockfile and pub
-# refuses to operate there -- so such a recipe points this at the root and
-# leaves FLUTTER_APPLICATION_PATH on the member.
-FLUTTER_PUB_ROOT ??= "${FLUTTER_APPLICATION_PATH}"
 FLUTTER_PREBUILD_CMD ??= ""
 
 PUB_CACHE_EXTRA_ARCHIVE_CMD ??= ""
@@ -33,12 +26,75 @@ FLUTTER_APPLICATION_INSTALL_PREFIX ??= "${datadir}/flutter"
 FLUTTER_APPLICATION_INSTALL_SUFFIX ??= "${PUBSPEC_APPNAME}"
 FLUTTER_INSTALL_DIR = "${FLUTTER_APPLICATION_INSTALL_PREFIX}/${FLUTTER_APPLICATION_INSTALL_SUFFIX}"
 
-PUB_CACHE = "${WORKDIR}/pub_cache"
+# ??=: pub-cache.bbclass points PUB_CACHE under UNPACKDIR, and a hard
+# assignment here beats it whatever order the recipe inherits in.
+PUB_CACHE ??= "${WORKDIR}/pub_cache"
 PUB_CACHE_ARCHIVE = ""
 
 PUBSPEC_IGNORE_LOCKFILE ??= "0"
 
 FLUTTER_SDK = "${STAGING_DIR_NATIVE}/usr/share/flutter/sdk"
+
+# flutter re-runs `pub get` when package_config.json does not look newer than
+# the pubspec beside it, and that resolve carries no --offline: with no network
+# it hangs holding flutter's startup lock, so a second app blocks behind it.
+#
+# Stamping in the SDK's do_install is not enough. mtimes only enter a task's
+# output hash for do_package (include_timestamps in oe/sstatesig.py), so hash
+# equivalence hands back the object built before the stamp. Do it here, where
+# it always runs.
+python flutter_stamp_sdk_resolution() {
+    import os
+
+    sdk_root = d.getVar('FLUTTER_SDK')
+    if not sdk_root or not os.path.isdir(sdk_root):
+        return
+
+    def restamp(path, when):
+        # STAGING_DIR_NATIVE is hardlinked from the sysroot-components tree, so
+        # utime() here would also move the mtime of a file shared with every
+        # other recipe staging this SDK. Break the link first.
+        try:
+            if os.stat(path).st_nlink > 1:
+                tmp = path + '.stamp.tmp'
+                with open(path, 'rb') as src, open(tmp, 'wb') as dst:
+                    dst.write(src.read())
+                os.chmod(tmp, os.stat(path).st_mode & 0o7777)
+                os.replace(tmp, path)
+            os.utime(path, (when, when))
+        except OSError as e:
+            bb.warn('could not stamp %s: %s' % (path, e))
+            return False
+        return True
+
+    stamped = 0
+    for root, dirs, files in os.walk(sdk_root):
+        if 'package_config.json' not in files:
+            continue
+
+        cfg = os.path.join(root, 'package_config.json')
+        pubspecs = [os.path.join(root, os.pardir, n)
+                    for n in ('pubspec.yaml', 'pubspec.lock')]
+        pubspecs = [p for p in pubspecs if os.path.isfile(p)]
+        if not pubspecs:
+            continue
+
+        newest = max(os.stat(p).st_mtime for p in pubspecs)
+        if os.stat(cfg).st_mtime > newest:
+            continue
+
+        when = newest + 2
+        if restamp(cfg, when):
+            stamped += 1
+        graph = os.path.join(root, 'package_graph.json')
+        if os.path.isfile(graph):
+            restamp(graph, when)
+
+    if stamped:
+        bb.note('stamped %d package_config.json file(s) in the staged SDK '
+                'as newer than their pubspec' % stamped)
+}
+do_prepare_recipe_sysroot[postfuncs] += "flutter_stamp_sdk_resolution"
 
 require conf/include/clang-utils.inc
 
@@ -209,10 +265,6 @@ python do_archive_pub_cache() {
                 return
 
     app_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_APPLICATION_PATH"))
-    # pub runs here; for a workspace member this is the workspace root rather
-    # than the application. The cache is still keyed on the application, since
-    # that identifies what is being built -- one pub root can host several.
-    pub_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_PUB_ROOT"))
     localfile = get_pub_cache_archive_name(d, app_root)
     localpath = os.path.join(d.getVar("DL_DIR"), localfile)
 
@@ -230,10 +282,10 @@ python do_archive_pub_cache() {
     # Remove pubspec.lock file if present
     #
     if d.getVar("PUBSPEC_IGNORE_LOCKFILE") == "1":
-        pubspec_lock = os.path.join(pub_root, 'pubspec.lock')
+        pubspec_lock = os.path.join(app_root, 'pubspec.lock')
         if os.path.exists(pubspec_lock):
             bb.note('Deleting the pubspec.lock due to PUBSPEC_IGNORE_LOCKFILE = "1"')
-            run_command(d, 'rm -rf pubspec.lock', pub_root, env)
+            run_command(d, 'rm -rf pubspec.lock', app_root, env)
         else:
             bb.note('The pubspec.lock file is not present')
 
@@ -253,23 +305,20 @@ python do_archive_pub_cache() {
     #
     # go online to fetch, then mark offline
     #
-    run_command(d, 'flutter config --no-analytics', pub_root, env)
-    run_command(d, 'flutter config --no-cli-animations', pub_root, env)
-    run_command(d, 'flutter clean', pub_root, env)
+    run_command(d, 'flutter config --no-analytics', app_root, env)
+    run_command(d, 'flutter config --no-cli-animations', app_root, env)
+    run_command(d, 'flutter clean', app_root, env)
 
     # if no pubspec.lock, create it
-    pubspec_lock = os.path.join(pub_root, 'pubspec.lock')
+    pubspec_lock = os.path.join(app_root, 'pubspec.lock')
     if not os.path.exists(pubspec_lock):
-        run_command(d, 'dart pub --suppress-analytics --directory . get --example', pub_root, env)
-        run_command(d, 'dart pub --suppress-analytics --directory . get', pub_root, env)
+        run_command(d, 'dart pub --suppress-analytics --directory . get', app_root, env)
 
-    run_command(d, 'flutter pub get --enforce-lockfile', pub_root, env)
-    run_command(d, 'flutter pub get --enforce-lockfile --offline', pub_root, env)
+    run_command(d, 'flutter pub get --enforce-lockfile', app_root, env)
+    run_command(d, 'flutter pub get --enforce-lockfile --no-example --offline', app_root, env)
 
-    # The resolution artifacts (.dart_tool and friends) are written where pub
-    # ran, which for a workspace member is the root rather than the member.
     cp_cmd = f'mkdir -p {pub_cache}/.project | true; cp -rT . {pub_cache}/.project/ | true;'
-    run_command(d, cp_cmd, pub_root, env)
+    run_command(d, cp_cmd, app_root, env)
 
     bb_number_threads = d.getVar("BB_NUMBER_THREADS", multiprocessing.cpu_count()).strip()
     pack_cmd = f'tar -I \"pbzip2 -p{bb_number_threads}\" -cf {localpath} ./'
@@ -302,8 +351,6 @@ python do_restore_pub_cache() {
     from   bb.fetch2 import UnpackError
 
     app_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_APPLICATION_PATH"))
-    # Mirrors the archive side: the resolution tree goes back where pub ran.
-    pub_root = os.path.join(d.getVar("S"), d.getVar("FLUTTER_PUB_ROOT"))
 
     workspace = d.getVar('WORKDIR')
     file = os.path.join(workspace, 'PUB_CACHE_ARCHIVE')
@@ -329,13 +376,13 @@ python do_restore_pub_cache() {
 
     # restore flutter pub get artifacts
     cmd = \
-        f'mv .project/.dart_tool {pub_root}/ | true; ' \
-        f'mv .project/.packages {pub_root}/ | true; ' \
-        f'mv .project/.dart_tool {pub_root}/ | true; ' \
-        f'mv .project/.flutter-plugins {pub_root}/ | true; ' \
-        f'mv .project/.flutter-plugins-dependencies {pub_root}/ | true; ' \
-        f'mv .project/.metadata {pub_root}/ | true; ' \
-        f'mv .project/.packages {pub_root}/ | true; ' \
+        f'mv .project/.dart_tool {app_root}/ | true; ' \
+        f'mv .project/.packages {app_root}/ | true; ' \
+        f'mv .project/.dart_tool {app_root}/ | true; ' \
+        f'mv .project/.flutter-plugins {app_root}/ | true; ' \
+        f'mv .project/.flutter-plugins-dependencies {app_root}/ | true; ' \
+        f'mv .project/.metadata {app_root}/ | true; ' \
+        f'mv .project/.packages {app_root}/ | true; ' \
         'rm -rf .project'
     bb.note(f'Running [{cmd}] in {unpackdir}')
     ret = subprocess.call(cmd, preexec_fn=subprocess_setup, shell=True, cwd=unpackdir)
@@ -405,7 +452,7 @@ python do_compile() {
 
     run_command(d, 'flutter config --no-analytics', source_root, env)
     run_command(d, 'flutter config --no-cli-animations', source_root, env)
-    run_command(d, 'flutter pub get --enforce-lockfile --offline -v', source_root, env)
+    run_command(d, 'flutter pub get --enforce-lockfile --no-example --offline -v', source_root, env)
 
     build_type = d.getVar('BUILD_TYPE')
 
@@ -465,6 +512,9 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
         build_folder = os.path.join(source_root, 'build')
         if os.path.exists(build_folder):
             run_command(d, 'flutter clean -v', source_root, env)
+            # clean drops .dart_tool and the build carries --no-pub without
+            # network, so nothing puts the resolution back. Rebuild path only.
+            run_command(d, 'flutter pub get --offline', source_root, env)
 
         if runtime_mode == 'jit_release':
             cmd = (f'flutter build {flutter_build_args} --local-engine -v')
@@ -504,6 +554,38 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
             flutter_filesystem = ''
             flutter_app_dir = os.path.normpath(f'{source_dir}/{flutter_application_path}')
             dart_plugin_registrant_file = f'{flutter_app_dir}/.dart_tool/flutter_build/dart_plugin_registrant.dart'
+
+            # An app with no plugins gets neither .flutter-plugins-dependencies
+            # nor a generated registrant, so an absent registrant is an ordinary
+            # state and leaving the flags below empty is right. An app that has
+            # plugins for this platform and no registrant is not: the snapshot
+            # is built without registration and the image ships with those
+            # plugins inert -- no error, no missing file, just an app whose
+            # plugins do nothing. Nothing downstream reads it either, so the
+            # only place it shows is the artifact.
+            #
+            # Both files are written by `flutter build`, which has already run
+            # by the time this code executes, so reaching here with a plugin
+            # list and no registrant means that step did not generate it or
+            # something removed it afterwards. Distinguish the two cases rather
+            # than skipping both.
+            plugins_json = f'{flutter_app_dir}/.flutter-plugins-dependencies'
+            have_registrant = os.path.isfile(dart_plugin_registrant_file)
+            linux_plugins = []
+            if os.path.isfile(plugins_json):
+                with open(plugins_json, 'r') as f:
+                    linux_plugins = [p['name'] for p in
+                                     json.load(f).get('plugins', {}).get('linux', [])]
+
+            if not have_registrant and linux_plugins:
+                bb.fatal(
+                    f'{pubspec_appname}: .flutter-plugins-dependencies lists '
+                    f'Linux plugins ({", ".join(linux_plugins)}) but no '
+                    f'registrant was generated at '
+                    f'{dart_plugin_registrant_file}.\n'
+                    f'Building the snapshot without it would ship an image '
+                    f'whose plugins are never registered.')
+
             if os.path.isfile(dart_plugin_registrant_file):
                 # The registrant is the one library with no package: URI, so it
                 # is named to the frontend by path -- and that path becomes the
@@ -558,7 +640,6 @@ def build_app(d, source_dir, flutter_sdk, pubspec_appname, flutter_application_p
                 engine_snapshot = f'{flutter_sdk}/bin/cache/artifacts/engine/linux-{clang_build_arch(d)}/frontend_server_aot.dart.snapshot'
                 frontend_snapshot = sdk_snapshot if os.path.exists(sdk_snapshot) else engine_snapshot
                 dep_path = glob.glob(f'{source_dir}/{flutter_application_path}/.dart_tool/flutter_build/*/kernel_snapshot_program.d')
-
             cmd = f'{dart_runtime} \
                 --disable-dart-dev \
                 {frontend_snapshot} \

--- a/conf/include/flutter-app.inc
+++ b/conf/include/flutter-app.inc
@@ -20,14 +20,11 @@ DEPENDS += " \
 
 BUILD_TYPE = "app"
 
+# Force the Flutter build to target the cross-compile machine architecture
+# rather than the build host (flutter defaults to `uname -m`). Use the
+# target-arch mapping (aarch64 -> arm64, x86-64 -> x64), not clang_build_arch()
+# which reports BUILD_ARCH. Use :append (not +=) so the ??= default survives.
 FLUTTER_BUILD_ARGS ??= "bundle"
-# We always build for Linux, but flutter defaults the target arch to the build
-# host's, so a cross-build resolves native assets for the wrong arch: the
-# bundled NativeAssetsManifest.json lists system assets (e.g. sqlite3, pulled in
-# via drift) under the host arch, and the app fails at runtime with "No
-# available native assets". Pin the target arch (aarch64 -> arm64, x86-64 ->
-# x64) via the target-arch mapping -- not clang_build_arch(), which reports
-# BUILD_ARCH. Use :append (not +=) so the ??= default survives.
 FLUTTER_BUILD_ARGS:append = " --target-platform linux-${@gn_target_arch_name(d)}"
 
 # flutter build bundle only accepts 64-bit Linux target platforms. As of 3.47.1
@@ -74,6 +71,9 @@ do_install() {
         install -d ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/lib
 
         if [ ! -z "${APP_CONFIG}" ]; then
+            # WORKDIR, not UNPACKDIR: that variable arrived in styhead and
+            # this branch has no definition for it, so ${UNPACKDIR} would
+            # expand to nothing and the install would read from /.
             install -D -m 0644 ${WORKDIR}/${APP_CONFIG} \
                 ${D}${FLUTTER_INSTALL_DIR}/${FLUTTER_SDK_VERSION}/${FLUTTER_RUNTIME_MODE}/config.toml
         fi
@@ -115,3 +115,47 @@ FILES:${PN} = "\
     "
 
 RDEPENDS:${PN} = "flutter-engine"
+
+# An app that ships without its plugins registered is indistinguishable from
+# one that has none: no error, no missing file, just an app whose plugins do
+# nothing. The generated registrant is the only library an app links that has
+# no package: URI, so nothing downstream records whether it made it.
+#
+# Check the packaged image, which is what ships. Apps with no Linux plugins
+# legitimately have no registrant, so the plugin list decides whether its
+# absence is a fault -- the same test conf/include/common.inc applies before
+# building the snapshot.
+python flutter_check_packaged_registrant() {
+    import json
+    import os
+
+    pkgdest = d.getVar('PKGDEST')
+    if not pkgdest or not os.path.isdir(pkgdest):
+        return
+
+    app_dir = os.path.join(d.getVar('S'),
+                           d.getVar('FLUTTER_APPLICATION_PATH') or '')
+    plugins_json = os.path.join(app_dir, '.flutter-plugins-dependencies')
+    linux_plugins = []
+    if os.path.isfile(plugins_json):
+        with open(plugins_json, 'r') as f:
+            linux_plugins = [p['name'] for p in
+                             json.load(f).get('plugins', {}).get('linux', [])]
+
+    for dirpath, _, files in os.walk(pkgdest):
+        if 'libapp.so' not in files:
+            continue
+        path = os.path.join(dirpath, 'libapp.so')
+        if os.path.islink(path):
+            continue
+        with open(path, 'rb') as f:
+            count = f.read().count(b'_PluginRegistrant')
+        rel = os.path.relpath(path, pkgdest)
+        if linux_plugins and not count:
+            bb.fatal(
+                f'{rel} carries no plugin registrant, but this app declares '
+                f'Linux plugins ({", ".join(linux_plugins)}).\n'
+                f'It would install and run with those plugins silently inert.')
+        bb.note(f'plugin registrant in {rel}: {count}')
+}
+do_package[postfuncs] += "flutter_check_packaged_registrant"

--- a/conf/layer.conf
+++ b/conf/layer.conf
@@ -23,6 +23,10 @@ LAYERDEPENDS_flutter-layer = "core openembedded-layer"
 LAYERRECOMMENDS_flutter-layer = " clang-layer"
 LAYERSERIES_COMPAT_flutter-layer = "nanbield scarthgap"
 
+# pub-cache.bbclass bounds its offline resolve with timeout(1). This branch's
+# oe-core does not list it in HOSTTOOLS, so the task fails with 127 without it.
+HOSTTOOLS_NONFATAL += "timeout"
+
 BBFILES_DYNAMIC += " \
     clang-layer:${LAYERDIR}/dynamic-layers/clang-layer/*/*/*.bb \
     clang-layer:${LAYERDIR}/dynamic-layers/clang-layer/*/*/*/*.bb \


### PR DESCRIPTION
Stage 2 of wrynose/scarthgap parity, and the first stage that changes
build behavior. `pub-cache.bbclass` comes across with the `common.inc` and
`flutter-app.inc` changes it depends on.

**`pub-cache.bbclass` needed no adaptation.** `PUB_CACHE_BASE` and
`_stage()` already read `UNPACKDIR or WORKDIR`, so it works on a release
that defines neither.

**Three things are branch-specific and were handled, not copied:**

- `flutter-app.inc` installs `APP_CONFIG` from `${WORKDIR}`, where wrynose
  uses `${UNPACKDIR}`. UNPACKDIR arrived in styhead (oe-core `812dafbec1`,
  after this branch); here it expands to nothing and the install would
  read from `/`.
- `layer.conf` gains `HOSTTOOLS_NONFATAL += "timeout"`. `pub-cache` bounds
  its resolve with `timeout(1)` and this branch's oe-core does not list it
  in HOSTTOOLS, so `do_pub_get_offline` would fail with 127. Checked
  against this branch's `bitbake.conf`. `LAYERSERIES_COMPAT` and the
  clang-layer `BBFILES_DYNAMIC` are untouched.
- `common.inc` keeps the #575 comment on the frontend-server snapshot.
  wrynose dropped it, but the code it explains is byte-identical on both
  branches and the arm64 "Architecture mismatch" it documents is still
  reachable. Porting the deletion would have been a documentation
  regression, so it stayed.

**`FLUTTER_PUB_ROOT` goes away, and that is behavior-neutral here.** It
was referenced only inside `common.inc` -- no recipe sets or overrides it
-- and it defaulted to `FLUTTER_APPLICATION_PATH`, so `pub_root` and
`app_root` always resolved to the same directory. Checked before porting
the removal.

`[network]` task flags are already used on this branch (`gn-fetcher.bbclass`,
`common.inc`), so nothing new is required there.

This is the first PR to get real build coverage on this branch, via #918.