### PR TITLE
ci: build the SDK apps offline

### DIFF
--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -385,8 +385,17 @@ jobs:
           # proves it holds for an app with real dependencies. These are also
           # the only recipes that inherit pub-cache, so without them the class
           # and the timeout hosttool it needs are never executed.
-          bitbake flutter-sdk-examples-hello-world \
-                  flutter-sdk-dev-integration-tests-flutter-gallery
+          APPS="flutter-sdk-examples-hello-world \
+                flutter-sdk-dev-integration-tests-flutter-gallery"
+
+          # These vendor the SDK workspace's pub cache -- one fragment for all
+          # of them, since they are members of one workspace with one lockfile.
+          # Fetch first, then build with the network off: anything the fragment
+          # failed to declare cannot be fetched and fails here rather than
+          # working quietly on a machine that happens to be online. Same as
+          # master and wrynose.
+          bitbake --runall=fetch $APPS
+          BB_NO_NETWORK=1 bitbake $APPS
 
       #
       # bluez_native: compiles a vendored sdbus-c++ from its own hook.


### PR DESCRIPTION
Last of the three CI gaps. master already did this; wrynose adopted it in
#924.

The SDK app step ran plain `bitbake`, so a package the workspace pub cache
fragment failed to declare would be fetched anyway and the build would
pass -- on a runner that happens to be online. Now:

```
bitbake --runall=fetch $APPS
BB_NO_NETWORK=1 bitbake $APPS
```

Fetch first, then build offline, so an undeclared package fails at the
fetch instead of quietly working.

This branch has the sharpest reason for it. The SDK apps here hung for the
full 600s in `do_pub_get_offline` until #921 relativized the staged
package configs -- a resolve reaching for the network in a task that had
none. With the network up, a regression of that shape can pass.

After this the three branches build the SDK apps the same way, and all
three carry the failure-log step.