### PR TITLE
flutter-engine: give consumers a package name to depend on

### DIFF
--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -287,6 +287,23 @@ jobs:
           . ./openembedded-core/oe-init-build-env
           bitbake flutter-pi
 
+      # The sony embedders. These link libflutter_engine.so directly, so they
+      # are the recipes that exercise FLUTTER_ENGINE_PACKAGE -- nothing else in
+      # this workflow does, and #887 sat broken because none of them was ever
+      # built here.
+      #
+      # x11-client needs the x11 distro feature and the rest need wayland; the
+      # CI distro carries both.
+      - name: Build the sony embedders
+        shell: bash
+        working-directory: ../scarthgap-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          bitbake flutter-wayland-client \\
+                  flutter-x11-client \\
+                  flutter-drm-gbm-backend \\
+                  flutter-drm-eglstream-backend
+
       # The ivi-homescreen v3 integration tests. All ten come from one upstream
       # tree at HOMESCREEN_COMMIT through ivi-homescreen-test.inc, so they share
       # a source revision and stand or fall together far more often than not.

--- a/.github/workflows/scarthgap-build.yml
+++ b/.github/workflows/scarthgap-build.yml
@@ -299,9 +299,9 @@ jobs:
         working-directory: ../scarthgap-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-wayland-client \\
-                  flutter-x11-client \\
-                  flutter-drm-gbm-backend \\
+          bitbake flutter-wayland-client \
+                  flutter-x11-client \
+                  flutter-drm-gbm-backend \
                   flutter-drm-eglstream-backend
 
       # The ivi-homescreen v3 integration tests. All ten come from one upstream

--- a/conf/include/flutter-version.inc
+++ b/conf/include/flutter-version.inc
@@ -6,6 +6,23 @@
 
 FLUTTER_SDK_TAG ??= "3.47.2"
 
+# The package that ships libflutter_engine.so.
+#
+# flutter-engine is ALLOW_EMPTY and carries no files of its own: the per-mode
+# packages claim them, and it only RDEPENDs on whichever modes were built.
+# file-rdeps resolves a shared library against the packages named in a recipe's
+# RDEPENDS and does not follow a metapackage's own, so a recipe that links the
+# engine has to name the package that carries it. Depending on flutter-engine
+# alone gives "requires libflutter_engine.so(), but no providers found in
+# RDEPENDS" -- see #887.
+#
+# release is in the engine's default PACKAGECONFIG. Override in local.conf for
+# an image that ships a different mode:
+#
+#   FLUTTER_ENGINE_PACKAGE = "flutter-engine-debug"
+#
+FLUTTER_ENGINE_PACKAGE ??= "flutter-engine-release"
+
 def get_flutter_archive(d):
     return _get_flutter_release_info(d, "archive")
 

--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -73,7 +73,10 @@ do_configure:prepend() {
 
 PRIVATE_LIBS:${PN} = "libflutter_engine.so"
 
-RDEPENDS:${PN} += "flutter-engine"
+# flutter-engine for the metapackage, and the package that actually ships
+# libflutter_engine.so so file-rdeps can resolve it. See FLUTTER_ENGINE_PACKAGE
+# in conf/include/flutter-version.inc.
+RDEPENDS:${PN} += "flutter-engine ${FLUTTER_ENGINE_PACKAGE}"
 
 python () {
     d.setVar('FLUTTER_SDK_VERSION', get_flutter_sdk_version(d))


### PR DESCRIPTION
Port of #946. Fixes #887, which was reported against this branch.

`flutter-engine` carries no files of its own: the per-mode packages
(`-debug`, `-profile`, `-release`, `-jit-release`) claim them, and
`flutter-engine` is `ALLOW_EMPTY`, RDEPENDing on whichever modes were built.
`file-rdeps` resolves a shared library against the packages named in a
recipe's RDEPENDS and does not follow a metapackage's own -- so
`flutter-wayland-client`'s dependency stopped resolving
`libflutter_engine.so` when `8a406347` split the engine up.

The recipe was never missing a declaration: it has had
`RDEPENDS:${PN} += "flutter-engine"` since 2022 and
`PRIVATE_LIBS:${PN} = "libflutter_engine.so"` since June.

**The fix.** `FLUTTER_ENGINE_PACKAGE ??= "flutter-engine-release"`, in
`conf/include/flutter-version.inc` beside `FLUTTER_SDK_TAG` -- a file every
consumer already `require`s. `release` is in this branch's default
`PACKAGECONFIG`, so it resolves out of the box, and local.conf overrides it
with a plain assignment for an image shipping a different mode. The variable
block is byte-identical to master's, checked, so the branches do not drift.

`sony-flutter.inc` keeps `flutter-engine` alongside it, so the metapackage
still pulls in the other built modes rather than narrowing the image to one.

**Also builds the four sony embedders in CI.** They are the only recipes on
this branch that link `libflutter_engine.so` directly, so nothing else
exercises this variable. `flutter-x11-client` needs the `x11` distro
feature and the rest need `wayland`; I checked a green run's
`DISTRO_FEATURES` on this branch and both are present.

Proven on master in #946, where the equivalent step ran and passed.