### PR TITLE
tools: check the layer for the defects that keep shipping

### DIFF
--- a/.github/workflows/tools-tests.yml
+++ b/.github/workflows/tools-tests.yml
@@ -13,6 +13,13 @@ on:
     paths:
       - 'tools/**'
       - '.github/workflows/tools-tests.yml'
+      # the consistency job reads recipes, so it has to run when they change.
+      # These are cheap GitHub-hosted jobs; they do not touch the build runner.
+      - 'recipes-*/**'
+      - 'meta-flutter-apps/**'
+      - 'classes/**'
+      - 'conf/**'
+      - 'dynamic-layers/**'
   workflow_dispatch:
 
 jobs:
@@ -84,3 +91,27 @@ jobs:
         # Network populates the cache; the pub get itself is --offline and
         # fails if it reaches out.
         run: python tools/pubvendor/offline_check.py
+
+  consistency:
+
+    # Cheap text checks for defects that shipped on more than one branch and
+    # sat unnoticed: a patch no SRC_URI names, destsuffix on a fetcher that
+    # ignores it, a packagegroup naming a recipe that is gone. See #967.
+    #
+    # GitHub-hosted like the rest of this workflow -- it reads files and needs
+    # no bitbake, so it must not queue behind an hour-long build.
+    name: consistency
+    runs-on: ubuntu-24.04
+
+    steps:
+
+      - name: 📚 Git Checkout
+        uses: actions/checkout@v4
+
+      - name: 🐍 Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.13'
+
+      - name: 🔍 Layer consistency
+        run: python tools/consistency.py --path . --constants

