### PR TITLE
flutter-elinux: guard DRM_MODE_CONNECTOR_SPI for this libdrm

### DIFF
--- a/.github/workflows/dunfell-build.yml
+++ b/.github/workflows/dunfell-build.yml
@@ -320,14 +320,14 @@ jobs:
         working-directory: ../dunfell-linux-dummy
         run: |
           . ./openembedded-core/oe-init-build-env
-          # Only the two client embedders. The DRM backends do not compile on
-          # this release: the upstream source uses DRM_MODE_CONNECTOR_SPI and
-          # DRM_MODE_CONNECTOR_USB, and this branch's libdrm is 2.4.101, which
-          # has neither. That is a pre-existing breakage, not something this
-          # change introduces, and both recipes below link libflutter_engine.so
-          # so FLUTTER_ENGINE_PACKAGE is still exercised.
+          # All four, as the other branches build. The DRM backends needed a
+          # guard for DRM_MODE_CONNECTOR_SPI against this release's libdrm
+          # 2.4.101 -- see the patch in flutter-elinux/files. Building them is
+          # what keeps that honest.
           bitbake flutter-wayland-client \
-                  flutter-x11-client
+                  flutter-x11-client \
+                  flutter-drm-gbm-backend \
+                  flutter-drm-eglstream-backend
 
       # The ivi-homescreen v3 integration tests. All ten come from one upstream
       # tree at HOMESCREEN_COMMIT through ivi-homescreen-test.inc, so they share

--- a/recipes-graphics/flutter-elinux/files/0001-Guard-DRM_MODE_CONNECTOR_SPI-for-older-libdrm.patch
+++ b/recipes-graphics/flutter-elinux/files/0001-Guard-DRM_MODE_CONNECTOR_SPI-for-older-libdrm.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Joel Winarske <joel.winarske@linux.com>
+Date: Mon, 8 Sep 2026 00:00:00 +0000
+Subject: [PATCH] Guard DRM_MODE_CONNECTOR_SPI for older libdrm
+
+native_window_drm.cc already guards DRM_MODE_CONNECTOR_USB so it builds
+against mesa < 21, but uses DRM_MODE_CONNECTOR_SPI unguarded a line later.
+Both arrived in the same era, so a libdrm old enough to want the USB guard
+wants this one too:
+
+  native_window_drm.cc:39:6: error: 'DRM_MODE_CONNECTOR_SPI' was not
+    declared in this scope; did you mean 'DRM_MODE_CONNECTOR_DPI'?
+
+Seen on Yocto dunfell, which carries libdrm 2.4.101 and defines neither.
+
+Same reasoning as the existing guard: a linux uapi value, safe to hardcode
+when unset. SPI is 19 and USB is 20 in drm_mode.h.
+
+Upstream-Status: Pending [sent to flutter-elinux/flutter-embedded-linux]
+Signed-off-by: Joel Winarske <joel.winarske@linux.com>
+---
+ .../linux_embedded/window/native_window_drm.cc         | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/src/flutter/shell/platform/linux_embedded/window/native_window_drm.cc b/src/flutter/shell/platform/linux_embedded/window/native_window_drm.cc
+--- a/src/flutter/shell/platform/linux_embedded/window/native_window_drm.cc
++++ b/src/flutter/shell/platform/linux_embedded/window/native_window_drm.cc
+@@ -16,6 +16,9 @@
+ // Allow building with mesa < 21
+ // This is a linux uapi header value so there is no risk in hardcoding it if
+ // unset
++#ifndef DRM_MODE_CONNECTOR_SPI
++#define DRM_MODE_CONNECTOR_SPI 19
++#endif
+ #ifndef DRM_MODE_CONNECTOR_USB
+ #define DRM_MODE_CONNECTOR_USB 20
+ #endif

--- a/recipes-graphics/flutter-elinux/flutter-elinux.inc
+++ b/recipes-graphics/flutter-elinux/flutter-elinux.inc
@@ -29,7 +29,13 @@ REQUIRED_DISTRO_FEATURES += "opengl"
 SRC_REPO ??= "github.com/flutter-elinux/flutter-embedded-linux.git"
 SRC_REPO_BRANCH ??= "master"
 
-SRC_URI = "git://${SRC_REPO};protocol=https;branch=${SRC_REPO_BRANCH}"
+FILESEXTRAPATHS_prepend := "${THISDIR}/files:"
+
+# This release's libdrm is 2.4.101 and defines neither DRM_MODE_CONNECTOR_SPI
+# nor _USB. Upstream guards USB only, so the DRM backends fail on SPI. Drop
+# this when the guard lands upstream.
+SRC_URI = "git://${SRC_REPO};protocol=https;branch=${SRC_REPO_BRANCH} \
+           file://0001-Guard-DRM_MODE_CONNECTOR_SPI-for-older-libdrm.patch"
 SRCREV ??= "ee831b1510e16911ca81200a3f066daaf2a087af"
 
 # The git fetcher unpacks to ${WORKDIR}/git on this release, while the default


### PR DESCRIPTION
Fixes #951.

`native_window_drm.cc` already guards `DRM_MODE_CONNECTOR_USB` so it builds
against mesa < 21:

```c
// Allow building with mesa < 21
// This is a linux uapi header value so there is no risk in hardcoding it if
// unset
#ifndef DRM_MODE_CONNECTOR_USB
#define DRM_MODE_CONNECTOR_USB 20
#endif
```

...then uses `DRM_MODE_CONNECTOR_SPI` unguarded three lines later. This
release's libdrm is **2.4.101** and defines neither, so the DRM backends fail:

```
native_window_drm.cc:39:6: error: 'DRM_MODE_CONNECTOR_SPI' was not declared
  in this scope; did you mean 'DRM_MODE_CONNECTOR_DPI'?
```

The fork migration (#954) fixed the USB half and left this. kirkstone
(libdrm 2.4.110) and newer have both constants and were never affected.

**The patch mirrors the existing guard, one constant over.** `SPI` is 19,
`USB` is 20 in `drm_mode.h`, and the upstream comment's reasoning carries
over unchanged. Dry-run against the pinned SRCREV before committing.

**It is in `SRC_URI`.** The `sony/` directory this replaced carried
`0001-Add-missing-stdint-header.patch` that was never wired up and therefore
never applied -- a fix that sat there doing nothing. Not repeating that: the
`FILESEXTRAPATHS_prepend` and the `file://` entry are both in place, in this
branch's underscore override syntax.

**CI goes back to all four embedders**, matching the other branches. That is
the point -- a guard nothing builds is the orphaned-patch failure again, so
the build is what keeps it honest.

`Upstream-Status: Pending`. The same guard belongs in
flutter-elinux/flutter-embedded-linux, where it helps anyone on an older
libdrm, and this patch drops out when it lands there.