### PR TITLE
ci: build kirkstone per pull request

### DIFF
--- a/.github/workflows/kirkstone-build.yml
+++ b/.github/workflows/kirkstone-build.yml
@@ -1,18 +1,44 @@
 name: kirkstone-build
 
-# Release-branch builds are dispatch-only, but cover every machine master
-# covers. The runner is sequential, so the matrix queues and runs one machine
-# at a time against a single tree, which is how master's tmp comes to hold all
-# four already.
+# Builds per pull request, and covers every machine master covers. The runner
+# is sequential, so the matrix queues and runs one machine at a time against a
+# single tree, which is how master's tmp comes to hold all four already.
 #
-# Dispatch rather than per-pull-request is a disk constraint, not a coverage
-# one: a populated tmp is around 106G against 264G free, so master and the four
-# release branches cannot all keep one. The tree here is this branch's own, so
-# master's is never disturbed, and any other release branch's tmp is removed
-# first, which holds the release branches to one populated tree between them.
+# This was dispatch-only on the grounds that a populated tmp is around 106G
+# against 264G free. That figure was an assumption and it was wrong: measured,
+# the five trees come to 153G in total, 19G to 34G each, against terabytes
+# free -- see the reclaim step below, which has been conditional on the disk
+# actually being short since. master, wrynose and scarthgap already build per
+# pull request; this branch is next in line for parity work and should not
+# take it unbuilt.
+#
+# The tree here is this branch's own, so master's is never disturbed.
 
 on:
+  pull_request:
+    # No 'closed': nothing here is conditioned on the event, so closing or
+    # merging would start a second full build of work already merged.
+    types: [ opened, synchronize, reopened ]
+    # A change that cannot affect a build should not cost a matrix.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'tools/**'
+      - '.github/workflows/tools-tests.yml'
+      - '.gitignore'
+      - 'LICENSE'
   workflow_dispatch:
+
+# One run per branch. Every push to a pull request starts a run and GitHub does
+# not stop the previous one, so an iterated branch leaves a queue of runs
+# against commits that have already been superseded.
+#
+# Cancelling is limited to pull_request on purpose: a workflow_dispatch is
+# someone deliberately asking for a build, and a second dispatch on the same
+# ref should not silently kill the first.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
 


### PR DESCRIPTION
Gives this branch the `pull_request` trigger and `concurrency` block
master, wrynose and scarthgap have: same `paths-ignore`, same `types` list
without `closed`, and `cancel-in-progress` limited to `pull_request` so a
deliberate dispatch is never killed by a second one.

**The stated reason for dispatch-only does not hold.** The header claimed a
populated tmp is "around 106G against 264G free", so master plus the four
release branches could not all keep one. That was an assumption. The
reclaim step *in this same file* already records the measurement that
replaced it -- 153G across five trees, 19G to 34G each, against terabytes
free -- which is why reclaiming has been conditional on `MIN_FREE_GB`
rather than unconditional.

Nothing about tree ownership changes: the reclaim list here already
protects `master` and `kirkstone`.

**Why now.** Parity work is coming to this branch, and nothing here runs on
a pull request today. The scarthgap port found three separate bugs only
because CI built it -- a missing postfunc that hung the SDK apps for 600s,
a missing `S`, and CapnProto exporting binaries absent from the target
sysroot. Porting to a branch with no automatic builds would mean finding
those by hand, or not at all.

dunfell gets the same change separately.