### PR TITLE
test-runner: port the recipe from wrynose

### DIFF
--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -366,25 +366,6 @@ jobs:
 
       # The remote test-runner daemon. No Flutter involvement, so unlike the
       # app recipes below it builds on qemuarm too.
-      # bitbake prints only the path to a failed task's log, and that path is
-      # inside the work tree on the runner. Without this a do_configure or
-      # do_compile failure reaches us as "ExecutionError(...run.do_configure)"
-      # and nothing else, which is not enough to act on.
-      - name: Show bitbake failure logs
-        if: failure()
-        shell: bash
-        working-directory: ../scarthgap-linux-dummy
-        run: |
-          found=0
-          while IFS= read -r f; do
-            grep -qiE '^(ERROR|CMake Error)|error:' "$f" || continue
-            found=1
-            echo "::group::$f"
-            tail -120 "$f"
-            echo "::endgroup::"
-          done < <(find build/tmp*/work -name 'log.do_*' -mmin -240 2>/dev/null | head -40)
-          [ "$found" = 1 ] || echo "no task log with an error recorded in the last 4h"
-
       - name: Build test-runner
         shell: bash
         working-directory: ../scarthgap-linux-dummy
@@ -425,3 +406,23 @@ jobs:
         shell: bash
         working-directory: ../scarthgap-linux-dummy
         run: rm -f .ci-build-incomplete
+
+      # bitbake prints only the path to a failed task's log, and that path is
+      # inside the work tree on the runner. Without this a do_configure or
+      # do_compile failure reaches us as "ExecutionError(...run.do_configure)"
+      # and nothing else, which is not enough to act on. Last in the job so it
+      # sees a failure from any step above it.
+      - name: Show bitbake failure logs
+        if: failure()
+        shell: bash
+        working-directory: ../scarthgap-linux-dummy
+        run: |
+          found=0
+          while IFS= read -r f; do
+            grep -qiE '^(ERROR|CMake Error)|error:' "$f" || continue
+            found=1
+            echo "::group::$f"
+            tail -120 "$f"
+            echo "::endgroup::"
+          done < <(find build/tmp*/work -name 'log.do_*' -mmin -240 2>/dev/null | head -40)
+          [ "$found" = 1 ] || echo "no task log with an error recorded in the last 4h"

--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -366,6 +366,25 @@ jobs:
 
       # The remote test-runner daemon. No Flutter involvement, so unlike the
       # app recipes below it builds on qemuarm too.
+      # bitbake prints only the path to a failed task's log, and that path is
+      # inside the work tree on the runner. Without this a do_configure or
+      # do_compile failure reaches us as "ExecutionError(...run.do_configure)"
+      # and nothing else, which is not enough to act on.
+      - name: Show bitbake failure logs
+        if: failure()
+        shell: bash
+        working-directory: ../scarthgap-linux-dummy
+        run: |
+          found=0
+          while IFS= read -r f; do
+            grep -qiE '^(ERROR|CMake Error)|error:' "$f" || continue
+            found=1
+            echo "::group::$f"
+            tail -120 "$f"
+            echo "::endgroup::"
+          done < <(find build/tmp*/work -name 'log.do_*' -mmin -240 2>/dev/null | head -40)
+          [ "$found" = 1 ] || echo "no task log with an error recorded in the last 4h"
+
       - name: Build test-runner
         shell: bash
         working-directory: ../scarthgap-linux-dummy

--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -364,6 +364,15 @@ jobs:
           . ./openembedded-core/oe-init-build-env
           bitbake flatpak-minimal-appstream-dart-flathub-catalog
 
+      # The remote test-runner daemon. No Flutter involvement, so unlike the
+      # app recipes below it builds on qemuarm too.
+      - name: Build test-runner
+        shell: bash
+        working-directory: ../scarthgap-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          bitbake test-runner
+
       - name: Build the Flutter SDK example apps
         # flutter build bundle has no linux-arm target platform,
         # so the app recipes do not parse for a 32-bit machine

