### PR TITLE
ci: show bitbake failure logs

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -422,3 +422,23 @@ jobs:
         shell: bash
         working-directory: ../master-linux-dummy
         run: rm -f .ci-build-incomplete
+
+      # bitbake prints only the path to a failed task's log, and that path is
+      # inside the work tree on the runner. Without this a do_configure or
+      # do_compile failure reaches us as "ExecutionError(...run.do_configure)"
+      # and nothing else, which is not enough to act on. Last in the job so it
+      # sees a failure from any step above it.
+      - name: Show bitbake failure logs
+        if: failure()
+        shell: bash
+        working-directory: ../master-linux-dummy
+        run: |
+          found=0
+          while IFS= read -r f; do
+            grep -qiE '^(ERROR|CMake Error)|error:' "$f" || continue
+            found=1
+            echo "::group::$f"
+            tail -120 "$f"
+            echo "::endgroup::"
+          done < <(find build/tmp*/work -name 'log.do_*' -mmin -240 2>/dev/null | head -40)
+          [ "$found" = 1 ] || echo "no task log with an error recorded in the last 4h"


### PR DESCRIPTION
A failed task reaches us as `ExecutionError(...run.do_configure)` and a
path inside the runner's work tree -- not enough to act on without
reproducing the build locally.

On scarthgap this step is what turned two failures into a diagnosis rather
than guesswork: a missing `S` for that release's fetcher layout, and
CapnProto exporting imported targets for binaries Yocto does not stage
into the target sysroot. Both needed the CMake output, which otherwise
never leaves the machine.

Runs only on failure and is last in the job, so it sees a failure from any
step above it and a green run is unchanged.

Same step as #924 on wrynose. Nothing else here needs it: master already
builds the SDK apps and already does the fetch-then-`BB_NO_NETWORK` pass
the other two branches were missing -- #924 adopts that from here.