### PR TITLE
flutter-engine: give consumers a package name to depend on

### DIFF
--- a/.github/workflows/master-build.yml
+++ b/.github/workflows/master-build.yml
@@ -276,6 +276,23 @@ jobs:
           . ./openembedded-core/oe-init-build-env
           bitbake flutter-pi
 
+      # The flutter-elinux embedders. These link libflutter_engine.so directly,
+      # so they are the recipes that exercise FLUTTER_ENGINE_PACKAGE -- nothing
+      # else in this workflow does, and #887 sat broken because none of them was
+      # ever built here.
+      #
+      # x11-client needs the x11 distro feature and the rest need wayland; the
+      # CI distro carries both.
+      - name: Build the flutter-elinux embedders
+        shell: bash
+        working-directory: ../master-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          bitbake flutter-wayland-client \
+                  flutter-x11-client \
+                  flutter-drm-gbm-backend \
+                  flutter-drm-eglstream-backend
+
       # The ivi-homescreen v3 integration tests. All ten come from one upstream
       # tree at HOMESCREEN_COMMIT through ivi-homescreen-test.inc, so they share
       # a source revision and stand or fall together far more often than not.

--- a/conf/include/flutter-version.inc
+++ b/conf/include/flutter-version.inc
@@ -6,6 +6,23 @@
 
 FLUTTER_SDK_TAG ??= "3.47.2"
 
+# The package that ships libflutter_engine.so.
+#
+# flutter-engine is ALLOW_EMPTY and carries no files of its own: the per-mode
+# packages claim them, and it only RDEPENDs on whichever modes were built.
+# file-rdeps resolves a shared library against the packages named in a recipe's
+# RDEPENDS and does not follow a metapackage's own, so a recipe that links the
+# engine has to name the package that carries it. Depending on flutter-engine
+# alone gives "requires libflutter_engine.so(), but no providers found in
+# RDEPENDS" -- see #887.
+#
+# release is in the engine's default PACKAGECONFIG. Override in local.conf for
+# an image that ships a different mode:
+#
+#   FLUTTER_ENGINE_PACKAGE = "flutter-engine-debug"
+#
+FLUTTER_ENGINE_PACKAGE ??= "flutter-engine-release"
+
 def get_flutter_archive(d):
     return _get_flutter_release_info(d, "archive")
 

--- a/recipes-graphics/flutter-elinux/flutter-elinux.inc
+++ b/recipes-graphics/flutter-elinux/flutter-elinux.inc
@@ -59,7 +59,10 @@ do_configure:prepend() {
 
 PRIVATE_LIBS:${PN} = "libflutter_engine.so"
 
-RDEPENDS:${PN} += "flutter-engine"
+# flutter-engine for the metapackage, and the package that actually ships
+# libflutter_engine.so so file-rdeps can resolve it. See FLUTTER_ENGINE_PACKAGE
+# in conf/include/flutter-version.inc.
+RDEPENDS:${PN} += "flutter-engine ${FLUTTER_ENGINE_PACKAGE}"
 
 python () {
     d.setVar('FLUTTER_SDK_VERSION', get_flutter_sdk_version(d))


### PR DESCRIPTION
Fixes #887.

**The failure.** `flutter-wayland-client` fails `do_package_qa` on scarthgap:

```
/usr/bin/flutter-client contained in package flutter-wayland-client
requires libflutter_engine.so()(64bit), but no providers found in
RDEPENDS:flutter-wayland-client [file-rdeps]
```

**Why.** Not a missing declaration -- the recipe has carried
`RDEPENDS:${PN} += "flutter-engine"` since 2022 and
`PRIVATE_LIBS:${PN} = "libflutter_engine.so"` since June. What changed is
inside the reporter's own bump window: `flutter-engine` no longer carries
files of its own. The per-mode packages (`-debug`, `-profile`, `-release`,
`-jit-release`) claim them, and `flutter-engine` became `ALLOW_EMPTY`,
RDEPENDing on whichever modes were built.

`file-rdeps` resolves a shared library against the packages named in a
recipe's RDEPENDS. It does not follow a metapackage's own RDEPENDS. So
depending on `flutter-engine` stopped resolving the library, while still
looking correct.

That also explains why only these recipes broke: `flutter-elinux.inc`
symlinks `libflutter_engine.so` into its build dir and links it, so its
binaries carry a `NEEDED` entry. `ivi-homescreen` has no such step, no
requirement, and passes.

**The fix.** `FLUTTER_ENGINE_PACKAGE` names the package that ships the
library:

```
FLUTTER_ENGINE_PACKAGE ??= "flutter-engine-release"
```

`release` is in the engine's default `PACKAGECONFIG` (`debug profile
release`), so the default resolves out of the box. Override in local.conf
for an image shipping a different mode:

```
FLUTTER_ENGINE_PACKAGE = "flutter-engine-debug"
```

It lives in `conf/include/flutter-version.inc` beside `FLUTTER_SDK_TAG` --
the same shape of layer default, in a file every consumer already
`require`s. `flutter-elinux.inc` keeps `flutter-engine` alongside it, so
the metapackage still pulls in the other built modes.

**Also builds the four elinux embedders in CI.** They are the only recipes
in this layer that link `libflutter_engine.so` directly, so nothing else
exercises this variable -- and #887 sat broken for weeks precisely because
none of them was ever built here. `flutter-x11-client` needs the `x11`
distro feature and the rest need `wayland`; I checked a green run's
`DISTRO_FEATURES` and the CI distro carries both, plus opengl and vulkan.

Release branches follow once this proves out. wrynose and scarthgap have
the same code under `recipes-graphics/sony/sony-flutter.inc`.