--- a/recipes-devtools/capnproto/capnproto_%.bbappend
+++ b/recipes-devtools/capnproto/capnproto_%.bbappend
@@ -1,0 +1,17 @@
+#
+# SPDX-FileCopyrightText: (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
+#
+# meta-oe builds capnproto static and non-PIC, so linking capnp or kj into a
+# shared library fails on kj/exception.c++'s thread-local:
+#
+#   libkj.a(exception.c++.o): relocation R_X86_64_TPOFF32 against
+#   `kj::(anonymous namespace)::threadLocalCallback' can not be used when making
+#   a shared object; local-exec is incompatible with -shared
+#
+# test-runner hits this: libTestRunnerClient is SHARED and links both. Code model
+# only -- still static, no .so, no new packages -- but capnproto's sstate is
+# invalidated. Belongs in meta-oe; drop this when it lands there.
+#
+EXTRA_OECMAKE:append = " -DCMAKE_POSITION_INDEPENDENT_CODE=ON"

--- a/recipes-devtools/capnproto/capnproto_%.bbappend
+++ b/recipes-devtools/capnproto/capnproto_%.bbappend
@@ -15,3 +15,20 @@
 # invalidated. Belongs in meta-oe; drop this when it lands there.
 #
 EXTRA_OECMAKE:append = " -DCMAKE_POSITION_INDEPENDENT_CODE=ON"
+
+# find_package(CapnProto) fails against the target sysroot: CapnProtoTargets.cmake
+# exports imported targets for capnp_tool, capnpc_cpp and capnpc_capnp, and Yocto
+# does not stage ${bindir} for target recipes, so CMake reports the package as
+# "faulty ... but not all the files it references". test-runner's
+# find_package(CapnProto REQUIRED) is where it surfaces.
+#
+# meta-oe carries this patch already; it arrived after this branch. Native still
+# installs and exports the binaries, so capnproto-native keeps providing the capnp
+# the build actually runs -- the patch keys off CMAKE_CROSSCOMPILING, so a native
+# build is unchanged. Cross installs them without exporting. Applied to every
+# variant, as meta-oe does, so nativesdk is covered too.
+#
+# Applies to 1.0.2, which is the only capnproto this branch's meta-oe has.
+# Belongs in meta-oe; drop this when it lands there.
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+SRC_URI:append = " file://0001-Export-binaries-only-for-native-build.patch"

