### PR TITLE
ci: the SDK ships fourteen apps, not fifteen

### DIFF
--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -381,7 +381,7 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          # Two of the fifteen. hello_world proves the shape; flutter_gallery
+          # Two of the fourteen. hello_world proves the shape; flutter_gallery
           # proves it holds for an app with real dependencies. These are also
           # the only recipes that inherit pub-cache, so without them the class
           # and the timeout hosttool it needs are never executed.


### PR DESCRIPTION
The comment on the SDK app build step says "Two of the fifteen". It is fourteen.

The roll generates 14 `flutter-sdk-*.bb` recipes. The other two files in `recipes-graphics/flutter-sdk/apps/` are
`flutter-sdk-workspace-pubcache.inc` (the pub cache fragment) and `sdk-apps-overrides.json` (generator input) -- neither is an app. My miscount when writing this branch's step, from counting files in the directory rather than recipes. wrynose says "fourteen"; kirkstone's equivalent was written without a count.

The same miscount is in #921's commit message, which is history and stays as it is.

Comment only. Costs a matrix because the workflow file is not in its own paths-ignore, and there was no other pending scarthgap change to bundle it with.