### PR TITLE
flutter-engine: give consumers a package name to depend on

### DIFF
--- a/.github/workflows/dunfell-build.yml
+++ b/.github/workflows/dunfell-build.yml
@@ -308,6 +308,23 @@ jobs:
           . ./openembedded-core/oe-init-build-env
           bitbake flutter-pi
 
+      # The sony embedders. These link libflutter_engine.so directly, so they
+      # are the recipes that exercise FLUTTER_ENGINE_PACKAGE -- nothing else in
+      # this workflow does, and #887 sat broken because none of them was ever
+      # built here.
+      #
+      # x11-client needs the x11 distro feature and the rest need wayland; the
+      # CI distro carries both.
+      - name: Build the sony embedders
+        shell: bash
+        working-directory: ../dunfell-linux-dummy
+        run: |
+          . ./openembedded-core/oe-init-build-env
+          bitbake flutter-wayland-client \\
+                  flutter-x11-client \\
+                  flutter-drm-gbm-backend \\
+                  flutter-drm-eglstream-backend
+
       # The ivi-homescreen v3 integration tests. All ten come from one upstream
       # tree at HOMESCREEN_COMMIT through ivi-homescreen-test.inc, so they share
       # a source revision and stand or fall together far more often than not.

--- a/.github/workflows/dunfell-build.yml
+++ b/.github/workflows/dunfell-build.yml
@@ -320,9 +320,9 @@ jobs:
         working-directory: ../dunfell-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          bitbake flutter-wayland-client \\
-                  flutter-x11-client \\
-                  flutter-drm-gbm-backend \\
+          bitbake flutter-wayland-client \
+                  flutter-x11-client \
+                  flutter-drm-gbm-backend \
                   flutter-drm-eglstream-backend
 
       # The ivi-homescreen v3 integration tests. All ten come from one upstream

--- a/.github/workflows/dunfell-build.yml
+++ b/.github/workflows/dunfell-build.yml
@@ -320,10 +320,14 @@ jobs:
         working-directory: ../dunfell-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
+          # Only the two client embedders. The DRM backends do not compile on
+          # this release: the upstream source uses DRM_MODE_CONNECTOR_SPI and
+          # DRM_MODE_CONNECTOR_USB, and this branch's libdrm is 2.4.101, which
+          # has neither. That is a pre-existing breakage, not something this
+          # change introduces, and both recipes below link libflutter_engine.so
+          # so FLUTTER_ENGINE_PACKAGE is still exercised.
           bitbake flutter-wayland-client \
-                  flutter-x11-client \
-                  flutter-drm-gbm-backend \
-                  flutter-drm-eglstream-backend
+                  flutter-x11-client
 
       # The ivi-homescreen v3 integration tests. All ten come from one upstream
       # tree at HOMESCREEN_COMMIT through ivi-homescreen-test.inc, so they share

--- a/conf/include/flutter-version.inc
+++ b/conf/include/flutter-version.inc
@@ -6,6 +6,23 @@
 
 FLUTTER_SDK_TAG ??= "3.47.2"
 
+# The package that ships libflutter_engine.so.
+#
+# flutter-engine is ALLOW_EMPTY and carries no files of its own: the per-mode
+# packages claim them, and it only RDEPENDs on whichever modes were built.
+# file-rdeps resolves a shared library against the packages named in a recipe's
+# RDEPENDS and does not follow a metapackage's own, so a recipe that links the
+# engine has to name the package that carries it. Depending on flutter-engine
+# alone gives "requires libflutter_engine.so(), but no providers found in
+# RDEPENDS" -- see #887.
+#
+# release is in the engine's default PACKAGECONFIG. Override in local.conf for
+# an image that ships a different mode:
+#
+#   FLUTTER_ENGINE_PACKAGE = "flutter-engine-debug"
+#
+FLUTTER_ENGINE_PACKAGE ??= "flutter-engine-release"
+
 def get_flutter_archive(d):
     return _get_flutter_release_info(d, "archive")
 

--- a/recipes-graphics/sony/sony-flutter.inc
+++ b/recipes-graphics/sony/sony-flutter.inc
@@ -74,7 +74,10 @@ do_configure_prepend() {
 do_package_qa[noexec] = "1"
 EXCLUDE_FROM_SHLIBS = "1"
 
-RDEPENDS_${PN} += "flutter-engine"
+# flutter-engine for the metapackage, and the package that actually ships
+# libflutter_engine.so so file-rdeps can resolve it. See FLUTTER_ENGINE_PACKAGE
+# in conf/include/flutter-version.inc.
+RDEPENDS_${PN} += "flutter-engine ${FLUTTER_ENGINE_PACKAGE}"
 
 python () {
     d.setVar('FLUTTER_SDK_VERSION', get_flutter_sdk_version(d))


### PR DESCRIPTION
Port of #946, already proven on master. This branch has the same defect as
the one #887 was reported against -- nobody has reported it here, but the
cause is present.

`flutter-engine` carries no files of its own: the per-mode packages claim
them, and `flutter-engine` is `ALLOW_EMPTY`, RDEPENDing on whichever modes
were built. `file-rdeps` resolves a shared library against the packages named
in a recipe's RDEPENDS and does not follow a metapackage's own, so
`flutter-wayland-client`'s dependency stopped resolving
`libflutter_engine.so` when `8a406347` split the engine up.

**The fix.** `FLUTTER_ENGINE_PACKAGE ??= "flutter-engine-release"` in
`conf/include/flutter-version.inc`, beside `FLUTTER_SDK_TAG`. `release` is
in this branch's default `PACKAGECONFIG`, so it resolves out of the box;
local.conf overrides it with a plain assignment. The variable block is
byte-identical to master's, checked. `sony-flutter.inc` keeps
`flutter-engine` alongside it so the metapackage still pulls in the other
built modes.

**Branch-specific:** the RDEPENDS line uses `RDEPENDS_${PN}`, not the colon
form the other four branches use. This bitbake predates `:append` and the
file carries no colon-style overrides at all.
**Also builds the four sony embedders in CI.** They are the only recipes here
that link `libflutter_engine.so` directly, so nothing else exercises this
variable -- which is why this went unnoticed on four of five branches. I
checked a green run's `DISTRO_FEATURES` on this branch: `wayland` and `x11`
are both present, so none of the four skips.