--- a/recipes-devtools/capnproto/files/0001-Export-binaries-only-for-native-build.patch
+++ b/recipes-devtools/capnproto/files/0001-Export-binaries-only-for-native-build.patch
@@ -1,0 +1,53 @@
+From e654a7015f5e8f20bf7681681cc2b80082303007 Mon Sep 17 00:00:00 2001
+From: Gyorgy Sarvari <skandigraun@gmail.com>
+Date: Tue, 25 Feb 2025 13:43:42 +0100
+Subject: [PATCH] Export binaries only for native build
+
+By default, the cmake configuratione exports all generated files,
+so when using the generated cmake file with a find_package command,
+it verifies that these files actually exist.
+
+When using the cross-compiled version of capnproto, the generated
+binaries are not available in RECIPE_SYSROOT (since they can be
+used as RDEPENDS only, but not usable as DEPENDS), and due to
+this the compilation fails.
+
+To avoid this, check during the compilation of capnproto if it is
+being cross-compiled, or not. If is it cross-compiled, then only
+install the generated binary files in their final location, but
+don't export them. When not cross-compiling, do the same, but also
+export the files (which is the default behavior).
+
+Upstream-Status: Inappropriate [oe specific: see above message]
+
+Signed-off-by: Gyorgy Sarvari <skandigraun@gmail.com>
+---
+ c++/src/capnp/CMakeLists.txt | 15 ++++++++++++++-
+ 1 file changed, 14 insertions(+), 1 deletion(-)
+
+diff --git a/c++/src/capnp/CMakeLists.txt b/c++/src/capnp/CMakeLists.txt
+index 9980fde6..8732db93 100644
+--- a/src/capnp/CMakeLists.txt
++++ b/src/capnp/CMakeLists.txt
+@@ -210,7 +210,20 @@ if(NOT CAPNP_LITE)
+   target_link_libraries(capnpc_capnp capnp kj)
+   set_target_properties(capnpc_capnp PROPERTIES OUTPUT_NAME capnpc-capnp)
+ 
+-  install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
++  if(NOT CMAKE_CROSSCOMPILING)
++    install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_DEFAULT_ARGS})
++  else()
++    # INSTALL_TARGETS_CROSS_COMPILED_BINARY_ARGS is identical to INSTALL_TARGETS_DEFAULT_ARGS,
++    # except that the installed files are not exported, so when the generated cmake file
++    # is used by a find_package command, it won't try to find these files.
++    set(INSTALL_TARGETS_CROSS_COMPILED_BINARY_ARGS
++      ARCHIVE DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++      LIBRARY DESTINATION "${CMAKE_INSTALL_LIBDIR}"
++      RUNTIME DESTINATION "${CMAKE_INSTALL_BINDIR}"
++    )
++
++    install(TARGETS capnp_tool capnpc_cpp capnpc_capnp ${INSTALL_TARGETS_CROSS_COMPILED_BINARY_ARGS})
++  endif()
+ 
+   if(WIN32)
+     # On Windows platforms symlinks are not guaranteed to support. Also different version of CMake handle create_symlink in a different way.

