### PR TITLE
sdk_apps: skip branches that carry no SDK apps

### DIFF
--- a/tools/sdk_apps.py
+++ b/tools/sdk_apps.py
@@ -243,6 +243,16 @@ def roll_sdk_apps(layer_root, clone=None):
     output_dir = os.path.join(layer_root, 'recipes-graphics', 'flutter-sdk', 'apps')
     overrides = os.path.join(output_dir, 'sdk-apps-overrides.json')
 
+    # Every generated recipe starts with `require conf/include/flutter-sdk-app.inc`.
+    # A branch that does not carry that include does not carry SDK apps, and
+    # writing recipes that require a missing file would break parsing for every
+    # target on the branch. Skip rather than emit them.
+    include = os.path.join(layer_root, 'conf', 'include', 'flutter-sdk-app.inc')
+    if not os.path.isfile(include):
+        print('No conf/include/flutter-sdk-app.inc; this branch carries no SDK '
+              'apps, skipping their generation')
+        return True
+
     tmp = None
     if clone is None:
         release_hash = pinned_release_hash(layer_root)

--- a/tools/tests/test_sdk_apps.py
+++ b/tools/tests/test_sdk_apps.py
@@ -131,6 +131,13 @@ def test_apps_are_emitted_in_a_stable_order(tmp_path):
     assert [c['path'] for c in cands] == sorted(c['path'] for c in cands)
 
 
+def _carries_sdk_apps(layer):
+    """The guard in roll_sdk_apps skips a branch with no flutter-sdk-app.inc."""
+    inc = layer / 'conf' / 'include'
+    inc.mkdir(parents=True, exist_ok=True)
+    (inc / 'flutter-sdk-app.inc').write_text('# marker\n')
+
+
 def test_roll_sdk_apps_is_not_fatal_when_the_clone_fails(tmp_path, monkeypatch, capsys):
     """A roll that has already bumped the SDK must not be thrown away.
 
@@ -138,6 +145,7 @@ def test_roll_sdk_apps_is_not_fatal_when_the_clone_fails(tmp_path, monkeypatch, 
     parsing, and only the handful built in CI would ever notice.
     """
     import subprocess as sp
+    _carries_sdk_apps(tmp_path)
     monkeypatch.setattr(sdk_apps, 'pinned_release_hash', lambda root: 'deadbeef')
 
     def boom(*a, **kw):
@@ -151,6 +159,7 @@ def test_roll_sdk_apps_is_not_fatal_when_the_clone_fails(tmp_path, monkeypatch, 
 
 
 def test_roll_sdk_apps_reports_a_missing_release_hash(tmp_path, monkeypatch, capsys):
+    _carries_sdk_apps(tmp_path)
     monkeypatch.setattr(sdk_apps, 'pinned_release_hash', lambda root: None)
     assert sdk_apps.roll_sdk_apps(str(tmp_path)) is False
     assert 'no release hash' in capsys.readouterr().out
@@ -162,6 +171,7 @@ def test_roll_sdk_apps_generates_from_an_existing_clone(tmp_path):
     (clone / 'pubspec.yaml').write_text('name: _flutter_packages\n')
     layer = tmp_path / 'layer'
     (layer / 'conf' / 'include').mkdir(parents=True)
+    _carries_sdk_apps(layer)
     (layer / 'conf' / 'include' / 'flutter-version.inc').write_text(
         'FLUTTER_SDK_TAG ??= "3.47.1"\n')
     (layer / 'conf' / 'include' / 'releases_linux.json').write_text(
@@ -171,3 +181,15 @@ def test_roll_sdk_apps_generates_from_an_existing_clone(tmp_path):
     written = sorted(p.name for p in
                      (layer / 'recipes-graphics' / 'flutter-sdk' / 'apps').iterdir())
     assert 'flutter-sdk-examples-hello-world.bb' in written
+
+
+def test_roll_sdk_apps_skips_a_branch_without_the_include(tmp_path, capsys):
+    """dunfell carries no SDK apps.
+
+    Every generated recipe requires conf/include/flutter-sdk-app.inc, so
+    emitting them on a branch without it would break parsing for every target
+    on that branch. Skipping is success, not failure -- there is nothing to
+    generate.
+    """
+    assert sdk_apps.roll_sdk_apps(str(tmp_path)) is True
+    assert 'carries no SDK apps' in capsys.readouterr().out


### PR DESCRIPTION
Every generated SDK app recipe opens with `require conf/include/flutter-sdk-app.inc`. A branch without that include does not carry SDK apps, and writing recipes that require a missing file breaks parsing for **every** target on the branch, not just the apps.

`roll_sdk_apps()` is called unconditionally from the roll, so there was no way to express that. Now it checks for the include, skips, and says why. It returns `True`: there is nothing to generate, which is not a failure.

**Inert here.** master, wrynose, scarthgap and kirkstone all carry the include, so the guard never fires on them and the roll behaves exactly as before.

**Why now.** dunfell is getting the tooling and the roll to 3.47.2 without the pub-cache and SDK app stack -- `[network]` is a no-op on bitbake 1.46, so the offline guarantee cannot be enforced there. Without this guard its
roll would emit 14 recipes requiring an include the branch does not have. Deleting them after each roll would work once and regress on the next one, so the guard belongs in the tooling.

Three tests built a layer root without the include and were relying on the old unconditional behavior; they now state that precondition through a helper. One more test covers the skip. 115/115.

`tools/**` is in paths-ignore, so this costs no matrix.