### PR TITLE
flutter-sdk: drop the dead material fonts fetch

### DIFF
--- a/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
+++ b/recipes-graphics/flutter-sdk/flutter-sdk_git.bb
@@ -45,10 +45,23 @@ inherit pkgconfig
 
 SRC_URI = "\
     https://storage.googleapis.com/flutter_infra_release/releases/${@get_flutter_archive(d)};name=flutter-sdk \
-    https://storage.googleapis.com/flutter_infra_release/flutter/fonts/3012db47f3130e62f7cc0beabff968a33cbec8d8/fonts.zip;name=fonts;destsuffix=${D}${datadir}/flutter/sdk/bin/cache/artifacts/material_fonts \
 "
 SRC_URI[flutter-sdk.sha256sum] = "${@get_flutter_sha256(d)}"
-SRC_URI[fonts.sha256sum] = "e56fa8e9bb4589fde964be3de451f3e5b251e4a1eafb1dc98d94add034dd5a86"
+
+# No SRC_URI entry for the material fonts. One was here, with
+# destsuffix=${D}.../bin/cache/artifacts/material_fonts, and it placed nothing:
+# destsuffix is implemented by the git, hg, npm and npmsw fetchers only, and
+# wget inherits the generic unpack, which honours subdir alone and ignores an
+# unknown parameter. The files landed in ${WORKDIR} and were never installed.
+#
+# Placement would not have survived anyway -- do_unpack:append below removes
+# ${S}/bin/cache, and ${D} does not exist at do_unpack. flutter_tools fetches
+# the fonts itself during do_unpack, which is why the dead entry looked like it
+# worked.
+#
+# Fetching precache artifacts declaratively is #711 and needs more than a
+# placement parameter: somewhere that survives the rmtree, and a way to stop
+# flutter_tools re-downloading.
 
 S = "${UNPACKDIR}/flutter"
 


### PR DESCRIPTION
Port of #962. The material fonts `SRC_URI` entry places nothing on this branch
either.

`destsuffix` is implemented by the `git`, `hg`, `npm` and `npmsw` fetchers.
`wget.py` defines no `unpack`, so it inherits the generic one, which handles
`subdir` alone and silently ignores an unrecognised parameter. Checked against
**this branch's** bitbake rather than assuming master's behaviour carries:
`wget.py` has no `unpack` and no mention of `destsuffix`, and the generic
unpack does not handle it, on every release back to dunfell.

Placement could not have worked regardless:

- `${D}` does not exist at `do_unpack` and is outside the unpack root
- `do_unpack:append()` runs `shutil.rmtree(f'{source_dir}/bin/cache')`, which
  is exactly where the entry aimed -- present on this branch too

The fonts reach the SDK because `flutter_tools` downloads them during
`do_unpack`, which carries `network = "1"`. That fetch masked the dead entry.

URL and sha256 both removed, with a comment recording why so it is not
re-added the same way. #711 covers doing this properly, which needs a
destination surviving the `rmtree` and a way to stop `flutter_tools`
re-downloading.

Reported by aki1770-del on #711 with a bitbake fetcher reproducer.