--- a/recipes-graphics/toyota/test-runner_git.bb
+++ b/recipes-graphics/toyota/test-runner_git.bb
@@ -1,0 +1,123 @@
+#
+# SPDX-FileCopyrightText: (c) 2026 Joel Winarske
+#
+# SPDX-License-Identifier: MIT
+#
+# Cap'n Proto RPC daemon that runs on a device under test beside
+# ivi-homescreen, plus the client library a harness drives it with.
+#
+# Binds 0.0.0.0:4004 unauthenticated: test lab networks only. Needs
+# CONFIG_INPUT_UINPUT and /dev/uinput to inject, /dev/input/event* to record.
+#
+
+SUMMARY = "Remote input injection and recording daemon for ivi-homescreen"
+DESCRIPTION = "Cap'n Proto RPC server that injects mouse, keyboard, touchscreen \
+and multi-touch events through uinput, records /dev/input events for replay, and \
+captures Weston compositor screenshots. Ships the client library harnesses use."
+AUTHOR = "matt.everett@toyotaconnected.com"
+HOMEPAGE = "https://github.com/toyota-connected/test_runner"
+BUGTRACKER = "https://github.com/toyota-connected/test_runner/issues"
+SECTION = "devel"
+CVE_PRODUCT = "test_runner"
+
+# Sources say "GPLv3", which is not valid SPDX; LICENSE is the GPLv3 text.
+LICENSE = "GPL-3.0-only"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=1ebbd3e34237af26da5dc08a4e440464"
+
+TEST_RUNNER_COMMIT ??= "f544fc2bd5539ec4c9d0f867a46745745314e4f4"
+
+SRC_URI = "git://github.com/toyota-connected/test_runner.git;protocol=https;branch=main"
+SRCREV = "${TEST_RUNNER_COMMIT}"
+PV = "0.1+git"
+
+inherit cmake pkgconfig features_check
+
+# capnproto.bbclass arrived in meta-oe in 6b1ba4543a, after this branch, so
+# inherit it by hand. This is the whole class: capnp and capnpc-c++ have to be
+# the native ones, because CMake runs them at build time.
+DEPENDS:append = " capnproto-native "
+DEPENDS:append:class-target = " capnproto "
+EXTRA_OECMAKE:append:class-target = " -DCAPNP_EXECUTABLE=${RECIPE_SYSROOT_NATIVE}${bindir}/capnp \
+                                      -DCAPNPC_CXX_EXECUTABLE=${RECIPE_SYSROOT_NATIVE}${bindir}/capnpc-c++ "
+
+# ON builds the vendored capnproto 0.9.1, which runs ./configure at configure
+# time and then hands CMake a target capnp to run on the build host.
+# capnproto.bbclass feeds upstream's if(NOT BUILD_CAPNP) path instead.
+EXTRA_OECMAKE += "-DBUILD_CAPNP=OFF"
+
+# Both are broken upstream (see below) and read undeclared cache variables, so
+# pin them rather than trust them to stay unset.
+EXTRA_OECMAKE += "-DBUILD_TESTS=OFF -DBUILD_UNIT_TESTS=OFF"
+
+PACKAGECONFIG ??= "server examples recorder weston-screenshooter agl-health"
+
+# Client only: the host side of a harness needs no uinput or Wayland.
+PACKAGECONFIG:class-native = "weston-screenshooter agl-health"
+PACKAGECONFIG:class-nativesdk = "weston-screenshooter agl-health"
+
+# Builds libTestRunnerServer and libTestRunnerRecorder; without it the project
+# produces only libTestRunnerClient.
+PACKAGECONFIG[server] = "-DBUILD_SERVER=ON,-DBUILD_SERVER=OFF,libxkbcommon udev"
+
+# Builds the executables, daemon included, so not optional in practice.
+PACKAGECONFIG[examples] = "-DBUILD_EXAMPLES=ON,-DBUILD_EXAMPLES=OFF"
+
+# libTestRunnerRecorder, the TestRunner-Recorder tool and the server's Recorder
+# RPC methods. OFF leaves those methods answering "unimplemented", so clients
+# need no rebuild.
+PACKAGECONFIG[recorder] = "-DBUILD_RECORDER=ON,-DBUILD_RECORDER=OFF"
+
+# Recorder input backend: libinput instead of raw evdev. Off matches upstream CI.
+PACKAGECONFIG[libinput] = "-DENABLE_LIBINPUT=ON,-DENABLE_LIBINPUT=OFF,libinput"
+
+# Only the plugin's server half links wayland-client, so that dependency is
+# added by server + this option together, below.
+PACKAGECONFIG[weston-screenshooter] = "-DENABLE_PLUGIN_WESTON_SCREENSHOOTER=ON,\
+    -DENABLE_PLUGIN_WESTON_SCREENSHOOTER=OFF"
+
+PACKAGECONFIG[agl-health] = "-DENABLE_PLUGIN_AGL_HEALTH=ON,-DENABLE_PLUGIN_AGL_HEALTH=OFF,curl"
+
+# Instrumented binaries only; the coverage targets run the tests and lcov on the
+# build host. GCOV_EXECUTABLE is seeded because coverage.cmake probes it
+# REQUIRED and no native gcov answers to that name.
+PACKAGECONFIG[coverage] = "-DENABLE_COVERAGE=ON \
+    -DGCOV_EXECUTABLE=${STAGING_BINDIR_TOOLCHAIN}/${TARGET_PREFIX}gcov,\
+    -DENABLE_COVERAGE=OFF,lcov-native"
+
+#
+# Not exposed:
+#
+#   BUILD_TESTS       compiles kj_client.cpp and kj_server.cpp, absent from the
+#                     tree, and depends on a renamed target
+#   BUILD_UNIT_TESTS  hard-codes the vendored capnproto 0.9.1 include path,
+#                     searched ahead of the sysroot while linking target libcapnp
+#
+
+DEPENDS += "${@bb.utils.contains('PACKAGECONFIG', 'server', \
+    bb.utils.contains('PACKAGECONFIG', 'weston-screenshooter', 'wayland', '', d), '', d)}"
+
+REQUIRED_DISTRO_FEATURES = "${@bb.utils.contains('PACKAGECONFIG', 'server', \
+    bb.utils.contains('PACKAGECONFIG', 'weston-screenshooter', 'wayland', '', d), '', d)}"
+
+python () {
+    pc = set((d.getVar('PACKAGECONFIG') or '').split())
+    pn = d.getVar('PN')
+
+    if 'examples' in pc and 'server' not in pc:
+        bb.fatal("%s: 'examples' links the libraries 'server' builds -- enable both" % pn)
+
+    if 'server' in pc and 'examples' not in pc:
+        bb.warn("%s: 'server' without 'examples' ships libraries but no daemon" % pn)
+
+    if 'recorder' in pc and 'server' not in pc:
+        bb.warn("%s: 'recorder' needs 'server'; the client builds no recorder" % pn)
+
+    if 'libinput' in pc and 'recorder' not in pc:
+        bb.warn("%s: 'libinput' is the recorder's input backend, and 'recorder' is off" % pn)
+}
+
+# No SOVERSION on any of the libraries, so keep the .so files out of -dev.
+SOLIBS = ".so"
+FILES_SOLIBSDEV = ""
+
+BBCLASSEXTEND = "native nativesdk"

