### PR TITLE
ci: build dunfell per pull request

### DIFF
--- a/.github/workflows/dunfell-build.yml
+++ b/.github/workflows/dunfell-build.yml
@@ -1,18 +1,45 @@
 name: dunfell-build
 
-# Release-branch builds are dispatch-only, but cover every machine master
-# covers. The runner is sequential, so the matrix queues and runs one machine
-# at a time against a single tree, which is how master's tmp comes to hold all
-# four already.
+# Builds per pull request. The runner is sequential, so the matrix queues and
+# runs one machine at a time against a single tree.
 #
-# Dispatch rather than per-pull-request is a disk constraint, not a coverage
-# one: a populated tmp is around 106G against 264G free, so master and the four
-# release branches cannot all keep one. The tree here is this branch's own, so
-# master's is never disturbed, and any other release branch's tmp is removed
-# first, which holds the release branches to one populated tree between them.
+# Three machines, not master's four: riscv64 was barely supported by this era's
+# toolchain -- see the matrix comment below.
+#
+# This was dispatch-only on the grounds that a populated tmp is around 106G
+# against 264G free. That figure was an assumption and it was wrong: measured,
+# the five trees come to 153G in total, 19G to 34G each, against terabytes
+# free -- see the reclaim step below, which has been conditional on the disk
+# actually being short since. master, wrynose, scarthgap and kirkstone build
+# per pull request; this branch was the last one that did not.
+#
+# The tree here is this branch's own, so master's is never disturbed.
 
 on:
+  pull_request:
+    # No 'closed': nothing here is conditioned on the event, so closing or
+    # merging would start a second full build of work already merged.
+    types: [ opened, synchronize, reopened ]
+    # A change that cannot affect a build should not cost a matrix.
+    paths-ignore:
+      - '**/*.md'
+      - 'docs/**'
+      - 'tools/**'
+      - '.github/workflows/tools-tests.yml'
+      - '.gitignore'
+      - 'LICENSE'
   workflow_dispatch:
+
+# One run per branch. Every push to a pull request starts a run and GitHub does
+# not stop the previous one, so an iterated branch leaves a queue of runs
+# against commits that have already been superseded.
+#
+# Cancelling is limited to pull_request on purpose: a workflow_dispatch is
+# someone deliberately asking for a build, and a second dispatch on the same
+# ref should not silently kill the first.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
 


### PR DESCRIPTION
Counterpart to #927. Gives this branch the `pull_request` trigger and
`concurrency` block the other four have.

**The stated reason for dispatch-only does not hold.** The header claimed a
populated tmp is "around 106G against 264G free". That was an assumption;
the reclaim step *in this same file* records the measurement that replaced
it -- 153G across five trees, 19G to 34G each, against terabytes free --
which is why reclaiming has been conditional on `MIN_FREE_GB` rather than
unconditional. The reclaim list already protects `master` and `dunfell`.

**One correction while rewriting it.** The header also said this branch
"cover[s] every machine master covers". It builds three, not four; the
matrix comment a few lines down already explains that riscv64 was barely
supported by this era's toolchain. Header now agrees with the matrix.

**Why now.** Parity work is planned here, and nothing runs on a pull
request today. Worth flagging one thing about this branch specifically:
bitbake 1.46 has no `disable_network`, so the `[network]` task flag is
silently ignored -- four files already set it and none of them do
anything. That makes CI the only place an offline-resolution regression
can be caught here, which is an argument for building per pull request
rather than against it.