--- a/tools/consistency.py
+++ b/tools/consistency.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+# SPDX-FileCopyrightText: (C) 2026 Joel Winarske
+# SPDX-License-Identifier: MIT
+#
+# Layer consistency checks. See #967.
+#
+# Everything here is a defect found by hand that a grep would have caught, on
+# more than one branch, sometimes for months. The checks are deliberately dumb:
+# they read text, they do not parse bitbake, and a check that cannot decide
+# says nothing rather than guessing. A false failure here costs more than the
+# defect it was meant to catch, because the next person routes around the
+# script.
+
+import os
+import re
+
+# Fetchers that implement destsuffix. wget defines no unpack() and inherits the
+# generic one, which honours subdir alone and ignores an unknown parameter --
+# so destsuffix on an http(s) URL places nothing and raises no error.
+_DESTSUFFIX_FETCHERS = ('git://', 'gitsm://', 'hg://', 'npm://', 'npmsw://')
+
+_RECIPE_SUFFIX = ('.bb', '.bbappend', '.inc', '.bbclass')
+
+_BRITISH = re.compile(
+    r'(unrecognis|recognis|behaviour|initialis|organis|optimis|normalis'
+    r'|serialis|colour|licence|centre|labelled|modelled|travelling)',
+    re.IGNORECASE)
+
+
+def _walk(root, suffixes):
+    for base, dirs, files in os.walk(root):
+        dirs[:] = [d for d in dirs if d != '.git']
+        for name in files:
+            if name.endswith(suffixes):
+                yield os.path.join(base, name)
+
+
+def _read(path):
+    with open(path, 'r', errors='replace') as f:
+        return f.read()
+
+
+def _recipe_text(root):
+    """Every recipe-ish file's text, concatenated. Enough for substring checks."""
+    return '\n'.join(_read(p) for p in _walk(root, _RECIPE_SUFFIX))
+
+
+def unwired_patches(root):
+    """Patch files no SRC_URI names.
+
+    An unreferenced patch is either dead weight or -- worse -- a fix someone
+    believes is applied. Both orphans found in this layer were the second kind:
+    0001-Add-missing-stdint-header.patch on four branches and
+    0001-suppres-musl-libc-warning.patch on three, neither in any SRC_URI.
+    """
+    text = _recipe_text(root)
+    missing = []
+    for path in _walk(root, ('.patch', '.diff')):
+        # only a recipe's own files/ dir follows the SRC_URI convention.
+        # tools/patches/ holds roll inputs, handed to the generator by
+        # directory through patch_dir and named in the recipes it emits.
+        if os.sep + 'files' + os.sep not in path:
+            continue
+        name = os.path.basename(path)
+        if name not in text:
+            missing.append(os.path.relpath(path, root))
+    return sorted(missing)
+
+
+def ineffective_destsuffix(root):
+    """destsuffix= on a fetcher that ignores it.
+
+    The material fonts entry carried
+    destsuffix=${D}...fonts.zip on an https:// URL for as long as it existed,
+    placed nothing, and was masked by flutter_tools downloading the same file.
+    """
+    bad = []
+    for path in _walk(root, _RECIPE_SUFFIX):
+        for n, line in enumerate(_read(path).splitlines(), 1):
+            if 'destsuffix=' not in line:
+                continue
+            if any(f in line for f in _DESTSUFFIX_FETCHERS):
+                continue
+            # a continuation may carry the parameter without the scheme; only
+            # flag a line that clearly holds a URL of its own
+            if '://' not in line:
+                continue
+            bad.append('%s:%d' % (os.path.relpath(path, root), n))
+    return sorted(bad)
+
+
+def british_spellings(root, suffixes=None):
+    """US English, including inside identifiers.
+
+    A \\b prefix misses test_an_unrecognised_failure, which is how five of
+    these survived a sweep.
+    """
+    suffixes = suffixes or (_RECIPE_SUFFIX + ('.py', '.md', '.yml', '.yaml'))
+    hits = []
+    for path in _walk(root, suffixes):
+        # this file and its tests spell the words on purpose
+        if os.path.basename(path) in ('consistency.py', 'test_consistency.py'):
+            continue
+        for n, line in enumerate(_read(path).splitlines(), 1):
+            m = _BRITISH.search(line)
+            if m:
+                hits.append('%s:%d: %s' % (os.path.relpath(path, root), n, m.group(0)))
+    return sorted(hits)
+
+
+def _declared_recipe_names(root):
+    names = set()
+    for path in _walk(root, ('.bb',)):
+        names.add(os.path.basename(path).split('_')[0].replace('.bb', ''))
+    return names
+
+
+def dangling_packagegroup_rdepends(root):
+    """packagegroup RDEPENDS naming a recipe that is not in the layer.
+
+    packagegroup-playx-flutter-playx-3d-scene had exactly one entry,
+    playx-flutter-playx-3d-scene-example-my-fox-example, which had not existed
+    since the recipes were removed. It could not resolve for anyone who pulled
+    it in.
+
+    Only packagegroups are checked, and only against recipes this layer
+    provides: a normal recipe may legitimately RDEPEND on another layer.
+    """
+    provided = _declared_recipe_names(root)
+    dangling = []
+    for path in _walk(root, ('.bb',)):
+        name = os.path.basename(path)
+        if not name.startswith('packagegroup-'):
+            continue
+        # A packagegroup RDEPENDs freely on other layers -- atk, cairo-dev and
+        # the rest are not ours to resolve. Only its own family is checkable:
+        # packagegroup-<stem> naming <stem>-something. That is the shape the
+        # playx one had, and it is the shape a removed app recipe leaves
+        # behind.
+        stem = name[len('packagegroup-'):].split('_')[0].replace('.bb', '')
+        text = _read(path)
+        for m in re.finditer(r'RDEPENDS[:_]\$\{PN\}[^=]*=\s*"(.*?)"', text, re.S):
+            for dep in m.group(1).split():
+                if dep in ('\\', '') or dep.startswith('$'):
+                    continue
+                if not dep.startswith(stem):
+                    continue
+                if dep not in provided:
+                    dangling.append('%s: %s' % (os.path.relpath(path, root), dep))
+    return sorted(set(dangling))
+
+
+def override_style(root):
+    """Which override syntax this branch's own metadata uses.
+
+    Returns 'new', 'old', or None when the evidence is mixed or absent --
+    common.py's OVERRIDE_STYLE should agree with it. dunfell is the branch that
+    needs 'old'; carrying 'new' there emits fragments its bitbake cannot parse.
+    """
+    new = old = 0
+    for sub in ('conf', 'classes'):
+        d = os.path.join(root, sub)
+        if not os.path.isdir(d):
+            continue
+        for path in _walk(d, _RECIPE_SUFFIX):
+            text = _read(path)
+            new += len(re.findall(r'^[A-Z][A-Za-z_]*:(?:append|prepend|remove)\b',
+                                  text, re.M))
+            old += len(re.findall(r'^[A-Z][A-Za-z_]*_(?:append|prepend|remove)\b',
+                                  text, re.M))
+    if new and not old:
+        return 'new'
+    if old and not new:
+        return 'old'
+    return None
+
+
+def license_operator(root):
+    """Which license operator this branch's generated recipes use.
+
+    '&' before oe-core 51c7930220, 'AND' after. common.py declares it because
+    it is correct on one branch and a regression on the other.
+    """
+    amp = land = 0
+    for path in _walk(root, ('.bb',)):
+        for m in re.finditer(r'^LICENSE\s*=\s*"([^"]*)"', _read(path), re.M):
+            value = m.group(1)
+            amp += value.count(' & ')
+            land += len(re.findall(r'\bAND\b', value))
+    if amp and not land:
+        return '&'
+    if land and not amp:
+        return 'AND'
+    return None
+
+
+CHECKS = (
+    ('unwired patches', unwired_patches,
+     'patch file no SRC_URI names -- dead, or a fix believed to be applied'),
+    ('ineffective destsuffix', ineffective_destsuffix,
+     'destsuffix on a fetcher that ignores it; the file is not placed'),
+    ('dangling packagegroup RDEPENDS', dangling_packagegroup_rdepends,
+     'packagegroup names a recipe of its own family that is not in the layer'),
+    ('british spellings', british_spellings,
+     'US English, identifiers included'),
+)
+
+
+def main(argv=None):
+    import argparse
+
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument('--path', default='.', help='layer root')
+    ap.add_argument('--constants', action='store_true',
+                    help='also report the branch constants common.py should declare')
+    args = ap.parse_args(argv)
+
+    failed = 0
+    for name, fn, why in CHECKS:
+        hits = fn(args.path)
+        if not hits:
+            print('ok   %s' % name)
+            continue
+        failed += 1
+        print('FAIL %s -- %s' % (name, why))
+        for h in hits:
+            print('       %s' % h)
+
+    if args.constants:
+        print('\nbranch constants, from this branch\'s own metadata:')
+        print('  OVERRIDE_STYLE    %s' % (override_style(args.path) or 'undecidable'))
+        print('  LICENSE_OPERATOR  %s' % (license_operator(args.path) or 'undecidable'))
+        print('  common.py must agree; each is a regression on the other branch.')
+
+    return 1 if failed else 0
+
+
+if __name__ == '__main__':
+    raise SystemExit(main())