--- a/recipes-graphics/toyota/test-runner_git.bb
+++ b/recipes-graphics/toyota/test-runner_git.bb
@@ -30,6 +30,12 @@ SRC_URI = "git://github.com/toyota-connected/test_runner.git;protocol=https;bran
 SRCREV = "${TEST_RUNNER_COMMIT}"
 PV = "0.1+git"
 
+# The git fetcher unpacks to ${WORKDIR}/git on this release, while the default
+# S is ${WORKDIR}/${BP}. wrynose needs no S because UNPACKDIR and the fetcher's
+# destsuffix agree there; here they do not, and do_populate_lic fails first --
+# LIC_FILES_CHKSUM points at a LICENSE that is not under S.
+S = "${WORKDIR}/git"
+
 inherit cmake pkgconfig features_check
 
 # capnproto.bbclass arrived in meta-oe in 6b1ba4543a, after this branch, so


### PR DESCRIPTION
Ports `test-runner_git.bb` and the `capnproto_%.bbappend` it depends on.

**The bbclass problem, and why vendoring is not the answer.**
`inherit capnproto` does not work here: meta-oe added `capnproto.bbclass`
in `6b1ba4543a` (2025-02-03), after this branch, and never backported it.

Building the vendored capnproto 0.9.1 instead does not solve it. That path
produces a *target* `capnp` and then has CMake run it on the build host,
which cannot work in a cross build -- it is exactly why the recipe pins
`-DBUILD_CAPNP=OFF`.

The bbclass is four lines, and nothing in them needs meta-oe to ship it,
so they are inlined with a note to drop them if it is ever backported.
`capnproto_1.0.2.bb` here carries `BBCLASSEXTEND = "native nativesdk"`, so
`capnproto-native` resolves.

**The bbappend is a separate requirement.** `libTestRunnerClient` is
SHARED and links both `capnp` and `kj`; meta-oe builds them static and
non-PIC, so the link fails:

```
libkj.a(exception.c++.o): relocation R_X86_64_TPOFF32 against
`kj::(anonymous namespace)::threadLocalCallback' can not be used when
making a shared object
```

Code model only -- still static, no `.so`, no new packages -- but it does
invalidate capnproto's sstate. Belongs in meta-oe; drop it when it lands
there. Same workaround wrynose carries, and what #899 is waiting on.

**Built in CI**, on every machine including `qemuarm` -- nothing here
involves Flutter, so the app recipes' 64-bit-only exclusion does not
apply. Mirrors wrynose's step.

That build is also the open question answered: this branch's meta-oe has
capnproto **1.0.2** where wrynose has 1.4.0, and I have not verified the
API is compatible. If it is not, this is where it shows.