### PR TITLE
depot-tools: LICENSE is BSD-3-Clause

### DIFF
--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -6,13 +6,13 @@ name: wrynose-build
 # already.
 #
 # This branch gets per-pull-request builds because it is the release branch
-# under active use, and because two populated trees fit: one measures around
-# 106G. The older release branches stay dispatch-only, since a third and fourth
-# tree would not. The tree here is this branch's own, so master's is never
-# disturbed, and any other release branch's tmp is removed first, which holds
-# the remaining release branches to one populated tree between them -- a
-# dispatch of one of those will evict this branch's tree, which then rebuilds
-# from sstate on the next pull request.
+# under active use. scarthgap builds per pull request too, since #918.
+#
+# The 106G-per-tree figure this comment used to cite was an estimate and it was
+# wrong: measured, the five trees come to 153G in total, 19G to 34G each,
+# against terabytes free -- see the reclaim step below, which has been
+# conditional on the disk actually being short ever since. The tree here is this
+# branch's own, so master's is never disturbed.
 
 on:
   pull_request:

--- a/recipes-devtools/depot-tools/depot-tools-native_git.bb
+++ b/recipes-devtools/depot-tools/depot-tools-native_git.bb
@@ -4,7 +4,7 @@
 # SPDX-License-Identifier: MIT
 #
 
-LICENSE = "GPLv3"
+LICENSE = "BSD-3-Clause"
 LIC_FILES_CHKSUM = "file://LICENSE;md5=c2c05f9bdd5fc0b458037c2d1fb8d95e"
 
 SRC_URI = "git://chromium.googlesource.com/chromium/tools/depot_tools;protocol=https;branch=main"


### PR DESCRIPTION
`LICENSE = "GPLv3"` is wrong twice over: the wrong license, in an
identifier SPDX does not accept.

`LIC_FILES_CHKSUM` was already correct and unchanged, which is what makes
this checkable. md5 `c2c05f9bdd5fc0b458037c2d1fb8d95e` is the LICENSE file
in depot_tools at the pinned SRCREV; extracted from the download cache it
is the Chromium Authors BSD-3-Clause text, opens with "Redistribution and
use in source and binary forms", and mentions the GPL nowhere.

master and scarthgap already say `BSD-3-Clause`; scarthgap fixed it in
`ad066a2e` ("license: fix the QA warnings and check declarations against
source"). wrynose kept the value from `32b5be80`, 2021.

Found while auditing the wrynose/scarthgap delta -- it showed up as a
branch difference, and the branch that differed turned out to be this one.

**Also bundles the build workflow header fix.** It has been wrong since
#918 and is comment-only, so it was held back rather than spend a
four-machine matrix on a comment; a recipe change pays for one anyway. The
header claimed a populated tree is "around 106G" and that older release
branches stay dispatch-only because a third would not fit. The reclaim
step in the same file has carried the measurement that replaced that
estimate for a while -- 153G across five trees, 19G to 34G each, against
terabytes free -- and scarthgap has built per pull request since #918.