--- a/tools/tests/test_consistency.py
+++ b/tools/tests/test_consistency.py
@@ -1,0 +1,123 @@
+# SPDX-FileCopyrightText: (C) 2026 Joel Winarske
+# SPDX-License-Identifier: MIT
+#
+# Each test is a defect that actually shipped, plus the case that must not be
+# flagged. The negative half matters as much: a check that cries wolf gets
+# routed around, and then it may as well not exist.
+
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..'))
+
+import consistency  # noqa: E402
+
+
+def _write(base, rel, text):
+    p = base / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(text)
+    return p
+
+
+def test_a_patch_no_src_uri_names_is_reported(tmp_path):
+    """0001-Add-missing-stdint-header.patch sat unreferenced on four branches.
+
+    It was not dead weight -- it was a fix for a real compile error that
+    everyone believed was applied.
+    """
+    _write(tmp_path, 'recipes-x/foo/files/0001-fix.patch', '--- a\n+++ b\n')
+    _write(tmp_path, 'recipes-x/foo/foo_git.bb', 'SRC_URI = "git://example.com/foo"\n')
+    assert consistency.unwired_patches(str(tmp_path)) == [
+        'recipes-x/foo/files/0001-fix.patch']
+
+
+def test_a_patch_in_src_uri_is_not_reported(tmp_path):
+    _write(tmp_path, 'recipes-x/foo/files/0001-fix.patch', '--- a\n+++ b\n')
+    _write(tmp_path, 'recipes-x/foo/foo_git.bb',
+           'SRC_URI = "git://example.com/foo file://0001-fix.patch"\n')
+    assert consistency.unwired_patches(str(tmp_path)) == []
+
+
+def test_roll_input_patches_are_not_reported(tmp_path):
+    """tools/patches/ is handed to the generator by directory, not by SRC_URI."""
+    _write(tmp_path, 'tools/patches/someapp/0001-fix.patch', '--- a\n+++ b\n')
+    assert consistency.unwired_patches(str(tmp_path)) == []
+
+
+def test_destsuffix_on_an_http_url_is_reported(tmp_path):
+    """The material fonts entry, verbatim in shape.
+
+    destsuffix is implemented by git, hg, npm and npmsw. wget inherits the
+    generic unpack, which honours subdir alone and ignores the parameter, so
+    the file is fetched and left in WORKDIR.
+    """
+    _write(tmp_path, 'recipes-x/foo/foo_git.bb',
+           'SRC_URI = "https://example.com/fonts.zip;name=fonts'
+           ';destsuffix=${D}/usr/share/foo"\n')
+    assert consistency.ineffective_destsuffix(str(tmp_path)) == [
+        'recipes-x/foo/foo_git.bb:1']
+
+
+def test_destsuffix_on_a_git_url_is_not_reported(tmp_path):
+    _write(tmp_path, 'recipes-x/foo/foo_git.bb',
+           'SRC_URI = "git://example.com/foo;destsuffix=src/foo"\n')
+    assert consistency.ineffective_destsuffix(str(tmp_path)) == []
+
+
+def test_packagegroup_naming_a_missing_recipe_of_its_family_is_reported(tmp_path):
+    """packagegroup-playx-... named an app recipe removed months earlier.
+
+    Nothing regenerated it -- there was no manifest entry -- so the group could
+    not resolve for anyone who pulled it in.
+    """
+    _write(tmp_path, 'recipes-platform/packagegroups/packagegroup-playx-thing.bb',
+           'RDEPENDS:${PN} += " \\\n    playx-thing-example \\\n    "\n')
+    hits = consistency.dangling_packagegroup_rdepends(str(tmp_path))
+    assert hits == ['recipes-platform/packagegroups/packagegroup-playx-thing.bb: '
+                    'playx-thing-example']
+
+
+def test_packagegroup_depending_on_another_layer_is_not_reported(tmp_path):
+    """atk, cairo-dev and friends are not ours to resolve.
+
+    An earlier draft flagged every one of them, which would have made the check
+    useless on its first run.
+    """
+    _write(tmp_path, 'recipes-platform/packagegroups/packagegroup-foo-deps.bb',
+           'RDEPENDS:${PN} += " \\\n    atk \\\n    cairo-dev \\\n    "\n')
+    assert consistency.dangling_packagegroup_rdepends(str(tmp_path)) == []
+
+
+def test_packagegroup_naming_a_recipe_that_exists_is_not_reported(tmp_path):
+    _write(tmp_path, 'recipes-platform/packagegroups/packagegroup-foo-thing.bb',
+           'RDEPENDS:${PN} += " foo-thing-example "\n')
+    _write(tmp_path, 'recipes-x/foo/foo-thing-example_1.0.bb', 'SUMMARY = "x"\n')
+    assert consistency.dangling_packagegroup_rdepends(str(tmp_path)) == []
+
+
+def test_british_spelling_inside_an_identifier_is_reported(tmp_path):
+    """A \\b prefix misses this, which is how five survived a sweep."""
+    _write(tmp_path, 'tools/x.py', 'def test_an_unrecognised_failure():\n    pass\n')
+    hits = consistency.british_spellings(str(tmp_path))
+    assert len(hits) == 1 and 'unrecognis' in hits[0]
+
+
+def test_override_style_reads_the_branch(tmp_path):
+    _write(tmp_path, 'conf/include/a.inc', 'FOO:append = " x"\n')
+    assert consistency.override_style(str(tmp_path)) == 'new'
+    _write(tmp_path, 'conf/include/a.inc', 'FOO_append = " x"\n')
+    assert consistency.override_style(str(tmp_path)) == 'old'
+
+
+def test_override_style_is_undecidable_when_mixed(tmp_path):
+    """Says nothing rather than guessing."""
+    _write(tmp_path, 'conf/include/a.inc', 'FOO:append = " x"\nBAR_append = " y"\n')
+    assert consistency.override_style(str(tmp_path)) is None
+
+
+def test_license_operator_reads_the_generated_recipes(tmp_path):
+    _write(tmp_path, 'a/x_1.0.bb', 'LICENSE = "MIT & Apache-2.0"\n')
+    assert consistency.license_operator(str(tmp_path)) == '&'
+    _write(tmp_path, 'a/x_1.0.bb', 'LICENSE = "MIT AND Apache-2.0"\n')
+    assert consistency.license_operator(str(tmp_path)) == 'AND'


