### PR TITLE
ci: build the SDK apps offline, and show failure logs

### DIFF
--- a/.github/workflows/wrynose-build.yml
+++ b/.github/workflows/wrynose-build.yml
@@ -402,8 +402,17 @@ jobs:
           . ./openembedded-core/oe-init-build-env
           # Two of the fourteen. hello_world proves the shape; flutter_gallery
           # proves it holds for an app with real dependencies.
-          bitbake flutter-sdk-examples-hello-world \
-                  flutter-sdk-dev-integration-tests-flutter-gallery
+          APPS="flutter-sdk-examples-hello-world \
+                flutter-sdk-dev-integration-tests-flutter-gallery"
+
+          # These vendor the SDK workspace's pub cache -- one fragment for all
+          # of them, since they are members of one workspace with one lockfile.
+          # Fetch first, then build with the network off: anything the fragment
+          # failed to declare cannot be fetched and fails here rather than
+          # working quietly on a machine that happens to be online. Same as
+          # master.
+          bitbake --runall=fetch $APPS
+          BB_NO_NETWORK=1 bitbake $APPS
 
       - name: Build jwinarske-bluez-native-flutter-ble-scanner
         # flutter build bundle has no linux-arm target platform,
@@ -421,3 +430,23 @@ jobs:
         shell: bash
         working-directory: ../wrynose-linux-dummy
         run: rm -f .ci-build-incomplete
+
+      # bitbake prints only the path to a failed task's log, and that path is
+      # inside the work tree on the runner. Without this a do_configure or
+      # do_compile failure reaches us as "ExecutionError(...run.do_configure)"
+      # and nothing else, which is not enough to act on. Last in the job so it
+      # sees a failure from any step above it.
+      - name: Show bitbake failure logs
+        if: failure()
+        shell: bash
+        working-directory: ../wrynose-linux-dummy
+        run: |
+          found=0
+          while IFS= read -r f; do
+            grep -qiE '^(ERROR|CMake Error)|error:' "$f" || continue
+            found=1
+            echo "::group::$f"
+            tail -120 "$f"
+            echo "::endgroup::"
+          done < <(find build/tmp*/work -name 'log.do_*' -mmin -240 2>/dev/null | head -40)
+          [ "$found" = 1 ] || echo "no task log with an error recorded in the last 4h"


### PR DESCRIPTION
Two CI gaps, each already closed on another branch.

**Build the SDK apps with the network off.** The step ran plain `bitbake`,
so a package the workspace pub cache fragment failed to declare would be
fetched anyway and the build would pass -- on a runner that happens to be
online. master already does:

```
bitbake --runall=fetch $APPS
BB_NO_NETWORK=1 bitbake $APPS
```

Fetch first, then build offline, so an undeclared package fails at the
fetch rather than quietly working. Adopted here unchanged. This is the
whole point of `pub-cache.bbclass`, and until now nothing on this branch
actually held it to it.

**Show bitbake's failure logs.** A failed task reaches us as
`ExecutionError(...run.do_configure)` and a path inside the runner's work
tree -- not enough to act on. On scarthgap this step is what turned two
failures from guesswork into a diagnosis: a missing `S` and CapnProto
exporting binaries absent from the target sysroot. Both needed the CMake
output, which never left the machine.

Runs only on failure and is last in the job, so it sees a failure from any
step above it and a green run is unchanged.

scarthgap gets the offline build next; master gets the failure-log step.