### PR DESCRIPTION
Port of #969, merged and green on master. Implements #967 for this branch.

Text checks, no bitbake, GitHub-hosted so they never queue behind a build:

| check | what it caught |
|---|---|
| patch no `SRC_URI` names | two orphans, on 4 branches and 3 -- neither dead weight, both fixes believed applied |
| `destsuffix` on a fetcher that ignores it | the material fonts entry, on all 5, for as long as it existed |
| packagegroup naming a missing recipe of its family | `packagegroup-playx` on 2 branches |
| British spellings, identifiers included | a `\b` prefix misses `test_an_unrecognised_failure` |

**Passes here as-is.** All four clean, since #963 removed the fonts entry from
this branch. The `--constants` report reads this branch's own metadata and
prints `OVERRIDE_STYLE new`, `LICENSE_OPERATOR '&'` -- what `common.py`
declares here. Reported rather than asserted, so a branch whose correct values
differ (dunfell's `old`) does not fail.

Script, tests and workflow are byte-identical to master's, checked. This
branch's `tools-tests.yml` differed from master's only by the consistency
addition -- zero wrynose-only lines -- so it was taken wholesale.

**Not ported to the other three yet.** scarthgap, kirkstone and dunfell each
still carry `recipes-devtools/dart/files/0001-suppres-musl-libc-warning.patch`
with no `SRC_URI` referencing it, so the check legitimately fails there. That
orphan needs a decision first -- wire it up, or delete it as the engine already
carries its own applied copy of the same fix.